### PR TITLE
fix(ci): run pre-commit twice in auto-updates workflow

### DIFF
--- a/.github/workflows/auto-updates.yml
+++ b/.github/workflows/auto-updates.yml
@@ -55,7 +55,9 @@ jobs:
             poetry run genbadge flake8 -i "${GITHUB_WORKSPACE}/docs/.flake8/report.txt" -o "${GITHUB_WORKSPACE}/docs/flake8-badge.svg"
 
       - name: Format generated markdown before commit
-        run: poetry run pre-commit run --files CHANGELOG.md README.md
+        run: |
+          poetry run pre-commit run --files CHANGELOG.md README.md || true
+          poetry run pre-commit run --files CHANGELOG.md README.md
 
       - name: Commit and push if changed
         run: |


### PR DESCRIPTION
Fixes Auto Updates failure after #76 merge: pre-commit exits 1 when hooks auto-fix CHANGELOG on first pass.

Made with [Cursor](https://cursor.com)