### PR TITLE
ci(badge): add CI adoption scoring workflow and README badge (PPT-042)

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -20,6 +20,7 @@ GitHub Actions workflows, validation scripts, and local pre-commit hooks for **s
 - [Workflow overview](#workflow-overview)
 - [Run checks locally](#run-checks-locally)
 - [Workflows in detail](#workflows-in-detail)
+- [CI Adoption Badge](#ci-adoption-badge)
 - [Pre-commit hooks](#pre-commit-hooks)
 - [Strata validation](#strata-validation)
 - [Supporting scripts](#supporting-scripts)
@@ -104,6 +105,7 @@ Use this matrix to predict required checks before opening a PR.
 | Trivy Security Scan  | [`workflows/trivy.yml`](./workflows/trivy.yml)                           | PR + push (manifest/docker paths); Mon 07:00 UTC           | Filesystem CVE + IaC misconfig (SARIF)                  |
 | Strata Check         | [`workflows/strata-check.yml`](./workflows/strata-check.yml)             | **PR only** (code/deploy paths)                            | `.strata/` layout + strict code/memory pairing          |
 | Auto Updates         | [`workflows/auto-updates.yml`](./workflows/auto-updates.yml)             | Push or merged PR to `main`                                | Regenerate [`CHANGELOG.md`](../CHANGELOG.md) and badges |
+| CI Adoption Badge    | [`workflows/ci-badge.yml`](./workflows/ci-badge.yml)                     | PR + push to `main`; Mon 06:00 UTC; `workflow_dispatch`    | Score CI maturity and update README adoption badge      |
 
 ---
 
@@ -318,6 +320,84 @@ See [Strata validation](#strata-validation) for the full rule set.
 
 ---
 
+### CI Adoption Badge
+
+|                 |                                                         |
+| :-------------- | :------------------------------------------------------ |
+| **Trigger**     | PR + push to `main`; Mon 06:00 UTC; `workflow_dispatch` |
+| **Permissions** | `contents: write`                                       |
+| **Script**      | [`evaluate_ci.py`](./scripts/evaluate_ci.py)            |
+
+**Steps:**
+
+1. Evaluate CI configuration files and quality signals; write `badge_url`, `level`, `score`, and `tools` to step outputs
+2. Replace the `CI Adoption` badge placeholder in [`README.md`](../README.md)
+3. Commit with `ci: update CI adoption badge [skip ci]` via `stefanzweifel/git-auto-commit-action@v5`
+4. Emit a step summary with level, score, detected tools, and quality signals
+
+**Loop guard:** push jobs skip when the head commit message contains `[skip ci]`.
+
+**Expected baseline for this repo:** ~65 (**Intermediate**) with the v1 rubric — nine GitHub Actions workflows (+ keyword bonuses), pre-commit, security scans (CodeQL, Trivy, Gitleaks), coverage artifacts, Docker Compose, `deploy/` scripts, and `.strata/` layout. **Advanced** (≥ 75) would require signals such as Dependabot and additional workflow keyword coverage.
+
+See [CI Adoption Badge](#ci-adoption-badge) for the scoring rubric and local usage.
+
+---
+
+## CI Adoption Badge
+
+The [`ci-badge.yml`](./workflows/ci-badge.yml) workflow maintains a dynamic shields.io badge in `README.md` that reflects repository CI maturity. Detection is **config-file based** (v1 does not query live workflow run status via the GitHub API).
+
+### Triggers
+
+| Event               | When it runs                                  |
+| :------------------ | :-------------------------------------------- |
+| `push`              | Commits to `main` (skips `[skip ci]` commits) |
+| `pull_request`      | PRs targeting `main`                          |
+| `schedule`          | Mondays at 06:00 UTC (`0 6 * * 1`)            |
+| `workflow_dispatch` | Manual run from the Actions tab               |
+
+### Scoring rubric (v1)
+
+| Signal                                                             | Base points      | Bonus                                                                     |
+| :----------------------------------------------------------------- | :--------------- | :------------------------------------------------------------------------ |
+| GitHub Actions (`.github/workflows/*.yml`)                         | +20              | +1 per keyword in YAML (`test`, `lint`, `deploy`, `security`, `coverage`) |
+| Travis / CircleCI / Jenkins / GitLab CI                            | +15 each         | +1 per keyword                                                            |
+| Azure / Bitbucket / Drone / TeamCity / Buildkite                   | +10 each         | +1 per keyword                                                            |
+| Test coverage config                                               | +5               | —                                                                         |
+| Linting config (`.flake8`, `.pylintrc`, `pyproject` tool sections) | +5               | —                                                                         |
+| Pre-commit hooks                                                   | +5               | —                                                                         |
+| Dependabot                                                         | +5               | —                                                                         |
+| Security scanning workflows                                        | +5               | —                                                                         |
+| Docker support                                                     | +3               | —                                                                         |
+| Deploy automation (`deploy/` or `Makefile`)                        | +2               | —                                                                         |
+| Strata layout (`.strata/`)                                         | +3               | repo-specific bonus                                                       |
+| **Maximum**                                                        | **100** (capped) |                                                                           |
+
+**Levels:** Advanced ≥ 75 · Intermediate ≥ 50 · Basic ≥ 20 · None &lt; 20
+
+### Run locally
+
+```bash
+python .github/scripts/evaluate_ci.py
+python .github/scripts/evaluate_ci.py --update-readme
+```
+
+`REPO_NAME` defaults to `owner/repo`; set it to `Elmorralito/save-ma-money` for the correct badge link target.
+
+**Local pre-push feedback (optional):** install the advisory hook once, then every `git push` prints the adoption report without blocking:
+
+```bash
+pre-commit install --hook-type pre-push
+```
+
+The hook uses [`pre_commit_ci_adoption.sh`](./scripts/pre_commit_ci_adoption.sh) (`stages: [pre-push]` only — not run by CI pre-commit).
+
+### Manual refresh
+
+Open **Actions → CI Adoption Badge → Run workflow** (`workflow_dispatch`) after CI changes land on `main`.
+
+---
+
 ## Pre-commit hooks
 
 Defined in [`.pre-commit-config.yaml`](../.pre-commit-config.yaml). CI runs all hooks **except** the two local-only entries below.
@@ -345,15 +425,17 @@ Defined in [`.pre-commit-config.yaml`](../.pre-commit-config.yaml). CI runs all 
 | `actionlint`              | actionlint v1.7.7               | GitHub Actions workflow syntax                              |
 | **`strata-validate`**     | **local only**                  | See [Strata validation](#strata-validation)                 |
 | **`mcp-config-validate`** | **local only**                  | See [MCP config](#mcp-config-local)                         |
+| **`ci-adoption-check`**   | **local pre-push, advisory**    | See [CI Adoption Badge](#ci-adoption-badge)                 |
 
 ### Local-only hooks
 
-| Hook ID               | Wrapper                                                  | When it runs                                                              |
-| :-------------------- | :------------------------------------------------------- | :------------------------------------------------------------------------ |
-| `strata-validate`     | [`pre_commit_strata.sh`](./scripts/pre_commit_strata.sh) | Staged paths: `modules/`, `deploy/`, `.strata/`, `AGENTS.md`, `CLAUDE.md` |
-| `mcp-config-validate` | [`pre_commit_mcp.sh`](./scripts/pre_commit_mcp.sh)       | Staged `.cursor/mcp.json`                                                 |
+| Hook ID               | Wrapper                                                            | When it runs                                                              |
+| :-------------------- | :----------------------------------------------------------------- | :------------------------------------------------------------------------ |
+| `strata-validate`     | [`pre_commit_strata.sh`](./scripts/pre_commit_strata.sh)           | Staged paths: `modules/`, `deploy/`, `.strata/`, `AGENTS.md`, `CLAUDE.md` |
+| `mcp-config-validate` | [`pre_commit_mcp.sh`](./scripts/pre_commit_mcp.sh)                 | Staged `.cursor/mcp.json`                                                 |
+| `ci-adoption-check`   | [`pre_commit_ci_adoption.sh`](./scripts/pre_commit_ci_adoption.sh) | `git push` when `pre-commit install --hook-type pre-push` is set          |
 
-Both wrappers **exit 0 immediately** when `CI` or `GITHUB_ACTIONS` is set (belt-and-suspenders alongside `SKIP` in quality-control).
+Both wrappers **exit 0 immediately** when `CI` or `GITHUB_ACTIONS` is set (belt-and-suspenders alongside `SKIP` in quality-control). `ci-adoption-check` uses `stages: [pre-push]` only, so CI pre-commit never invokes it.
 
 ---
 
@@ -416,18 +498,20 @@ Missing file → skip with success (project may not use MCP).
 
 ## Supporting scripts
 
-| Script                                                           | Invoked by               | Description                                                              |
-| :--------------------------------------------------------------- | :----------------------- | :----------------------------------------------------------------------- |
-| [`migration_check.sh`](./scripts/migration_check.sh)             | Migration Check          | Alembic upgrade → downgrade → upgrade → `check`; requires `DB_URL`       |
-| [`supply_chain_check.sh`](./scripts/supply_chain_check.sh)       | Supply Chain Check       | Poetry metadata, semver check, pip upgrade, pip-audit                    |
-| [`check_module_versions.py`](./scripts/check_module_versions.py) | Supply Chain Check       | Validates `[project].version` semver in each `modules/*/pyproject.toml`  |
-| [`strata_check.sh`](./scripts/strata_check.sh)                   | Strata Check, pre-commit | Layout, budgets, frontmatter, strict pairing                             |
-| [`pre_commit_strata.sh`](./scripts/pre_commit_strata.sh)         | pre-commit               | Sets `STRATA_STRICT_MODULES=1`, `STRATA_DIFF_SOURCE=staged`; skips in CI |
-| [`mcp_config_check.sh`](./scripts/mcp_config_check.sh)           | pre-commit               | MCP JSON structure + token scan                                          |
-| [`pre_commit_mcp.sh`](./scripts/pre_commit_mcp.sh)               | pre-commit               | CI skip wrapper for MCP check                                            |
-| [`update_todos.py`](./scripts/update_todos.py)                   | Auto Updates             | CHANGELOG from GitHub API                                                |
-| [`changelog_template.jinja`](./scripts/changelog_template.jinja) | update_todos.py          | CHANGELOG section template                                               |
-| [`issue_template.jinja`](./scripts/issue_template.jinja)         | update_todos.py          | Per-issue CHANGELOG entry template                                       |
+| Script                                                             | Invoked by               | Description                                                              |
+| :----------------------------------------------------------------- | :----------------------- | :----------------------------------------------------------------------- |
+| [`migration_check.sh`](./scripts/migration_check.sh)               | Migration Check          | Alembic upgrade → downgrade → upgrade → `check`; requires `DB_URL`       |
+| [`supply_chain_check.sh`](./scripts/supply_chain_check.sh)         | Supply Chain Check       | Poetry metadata, semver check, pip upgrade, pip-audit                    |
+| [`check_module_versions.py`](./scripts/check_module_versions.py)   | Supply Chain Check       | Validates `[project].version` semver in each `modules/*/pyproject.toml`  |
+| [`strata_check.sh`](./scripts/strata_check.sh)                     | Strata Check, pre-commit | Layout, budgets, frontmatter, strict pairing                             |
+| [`pre_commit_strata.sh`](./scripts/pre_commit_strata.sh)           | pre-commit               | Sets `STRATA_STRICT_MODULES=1`, `STRATA_DIFF_SOURCE=staged`; skips in CI |
+| [`mcp_config_check.sh`](./scripts/mcp_config_check.sh)             | pre-commit               | MCP JSON structure + token scan                                          |
+| [`pre_commit_mcp.sh`](./scripts/pre_commit_mcp.sh)                 | pre-commit               | CI skip wrapper for MCP check                                            |
+| [`pre_commit_ci_adoption.sh`](./scripts/pre_commit_ci_adoption.sh) | pre-push (local)         | Advisory CI adoption report; never blocks push                           |
+| [`update_todos.py`](./scripts/update_todos.py)                     | Auto Updates             | CHANGELOG from GitHub API                                                |
+| [`evaluate_ci.py`](./scripts/evaluate_ci.py)                       | CI Adoption Badge        | CI tool detection, adoption scoring, README badge metadata               |
+| [`changelog_template.jinja`](./scripts/changelog_template.jinja)   | update_todos.py          | CHANGELOG section template                                               |
+| [`issue_template.jinja`](./scripts/issue_template.jinja)           | update_todos.py          | Per-issue CHANGELOG entry template                                       |
 
 Shared shell helpers: [`deploy/utils.sh`](../deploy/utils.sh) (`log`, `run_command`).
 
@@ -514,6 +598,7 @@ All times **UTC**, every **Monday**:
 | Workflow            | Cron        | Local time hint (US Eastern, DST) |
 | :------------------ | :---------- | :-------------------------------- |
 | Secret Scan         | `0 5 * * 1` | ~01:00 EDT                        |
+| CI Adoption Badge   | `0 6 * * 1` | ~02:00 EDT                        |
 | CodeQL Analysis     | `0 6 * * 1` | ~02:00 EDT                        |
 | Trivy Security Scan | `0 7 * * 1` | ~03:00 EDT                        |
 | Supply Chain Check  | `0 8 * * 1` | ~04:00 EDT                        |
@@ -536,16 +621,16 @@ Each workflow also supports **`workflow_dispatch`** from the Actions tab.
 
 ## Environment variables
 
-| Variable                  | Used by                         |           Required           | Example                                                          |
-| :------------------------ | :------------------------------ | :--------------------------: | :--------------------------------------------------------------- |
-| `DB_URL`                  | `migration_check.sh`            |    Yes (migration checks)    | `postgresql+psycopg2://papita:papita@localhost:5432/papita_test` |
-| `STRATA_STRICT_MODULES`   | `strata_check.sh`               |       No (default `0`)       | `1` enables code/memory pairing                                  |
-| `STRATA_DIFF_SOURCE`      | `strata_check.sh`               |     No (default `range`)     | `staged` for pre-commit                                          |
-| `STRATA_BASE_REF`         | `strata_check.sh` (CI)          |  No (default `origin/main`)  | `origin/main`                                                    |
-| `CI` / `GITHUB_ACTIONS`   | pre-commit wrappers             |          Set by GHA          | Skips local-only hooks                                           |
-| `SKIP`                    | quality-control pre-commit step |       Set by workflow        | `strata-validate,mcp-config-validate`                            |
-| `GITHUB_TOKEN`            | Gitleaks, Auto Updates          |       Provided by GHA        | —                                                                |
-| `REPO_OWNER`, `REPO_NAME` | `update_todos.py`               | Set by Auto Updates workflow | —                                                                |
+| Variable                  | Used by                             |          Required          | Example                                                          |
+| :------------------------ | :---------------------------------- | :------------------------: | :--------------------------------------------------------------- |
+| `DB_URL`                  | `migration_check.sh`                |   Yes (migration checks)   | `postgresql+psycopg2://papita:papita@localhost:5432/papita_test` |
+| `STRATA_STRICT_MODULES`   | `strata_check.sh`                   |      No (default `0`)      | `1` enables code/memory pairing                                  |
+| `STRATA_DIFF_SOURCE`      | `strata_check.sh`                   |    No (default `range`)    | `staged` for pre-commit                                          |
+| `STRATA_BASE_REF`         | `strata_check.sh` (CI)              | No (default `origin/main`) | `origin/main`                                                    |
+| `CI` / `GITHUB_ACTIONS`   | pre-commit wrappers                 |         Set by GHA         | Skips local-only hooks                                           |
+| `SKIP`                    | quality-control pre-commit step     |      Set by workflow       | `strata-validate,mcp-config-validate`                            |
+| `GITHUB_TOKEN`            | Gitleaks, Auto Updates              |      Provided by GHA       | —                                                                |
+| `REPO_OWNER`, `REPO_NAME` | `update_todos.py`, `evaluate_ci.py` |      Set by workflow       | —                                                                |
 
 ---
 

--- a/.github/scripts/evaluate_ci.py
+++ b/.github/scripts/evaluate_ci.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""CI adoption evaluator — detect tools, score maturity, emit badge metadata."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TypedDict
+
+
+class CIToolDef(TypedDict):
+    """CI platform definition used for repository scanning."""
+
+    name: str
+    patterns: list[str]
+    base_score: int
+    bonus_checks: list[str]
+
+
+class QualitySignalDef(TypedDict):
+    """Repository quality signal definition."""
+
+    name: str
+    patterns: list[str]
+    score: int
+
+
+CI_TOOLS: list[CIToolDef] = [
+    {
+        "name": "GitHub Actions",
+        "patterns": [".github/workflows/*.yml", ".github/workflows/*.yaml"],
+        "base_score": 20,
+        "bonus_checks": ["test", "lint", "deploy", "security", "coverage"],
+    },
+    {
+        "name": "Travis CI",
+        "patterns": [".travis.yml"],
+        "base_score": 15,
+        "bonus_checks": ["script", "deploy", "notifications"],
+    },
+    {
+        "name": "CircleCI",
+        "patterns": [".circleci/config.yml", ".circleci/config.yaml"],
+        "base_score": 15,
+        "bonus_checks": ["workflows", "jobs", "orbs"],
+    },
+    {
+        "name": "Jenkins",
+        "patterns": ["Jenkinsfile", "jenkinsfile", "jenkins/Jenkinsfile"],
+        "base_score": 15,
+        "bonus_checks": ["pipeline", "stages", "post"],
+    },
+    {
+        "name": "GitLab CI",
+        "patterns": [".gitlab-ci.yml", ".gitlab-ci.yaml"],
+        "base_score": 15,
+        "bonus_checks": ["stages", "deploy", "test"],
+    },
+    {
+        "name": "Azure Pipelines",
+        "patterns": ["azure-pipelines.yml", "azure-pipelines.yaml"],
+        "base_score": 10,
+        "bonus_checks": ["stages", "jobs", "steps"],
+    },
+    {
+        "name": "Bitbucket Pipelines",
+        "patterns": ["bitbucket-pipelines.yml"],
+        "base_score": 10,
+        "bonus_checks": ["pipelines", "branches", "pull-requests"],
+    },
+    {
+        "name": "Drone CI",
+        "patterns": [".drone.yml", ".drone.yaml"],
+        "base_score": 10,
+        "bonus_checks": ["steps", "trigger", "services"],
+    },
+    {
+        "name": "TeamCity",
+        "patterns": [".teamcity/settings.kts", ".teamcity/pom.xml"],
+        "base_score": 10,
+        "bonus_checks": [],
+    },
+    {
+        "name": "Buildkite",
+        "patterns": [".buildkite/pipeline.yml", ".buildkite/pipeline.yaml"],
+        "base_score": 10,
+        "bonus_checks": ["steps", "env"],
+    },
+]
+
+QUALITY_SIGNALS: list[QualitySignalDef] = [
+    {
+        "name": "Test coverage config",
+        "patterns": [".coveragerc", "codecov.yml", ".nycrc", "docs/coverage.xml", "docs/coverage-badge.svg"],
+        "score": 5,
+    },
+    {
+        "name": "Linting config",
+        "patterns": [".eslintrc*", ".pylintrc", ".flake8", "*.rubocop*"],
+        "score": 5,
+    },
+    {
+        "name": "Pre-commit hooks",
+        "patterns": [".pre-commit-config.yaml"],
+        "score": 5,
+    },
+    {
+        "name": "Dependabot",
+        "patterns": [".github/dependabot.yml", ".github/dependabot.yaml"],
+        "score": 5,
+    },
+    {
+        "name": "Security scanning",
+        "patterns": [
+            ".github/workflows/*security*",
+            ".github/workflows/codeql.yml",
+            ".github/workflows/trivy.yml",
+            ".github/workflows/gitleaks.yml",
+        ],
+        "score": 5,
+    },
+    {
+        "name": "Docker support",
+        "patterns": ["Dockerfile", "docker-compose.yml", "docker/**"],
+        "score": 3,
+    },
+    {
+        "name": "Deploy automation",
+        "patterns": ["deploy/*.sh", "Makefile", "makefile"],
+        "score": 2,
+    },
+    {
+        "name": "Strata layout",
+        "patterns": [".strata/MANIFEST.md"],
+        "score": 3,
+    },
+]
+
+LEVEL_THRESHOLDS: list[tuple[int, str, str]] = [
+    (75, "Advanced", "brightgreen"),
+    (50, "Intermediate", "yellow"),
+    (20, "Basic", "orange"),
+    (0, "None", "red"),
+]
+
+CI_BADGE_PATTERN = re.compile(r"\[!\[CI Adoption\]\([^)]+\)\]\([^)]+\)")
+
+
+@dataclass
+class CITool:
+    """Detected CI tool with scoring metadata."""
+
+    name: str
+    files: list[str] = field(default_factory=list)
+    found: bool = False
+    score_contribution: int = 0
+    details: list[str] = field(default_factory=list)
+
+
+@dataclass
+class BadgeInfo:
+    """Shields.io badge metadata for the adoption report."""
+
+    level: str
+    color: str
+    url: str
+    link: str
+
+
+@dataclass
+class CIReport:
+    """Aggregated CI adoption report."""
+
+    tools: list[CITool]
+    quality_signals: list[str]
+    quality_score: int
+    total_score: int
+    badge: BadgeInfo
+    recommendations: list[str]
+
+
+def find_files(patterns: list[str], root: Path) -> list[str]:
+    """Resolve glob patterns relative to the repository root."""
+    found: list[str] = []
+    for pattern in patterns:
+        matches = glob.glob(str(root / pattern), recursive=True)
+        found.extend(matches)
+    return sorted(set(found))
+
+
+def read_file_content(filepath: str) -> str:
+    """Safely read file content as lowercase text."""
+    try:
+        return Path(filepath).read_text(encoding="utf-8", errors="ignore").lower()
+    except OSError:
+        return ""
+
+
+def has_linting_config(root: Path) -> bool:
+    """Return True when linting configuration files or pyproject tool sections exist."""
+    lint_signal = next((signal for signal in QUALITY_SIGNALS if signal["name"] == "Linting config"), None)
+    if lint_signal is not None:
+        if find_files(lint_signal["patterns"], root):
+            return True
+
+    pyproject = root / "pyproject.toml"
+    if not pyproject.is_file():
+        return False
+
+    content = read_file_content(str(pyproject))
+    return "[tool.flake8]" in content or "[tool.pylint]" in content
+
+
+def evaluate_tool(tool_def: CIToolDef, root: Path) -> CITool:
+    """Evaluate a single CI tool definition."""
+    patterns = tool_def["patterns"]
+    bonus_checks = tool_def["bonus_checks"]
+
+    ci_tool = CITool(name=tool_def["name"])
+    matched_files = find_files(patterns, root)
+    if not matched_files:
+        return ci_tool
+
+    ci_tool.found = True
+    ci_tool.files = matched_files
+    ci_tool.score_contribution = tool_def["base_score"]
+    ci_tool.details.append(f"Found {len(matched_files)} config file(s)")
+
+    for filepath in matched_files:
+        content = read_file_content(filepath)
+        for keyword in bonus_checks:
+            if keyword in content:
+                ci_tool.score_contribution += 1
+                ci_tool.details.append(f"  +1 keyword '{keyword}' in {Path(filepath).name}")
+
+    return ci_tool
+
+
+def evaluate_quality_signals(root: Path) -> tuple[int, list[str]]:
+    """Check repository quality signals beyond raw CI presence."""
+    bonus = 0
+    found_signals: list[str] = []
+
+    for signal in QUALITY_SIGNALS:
+        name = signal["name"]
+        patterns = signal["patterns"]
+        score = signal["score"]
+
+        if name == "Linting config":
+            if has_linting_config(root):
+                bonus += score
+                found_signals.append(name)
+            continue
+
+        if find_files(patterns, root):
+            bonus += score
+            found_signals.append(name)
+
+    return bonus, found_signals
+
+
+def compute_level(score: int) -> tuple[str, str]:
+    """Return adoption level name and shields.io color for a score."""
+    for threshold, level, color in LEVEL_THRESHOLDS:
+        if score >= threshold:
+            return level, color
+    return "None", "red"
+
+
+def build_recommendations(tools: list[CITool], quality_signals: list[str]) -> list[str]:
+    """Suggest improvements for missing CI maturity signals."""
+    found_names = {tool.name for tool in tools if tool.found}
+    recommendations: list[str] = []
+
+    if not found_names:
+        recommendations.append("No CI system detected — add GitHub Actions under .github/workflows/")
+    if "GitHub Actions" not in found_names:
+        recommendations.append("Add GitHub Actions for native GitHub integration")
+    if "Test coverage config" not in quality_signals:
+        recommendations.append("Add coverage reporting (docs/coverage.xml, codecov.yml, or .coveragerc)")
+    if "Linting config" not in quality_signals:
+        recommendations.append("Add linting configuration (.flake8, .pylintrc, or pyproject tool sections)")
+    if "Dependabot" not in quality_signals:
+        recommendations.append("Enable Dependabot (.github/dependabot.yml)")
+    if "Pre-commit hooks" not in quality_signals:
+        recommendations.append("Add pre-commit hooks (.pre-commit-config.yaml)")
+    if "Security scanning" not in quality_signals:
+        recommendations.append("Add security scanning workflows (CodeQL, Trivy, or Gitleaks)")
+    if "Docker support" not in quality_signals:
+        recommendations.append("Add Docker support (Dockerfile or docker/ directory)")
+    if "Deploy automation" not in quality_signals:
+        recommendations.append("Add deploy automation scripts (deploy/ or Makefile)")
+    if "Strata layout" not in quality_signals:
+        recommendations.append("Add Strata agent memory layout (.strata/MANIFEST.md)")
+
+    return recommendations
+
+
+def build_badge_url(level: str, score: int, color: str) -> str:
+    """Build a shields.io badge URL for the adoption level."""
+    label = "CI%20Adoption"
+    message = f"{level}%20%7C%20Score%3A%20{score}"
+    return (
+        f"https://img.shields.io/badge/{label}-{message}-{color}"
+        "?style=for-the-badge&logo=githubactions&logoColor=white"
+    )
+
+
+def build_badge_link(repo_name: str) -> str:
+    """Build the GitHub Actions page URL used as the badge link target."""
+    return f"https://github.com/{repo_name}/actions"
+
+
+def build_badge_markdown(badge_url: str, badge_link: str) -> str:
+    """Build README markdown for the CI Adoption badge."""
+    return f"[![CI Adoption]({badge_url})]({badge_link})"
+
+
+def set_output(name: str, value: str) -> None:
+    """Write a key/value pair to GITHUB_OUTPUT when running in Actions."""
+    github_output = os.environ.get("GITHUB_OUTPUT", "")
+    if not github_output:
+        print(f"{name}={value}")
+        return
+
+    with open(github_output, "a", encoding="utf-8") as handle:
+        if "\n" in value:
+            handle.write(f"{name}<<EOF\n{value}\nEOF\n")
+        else:
+            handle.write(f"{name}={value}\n")
+
+
+def build_report(root: Path, repo_name: str) -> CIReport:
+    """Evaluate the repository and return a full adoption report."""
+    evaluated_tools = [evaluate_tool(tool_def, root) for tool_def in CI_TOOLS]
+    found_tools = [tool for tool in evaluated_tools if tool.found]
+    quality_score, quality_signals = evaluate_quality_signals(root)
+
+    ci_score = sum(tool.score_contribution for tool in found_tools)
+    total_score = min(ci_score + quality_score, 100)
+    level, badge_color = compute_level(total_score)
+    badge_url = build_badge_url(level, total_score, badge_color)
+    badge_link = build_badge_link(repo_name)
+    recommendations = build_recommendations(evaluated_tools, quality_signals)
+
+    return CIReport(
+        tools=found_tools,
+        quality_signals=quality_signals,
+        quality_score=quality_score,
+        total_score=total_score,
+        badge=BadgeInfo(level=level, color=badge_color, url=badge_url, link=badge_link),
+        recommendations=recommendations,
+    )
+
+
+def print_report(report: CIReport) -> None:
+    """Print a human-readable adoption report."""
+    print("\n" + "=" * 60)
+    print(" CI Adoption Evaluator")
+    print("=" * 60)
+    print(f"\nAdoption level : {report.badge.level}")
+    print(f"Total score    : {report.total_score}/100")
+    print(f"\nDetected CI tools ({len(report.tools)}):")
+    for tool in report.tools:
+        print(f"  - {tool.name:<20} (+{tool.score_contribution} pts)")
+        for detail in tool.details[:4]:
+            print(f"      {detail}")
+
+    print(f"\nQuality signals ({len(report.quality_signals)}) +{report.quality_score} pts:")
+    for signal in report.quality_signals:
+        print(f"  - {signal}")
+
+    if report.recommendations:
+        print("\nRecommendations:")
+        for recommendation in report.recommendations:
+            print(f"  - {recommendation}")
+
+    print(f"\nBadge URL:\n  {report.badge.url}")
+    print("=" * 60 + "\n")
+
+
+def write_github_outputs(report: CIReport) -> None:
+    """Expose report fields to downstream GitHub Actions steps."""
+    tools_str = ", ".join(tool.name for tool in report.tools) or "None"
+    signals_str = ", ".join(report.quality_signals) or "None"
+
+    set_output("badge_url", report.badge.url)
+    set_output("badge_link", report.badge.link)
+    set_output("badge_markdown", build_badge_markdown(report.badge.url, report.badge.link))
+    set_output("level", report.badge.level)
+    set_output("score", str(report.total_score))
+    set_output("tools", tools_str)
+    set_output("quality_signals", signals_str)
+
+
+def update_readme_badge(readme_path: Path, badge_markdown: str) -> bool:
+    """Replace or insert the CI Adoption badge in README.md."""
+    if not readme_path.is_file():
+        raise FileNotFoundError(f"README not found: {readme_path}")
+
+    content = readme_path.read_text(encoding="utf-8")
+    if CI_BADGE_PATTERN.search(content):
+        updated = CI_BADGE_PATTERN.sub(badge_markdown, content, count=1)
+    else:
+        lines = content.splitlines()
+        insert_at = 0
+        for index, line in enumerate(lines):
+            if line.startswith("![") or line.startswith("[!["):
+                insert_at = index + 1
+                continue
+            if insert_at > 0 and line.strip():
+                break
+        lines.insert(insert_at if insert_at > 0 else 1, badge_markdown)
+        updated = "\n".join(lines) + ("\n" if content.endswith("\n") else "")
+
+    if updated == content:
+        return False
+
+    readme_path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Evaluate CI adoption and maintain README badge metadata.")
+    parser.add_argument(
+        "--update-readme",
+        action="store_true",
+        help="Update README.md with the computed CI Adoption badge.",
+    )
+    parser.add_argument(
+        "--readme-path",
+        default="README.md",
+        help="Path to README.md relative to the repository root.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the CI adoption evaluator."""
+    args = parse_args()
+    root = Path(os.environ.get("GITHUB_WORKSPACE", Path(__file__).resolve().parents[2]))
+    repo_name = os.environ.get("REPO_NAME", "owner/repo")
+
+    report = build_report(root, repo_name)
+    print_report(report)
+    write_github_outputs(report)
+
+    if args.update_readme:
+        readme_path = root / args.readme_path
+        badge_markdown = build_badge_markdown(report.badge.url, report.badge.link)
+        changed = update_readme_badge(readme_path, badge_markdown)
+        print(f"README badge {'updated' if changed else 'unchanged'}: {readme_path}")
+
+    if report.total_score == 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/pre_commit_ci_adoption.sh
+++ b/.github/scripts/pre_commit_ci_adoption.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Local pre-push wrapper for CI adoption scoring. Advisory only — never blocks push.
+
+set -euo pipefail
+
+if [[ -n "${CI:-}" ]] || [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${PROJECT_ROOT}" || exit 0
+
+if [[ -z "${REPO_NAME:-}" ]]; then
+    remote_url="$(git config --get remote.origin.url 2>/dev/null || true)"
+    if [[ "${remote_url}" =~ github\.com[:/]([^/]+/[^/.]+) ]]; then
+        export REPO_NAME="${BASH_REMATCH[1]}"
+    else
+        export REPO_NAME="owner/repo"
+    fi
+fi
+
+python "${SCRIPT_DIR}/evaluate_ci.py" || true
+exit 0

--- a/.github/workflows/ci-badge.yml
+++ b/.github/workflows/ci-badge.yml
@@ -1,0 +1,71 @@
+---
+name: CI Adoption Badge
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ci-badge-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate-ci:
+    name: Evaluate CI Adoption Level
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Evaluate CI configuration
+        id: ci_eval
+        env:
+          REPO_NAME: ${{ github.repository }}
+        run: python .github/scripts/evaluate_ci.py
+
+      - name: Update README badge
+        env:
+          REPO_NAME: ${{ github.repository }}
+        run: python .github/scripts/evaluate_ci.py --update-readme
+
+      - name: Commit badge update
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "ci: update CI adoption badge [skip ci]"
+          file_pattern: README.md
+          commit_user_name: "CI Badge Bot"
+          commit_user_email: "ci-badge-bot@users.noreply.github.com"
+
+      - name: Print CI summary
+        run: |
+          {
+            echo "### CI Adoption Report"
+            echo ""
+            echo "| Property | Value |"
+            echo "| --- | --- |"
+            echo "| **Level** | ${{ steps.ci_eval.outputs.level }} |"
+            echo "| **Score** | ${{ steps.ci_eval.outputs.score }}/100 |"
+            echo "| **Tools** | ${{ steps.ci_eval.outputs.tools }} |"
+            echo "| **Quality signals** | ${{ steps.ci_eval.outputs.quality_signals }} |"
+            echo "| **Badge** | ![CI Adoption](${{ steps.ci_eval.outputs.badge_url }}) |"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,6 +85,14 @@ repos:
         pass_filenames: false
         files: ^\.cursor/mcp\.json$
         # Excluded in CI via SKIP in quality-control.yml.
+      - id: ci-adoption-check
+        name: ci adoption check (local pre-push, advisory)
+        entry: /bin/bash .github/scripts/pre_commit_ci_adoption.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+        # Runs on `git push` when pre-push hook is installed locally; never blocks; skipped in CI.
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.18.2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # save-ma-money
 
 ![Python](https://img.shields.io/badge/python-3.12+-blue.svg)
+[![CI Adoption](https://img.shields.io/badge/CI%20Adoption-Intermediate%20%7C%20Score%3A%2065-yellow?style=for-the-badge&logo=githubactions&logoColor=white)](https://github.com/Elmorralito/save-ma-money/actions)
 ![interrogate score](./docs/interrogate_badge.svg)
 [![coverage score](./docs/coverage-badge.svg)](https://codecov.io/upload/v4?package=github-action-3.1.6-uploader-0.8.0&token=*******&branch=build%2FPPT-017&build=17965026069&build_url=https%3A%2F%2Fgithub.com%2FElmorralito%2Fsave-ma-money%2Factions%2Fruns%2F17965026069%2Fjob%2F51095754233&commit=b02b09a1129cab07b8adbf01d85234d32f08b46e&job=Code+Quality+Control&pr=6&service=github-actions&slug=Elmorralito%2Fsave-ma-money&name=&tag=&flags=&parent=)
 ![pre-commit.ci status](https://results.pre-commit.ci/badge/github/pre-commit/pre-commit/main.svg)


### PR DESCRIPTION
Implement ops/PPT-042 (#52): a config-file-based CI maturity evaluator that scores repository adoption signals, maintains a dynamic shields.io badge in README.md, and gives developers optional local pre-push feedback. Before this change, CI maturity was documented only in .github/CI.md with no automated visibility in the README or repeatable rubric.

After this change, a GitHub Actions workflow evaluates CI on push/PR to main, weekly schedule, and workflow_dispatch; commits badge updates with [skip ci] to avoid loops; and exposes level/score/tools in the job summary. Local developers can optionally install a pre-push hook for advisory output that never blocks push.

Changes by file:
- .github/workflows/ci-badge.yml: new workflow using Python 3.12, evaluate_ci.py, README update, git-auto-commit-action@v5, and step summary; skips push runs when head commit contains [skip ci]
- .github/scripts/evaluate_ci.py: scoring engine detecting 10 CI platforms, quality signals (pre-commit, security workflows, coverage, Docker, deploy, Strata, linting, Dependabot), keyword bonuses in workflow YAML, capped 100-point rubric with Advanced/Intermediate/Basic/None levels; writes badge_url, badge_link, level, score, tools, and quality_signals to GITHUB_OUTPUT; supports --update-readme for README badge replacement
- .github/scripts/pre_commit_ci_adoption.sh: local pre-push wrapper that skips in CI, infers REPO_NAME from origin, runs evaluate_ci.py, and always exits 0 (advisory only)
- .pre-commit-config.yaml: register ci-adoption-check hook at pre-push stage (local-only; not invoked by CI pre-commit)
- README.md: add CI Adoption shields.io badge linking to GitHub Actions (current measured level: Intermediate, score 65)
- .github/CI.md: document workflow, scoring rubric, triggers, local usage, pre-push install instructions, hook inventory, supporting scripts table, and scheduled scan entry

Closes PPT-042 / #52.