### PR TITLE
feat(PPT-043): integrate Redis for cache, sessions, and rate limits (PPT-…

### DIFF
--- a/.strata/docs/ARCHITECTURE.md
+++ b/.strata/docs/ARCHITECTURE.md
@@ -5,9 +5,9 @@ The codemap: where things happen, coarse module by coarse module — a map of a 
 ## Map
 
 - **`modules/model`** — `papita_txnsmodel`: SQLModel tables under `src/papita_txnsmodel/model/` (composite indexes on `accounts`, `transactions`, `transaction_templates`, `account_financing`), DTOs/repositories in `access/`, business logic in `services/`, loaders in `handlers/`. Balance report MVs in `views/balance_reports/` (SQL + `views.py` entities); MV fetch indexes in `views/indexes.py`. Generic balance report reads: `config/data/balance_report_filters.yaml`, `config/balance_report_specs.py`, `access/balance_reports/`, `services/balance_reports.py`, `handlers/balance_reports.py`. Partition + MV registry: `config/transaction_partitions.py`, `config/materialized_views.py`. Alembic under `alembic/`.
-- **`modules/api`** — `papita_txnsapi`: FastAPI app — health ([#45](https://github.com/Elmorralito/save-ma-money/issues/45)) including `/health/database` (API↔DB latency probe via `core/db_health.probe_database`), auth + tenant ([#44](https://github.com/Elmorralito/save-ma-money/issues/44)); **accounts + categories CRUD** ([#46](https://github.com/Elmorralito/save-ma-money/issues/46)); transactions/movements ([#47](https://github.com/Elmorralito/save-ma-money/issues/47)); **reports** ([#48](https://github.com/Elmorralito/save-ma-money/issues/48)).
+- **`modules/api`** — `papita_txnsapi`: FastAPI app — health ([#45](https://github.com/Elmorralito/save-ma-money/issues/45)) including `/health/database` (API↔DB latency probe via `core/db_health.probe_database`) and optional Redis probes (`core/redis`, PPT-043 / [#83](https://github.com/Elmorralito/save-ma-money/issues/83)); auth + tenant ([#44](https://github.com/Elmorralito/save-ma-money/issues/44)); **accounts + categories CRUD** ([#46](https://github.com/Elmorralito/save-ma-money/issues/46)); transactions/movements ([#47](https://github.com/Elmorralito/save-ma-money/issues/47)); **reports** ([#48](https://github.com/Elmorralito/save-ma-money/issues/48)). Optional Redis for cache-aside + distributed auth rate limits (`REDIS_*` settings; in-memory fallback when disabled).
 - **`deploy/`** — shared shell utilities, `alembic.sh`, `test.sh`, `transaction_partitions.sh` (monthly partition ensure + retention archive).
-- **`docker/database/`** — local PostgreSQL 15 via Compose for dev and migration CI.
+- **`docker/`** — local PostgreSQL 15 + Redis 7 via Compose for B0 API/dev (`docker/docker-compose.yml`, `docker/database/`).
 
 Registrar package is referenced in pytest config but not present in the tree yet.
 
@@ -68,7 +68,7 @@ Extension routing map: `services/account_extension_routing.py`. Live-DB tenancy 
 | `/api/v1/transactions` | `routers/v1/transactions.py` | `TransactionsService` — INCOME/EXPENSE CRUD + bulk (PPT-037 / #47)               |
 | `/api/v1/movements`    | `routers/v1/movements.py`    | `TransactionsService` — TRANSFER alias (PPT-037 / #47)                           |
 | `/api/v1/reports`      | `routers/v1/reports.py`      | `ReportService` — spending/cash-flow/trends/export; budget-performance 501 (#48) |
-| `/api/v1/health`       | `routers/v1/health.py`       | `probe_database` — readiness + `/database` latency (allowlisted details)         |
+| `/api/v1/health`       | `routers/v1/health.py`       | `probe_database` + Auth + optional Redis readiness (`/redis`)                    |
 
 Schemas: `schemas/accounts.py`, `schemas/categories.py`, `schemas/transactions.py`, `schemas/movements.py`,
 `schemas/reports.py`, `schemas/query_params.py`; enum slugs via `schemas/converters.py`.

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -8,23 +8,20 @@ description: Auth + user management owned by Supabase project; Compose injects S
 **Standing rule:** move / keep **user management and authentication in the Supabase
 project**. Papita API verifies JWTs + links `users` by `sub` — it is not the IdP.
 
-Compose API now injects `AUTH_PROVIDER` / `SUPABASE_*`. Smoke needs a real email
-(`AUTH_SMOKE_EMAIL`) and Confirm email off (or custom SMTP) for local.
-
 ### Last completed (this session)
 
-- PPT-040 PR [#92](https://github.com/Elmorralito/save-ma-money/pull/92): B0 live txn/movement tests,
-  Auth-first docs, source-package Codecov measurement
-- Diagnosed `codecov/patch` fail: suite mutates class-level `LinkedEntity.other_entity_service`,
-  hiding isinstance-continue; tests now clone unloaded links + ternary resolve/fallback
+- PPT-043 transactions Redis:
+  - Short-TTL cache on `GET /transactions` list + detail (`transactions` namespace, 30s)
+  - Ledger writes invalidate `transactions` + `reports` + `accounts`
+  - `Idempotency-Key` on `POST /transactions` and `/bulk` (`core/idempotency.py`)
 
 ### Next action
 
-- Commit + push Codecov isolation fix on `test/PPT-050` → confirm `codecov/patch` green on #92
-- Merge #92 → close #50; optional `make auth-smoke` against staging Auth
-- Do not reintroduce local password JWT as default; do not gate on Supabase PG/pooler
+- Optional: tenant-scoped API rate limits (Free/Pro tiers)
+- Staging: managed `REDIS_URL` when enabling horizontal scale
+- Do not commit `environments/**/.env`
 
 ### Uncommitted / staging notes
 
 - Do not commit `environments/**/.env`
-- Pending: `extends.py` + `test_linked_entities_get.py` + this strata update
+- Redis optional by default (`REDIS_ENABLED=false`)

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -10,13 +10,12 @@ project**. Papita API verifies JWTs + links `users` by `sub` — it is not the I
 
 ### Last completed (this session)
 
-- PPT-043 Redis on PR #94; added Codecov patch-gap tests
-- CI fix: rate-limiter tests must set `REDIS_URL` when `REDIS_ENABLED=true`
-  (Settings model_validator); local `.env` masked the failure
+- PPT-043 PR #94: QC green after REDIS_URL test fix; Codecov patch ~95%
+- Added owner-id-none cache BYPASS + Settings Redis URL + health degraded tests
 
 ### Next action
 
-- Confirm `quality-control` + `codecov/patch` green on #94
+- Confirm `codecov/patch` ≥ ~97.7% on #94
 - Staging: managed `REDIS_URL` when enabling horizontal scale
 - Do not commit `environments/**/.env`
 

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -10,14 +10,13 @@ project**. Papita API verifies JWTs + links `users` by `sub` — it is not the I
 
 ### Last completed (this session)
 
-- PPT-043 Redis on PR #94; Codecov patch was ~74% (target ~97.7% auto)
-- Added API unit/route tests for patch gaps: idempotency, redis client, cache
-  fail-open, broker, rate-limit edges, session store, transactions/reports Redis
-- Local: `modules/api/tests` — 242 passed, 21 skipped (live DB / B1 / Auth smoke)
+- PPT-043 Redis on PR #94; added Codecov patch-gap tests
+- CI fix: rate-limiter tests must set `REDIS_URL` when `REDIS_ENABLED=true`
+  (Settings model_validator); local `.env` masked the failure
 
 ### Next action
 
-- Push coverage commit; confirm `codecov/patch` green on #94
+- Confirm `quality-control` + `codecov/patch` green on #94
 - Staging: managed `REDIS_URL` when enabling horizontal scale
 - Do not commit `environments/**/.env`
 

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -10,14 +10,14 @@ project**. Papita API verifies JWTs + links `users` by `sub` — it is not the I
 
 ### Last completed (this session)
 
-- PPT-043 transactions Redis:
-  - Short-TTL cache on `GET /transactions` list + detail (`transactions` namespace, 30s)
-  - Ledger writes invalidate `transactions` + `reports` + `accounts`
-  - `Idempotency-Key` on `POST /transactions` and `/bulk` (`core/idempotency.py`)
+- PPT-043 Redis on PR #94; Codecov patch was ~74% (target ~97.7% auto)
+- Added API unit/route tests for patch gaps: idempotency, redis client, cache
+  fail-open, broker, rate-limit edges, session store, transactions/reports Redis
+- Local: `modules/api/tests` — 242 passed, 21 skipped (live DB / B1 / Auth smoke)
 
 ### Next action
 
-- Optional: tenant-scoped API rate limits (Free/Pro tiers)
+- Push coverage commit; confirm `codecov/patch` green on #94
 - Staging: managed `REDIS_URL` when enabling horizontal scale
 - Do not commit `environments/**/.env`
 

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,21 @@ b1-smoke:
 # Manual Supabase Auth JWT smoke against a running API (Auth-only DoD; not a DB gate).
 auth-smoke:
 	/bin/bash ./deploy/auth_smoke.sh
+
+# B0 Postgres + Redis (no API). Host uvicorn uses REDIS_URL=redis://localhost:6379/0
+redis-up:
+	docker compose --env-file environments/local/.env -f docker/database/docker-compose.yml up -d redis
+
+redis-down:
+	docker compose --env-file environments/local/.env -f docker/database/docker-compose.yml stop redis
+
+# Full B0 stack (Postgres + Redis + migrate + API). API Redis is on by default.
+stack-up:
+	docker compose --env-file environments/local/.env -f docker/docker-compose.yml up --build -d
+
+stack-down:
+	docker compose --env-file environments/local/.env -f docker/docker-compose.yml down
+
+# Redis readiness smoke against a running API (Compose or host).
+redis-smoke:
+	/bin/bash ./deploy/redis_smoke.sh

--- a/deploy/redis_smoke.sh
+++ b/deploy/redis_smoke.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Smoke Redis wiring against a running Papita API (PPT-043).
+#
+# Prerequisites:
+#   - API up (make stack-up, or host uvicorn with REDIS_ENABLED=true)
+#   - Redis reachable (Compose redis service or managed URL)
+#
+# Usage:
+#   make redis-smoke
+#   API_BASE_URL=http://localhost:8000 ./deploy/redis_smoke.sh
+
+set -euo pipefail
+
+API_BASE_URL="${API_BASE_URL:-http://localhost:8000}"
+
+echo "==> Redis smoke against ${API_BASE_URL}"
+
+ready="$(curl -fsS "${API_BASE_URL}/api/v1/health/ready")"
+echo "ready: ${ready}"
+echo "${ready}" | grep -Eq '"ready"[[:space:]]*:[[:space:]]*true'
+
+redis_health="$(curl -fsS "${API_BASE_URL}/api/v1/health/redis")"
+echo "redis: ${redis_health}"
+echo "${redis_health}" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'
+echo "${redis_health}" | grep -Fq 'api-redis link healthy'
+
+composite="$(curl -fsS "${API_BASE_URL}/api/v1/health")"
+echo "health: ${composite}"
+echo "${composite}" | grep -Eq '"redis"[[:space:]]*:[[:space:]]*"connected"'
+
+echo "OK — Redis is wired and ready"

--- a/docker/database/docker-compose.yml
+++ b/docker/database/docker-compose.yml
@@ -1,8 +1,12 @@
 ---
-# Database-only Postgres (B0). Prefer full stack via docker/docker-compose.yml.
+# Database + Redis (B0). Prefer full stack via docker/docker-compose.yml.
 #
 #   cp environments/local/.env.example environments/local/.env
 #   docker compose --env-file environments/local/.env -f docker/database/docker-compose.yml up -d
+#
+# Host API then uses:
+#   REDIS_URL=redis://localhost:6379/0
+#   REDIS_ENABLED=true
 #
 # Env layout: environments/README.md (PAPITA_ENV=local)
 
@@ -14,6 +18,8 @@ networks:
 
 volumes:
   papita-local-env:
+    driver: local
+  papita-redis-data:
     driver: local
 
 services:
@@ -44,3 +50,22 @@ services:
       PGPORT: "${POSTGRES_PORT:-${PGPORT:-${DB_PORT}}}"
     volumes:
       - "papita-local-env:/var/lib/postgresql/data:rw"
+
+  redis:
+    container_name: "redis-${COMPOSE_NAME:-papita-transactions-db}"
+    image: redis:7-alpine
+    restart: unless-stopped
+    networks:
+      - papita-local-net
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+    volumes:
+      - ../redis/redis.conf:/usr/local/etc/redis/redis.conf:ro
+      - papita-redis-data:/data:rw
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,13 +1,17 @@
 ---
-# Full local stack: PostgreSQL + Alembic migrate + FastAPI API (B0)
+# Full local stack: PostgreSQL + Redis + Alembic migrate + FastAPI API (B0)
 #
 #   cp environments/local/.env.example environments/local/.env
 #   docker compose --env-file environments/local/.env -f docker/docker-compose.yml up --build
 #
 # API: http://localhost:8000/api/docs
 # Health: http://localhost:8000/api/v1/health/ready
+# Redis: enabled in the API container by default (redis://redis:6379/0)
 #
-# Database-only:
+# Host uvicorn against Compose Redis:
+#   REDIS_URL=redis://localhost:6379/0 REDIS_ENABLED=true
+#
+# Database + Redis only (no API):
 #   docker compose --env-file environments/local/.env -f docker/database/docker-compose.yml up -d
 # Env layout: environments/README.md (PAPITA_ENV=local)
 
@@ -19,6 +23,8 @@ networks:
 
 volumes:
   papita-local-env:
+    driver: local
+  papita-redis-data:
     driver: local
 
 services:
@@ -50,6 +56,25 @@ services:
       PGPORT: "${DB_PORT:-5435}"
     volumes:
       - papita-local-env:/var/lib/postgresql/data:rw
+
+  redis:
+    container_name: "redis-${COMPOSE_NAME:-papita-transactions}"
+    image: redis:7-alpine
+    restart: unless-stopped
+    networks:
+      - papita-local-net
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+    volumes:
+      - ./redis/redis.conf:/usr/local/etc/redis/redis.conf:ro
+      - papita-redis-data:/data:rw
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
   migrate:
     build:
@@ -99,8 +124,23 @@ services:
       LOG_LEVEL: "${LOG_LEVEL:-INFO}"
       ALLOWED_ORIGINS: '${ALLOWED_ORIGINS:-["*"]}'
       DATABASE_POOL_SIZE: "${DATABASE_POOL_SIZE:-5}"
+      # In-compose Redis DNS (do not reuse host REDIS_URL=localhost from .env)
+      REDIS_URL: "redis://redis:6379/0"
+      REDIS_ENABLED: "${REDIS_ENABLED:-true}"
+      REDIS_DEFAULT_TTL_SECONDS: "${REDIS_DEFAULT_TTL_SECONDS:-60}"
+      REDIS_CACHE_TTL_ACCOUNTS_SECONDS: "${REDIS_CACHE_TTL_ACCOUNTS_SECONDS:-60}"
+      REDIS_CACHE_TTL_CATEGORIES_SECONDS: "${REDIS_CACHE_TTL_CATEGORIES_SECONDS:-300}"
+      REDIS_CACHE_TTL_REPORTS_SECONDS: "${REDIS_CACHE_TTL_REPORTS_SECONDS:-180}"
+      REDIS_CACHE_TTL_TRANSACTIONS_SECONDS: "${REDIS_CACHE_TTL_TRANSACTIONS_SECONDS:-15}"
+      REDIS_IDEMPOTENCY_TTL_SECONDS: "${REDIS_IDEMPOTENCY_TTL_SECONDS:-86400}"
+      REDIS_RATE_LIMIT_ENABLED: "${REDIS_RATE_LIMIT_ENABLED:-true}"
+      REDIS_MAX_CONNECTIONS: "${REDIS_MAX_CONNECTIONS:-10}"
+      API_RATE_LIMIT_ENABLED: "${API_RATE_LIMIT_ENABLED:-true}"
+      API_RATE_LIMIT_DEFAULT_TIER: "${API_RATE_LIMIT_DEFAULT_TIER:-free}"
     depends_on:
       postgres-db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
       migrate:
         condition: service_completed_successfully

--- a/docker/redis/redis.conf
+++ b/docker/redis/redis.conf
@@ -1,0 +1,23 @@
+# Redis 7 — B0 local / Compose (PPT-043)
+#
+# Loaded by docker/docker-compose.yml and docker/database/docker-compose.yml.
+# Not for production managed Redis (use provider TLS + ACLs there).
+
+bind 0.0.0.0
+protected-mode no
+port 6379
+tcp-backlog 511
+timeout 0
+tcp-keepalive 300
+
+# Persistence suitable for local rate-limit / cache / denylist state
+appendonly yes
+appendfsync everysec
+dir /data
+
+# Bound memory so a runaway cache cannot starve the host
+maxmemory 256mb
+maxmemory-policy allkeys-lru
+
+# Quiet enough for local logs
+loglevel notice

--- a/docs/interrogate_badge.svg
+++ b/docs/interrogate_badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="20" role="img" aria-label="interrogate: 97.2%">
-    <title>interrogate: 97.2%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="20" role="img" aria-label="interrogate: 98.2%">
+    <title>interrogate: 98.2%</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -15,8 +15,8 @@
     <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
         <text aria-hidden="true" x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" fill="#fff" textLength="610">interrogate</text>
-        <text aria-hidden="true" x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">97.2%</text>
-        <text x="1160" y="140" transform="scale(.1)" fill="#fff" textLength="370" data-interrogate="result">97.2%</text>
+        <text aria-hidden="true" x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">98.2%</text>
+        <text x="1160" y="140" transform="scale(.1)" fill="#fff" textLength="370" data-interrogate="result">98.2%</text>
     </g>
     <g id="logo-shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/docs/issues/PPT-045-uvicorn-process-packaging-brief.md
+++ b/docs/issues/PPT-045-uvicorn-process-packaging-brief.md
@@ -1,0 +1,106 @@
+**Parent program:** [#28](https://github.com/Elmorralito/save-ma-money/issues/28) (PPT-031) · **Parent epic:** [#42](https://github.com/Elmorralito/save-ma-money/issues/42) (PPT-032) · **PPT-045** · **Step:** Post-MVP ops packaging
+
+## Summary
+
+Standardize how `papita_txnsapi` is **launched under uvicorn** for B0 Compose and host/dev. This is **not** “add uvicorn” — the dependency, Dockerfile `CMD`, and README one-liners already exist. The gap is **canonical entrypoints**, Settings/`HOST`/`PORT` alignment, Make/Poetry convenience targets, worker guidance (especially vs Redis in-memory fallbacks), and runbook clarity so local and Compose paths do not drift.
+
+## Current state (inspected)
+
+| Surface       | Today                                                                                                                                                     |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ASGI app      | `papita_txnsapi.main:app` + lifespan (password manager + optional Redis)                                                                                  |
+| Dep           | `uvicorn[standard]` in `modules/api/pyproject.toml`                                                                                                       |
+| Compose image | `docker/api/Dockerfile` → `CMD ["uvicorn", "papita_txnsapi.main:app", "--host", "0.0.0.0", "--port", "8000"]` (hardcoded; ignores Settings `HOST`/`PORT`) |
+| Host docs     | Ad-hoc `uvicorn … --reload` in `modules/api/README.md` / root README                                                                                      |
+| Make          | `stack-up` / `redis-up` / `redis-smoke` exist; **no** `api-up` / host uvicorn target                                                                      |
+| Poetry        | No `[project.scripts]` / console entry for API serve                                                                                                      |
+| Settings      | `HOST`, `PORT`, `PAPITA_ENV`, DB/Auth/Redis already on `Settings`                                                                                         |
+
+## Depends on
+
+- [#42](https://github.com/Elmorralito/save-ma-money/issues/42) (PPT-032) — parent epic
+- [#83](https://github.com/Elmorralito/save-ma-money/issues/83) (PPT-043) — Redis lifespan + `/health/redis` / ready contract (coordinate; do not regress)
+- [#89](https://github.com/Elmorralito/save-ma-money/issues/89) (PPT-044) — related ops hardening (CORS/TrustedHost); keep scopes distinct
+
+## Blocks
+
+- Cleaner local DX for Auth smoke / Redis smoke against a consistently started API
+- Safer multi-replica notes before anyone enables `--workers` without Redis rate limits
+
+## Platform rule (B0 + B1)
+
+Validate process packaging on **B0 Docker Postgres** (and Compose Redis when enabled). Supabase remains **Auth-only** for MVP; do not require pooler DB for this issue. Staging/prod notes may document managed Redis + uvicorn flags without deploying K8s.
+
+## Decisions to lock in this issue
+
+1. **Canonical host entrypoint** — prefer one of:
+   - `make api-up` (PAPITA_ENV=local, reads `environments/local/.env`, `--reload` for dev), and/or
+   - Poetry script e.g. `papita-api` / `poetry run papita-api`
+2. **Canonical Compose path** — keep Dockerfile CMD; optionally shell-form or entrypoint that passes `$HOST`/`$PORT` from env to match Settings.
+3. **Reload policy** — `--reload` **host/dev only**; never in Compose prod-like `CMD`.
+4. **Workers** — B0 default **single worker**. Document: in-memory rate limiter is process-local; multi-worker requires `REDIS_RATE_LIMIT_ENABLED=true` (+ Redis denylist). Defer gunicorn+uvicorn-workers unless justified.
+5. **Lifecycle** — uvicorn must run the FastAPI lifespan (Redis init/teardown); document graceful shutdown expectations.
+6. **Health contract unchanged** — `/api/v1/health`, `/ready`, `/live`, `/redis` remain smoke targets (`make redis-smoke` when Redis on).
+
+## Tasks / deliverables
+
+### Ops / infra
+
+- [ ] Add Makefile target(s): e.g. `api-up` (host uvicorn + reload), document relationship to `stack-up` / `redis-up`
+- [ ] Optional Poetry console script or documented `poetry run uvicorn` wrapper with `cd`/PYTHONPATH clarity from repo root
+- [ ] Align Dockerfile/Compose CMD with `HOST`/`PORT` env (or document why flags stay literal `0.0.0.0:8000`)
+- [ ] Ensure Compose `api` service does not inject host `REDIS_URL=localhost` (already hardcoded `redis://redis:6379/0` — keep)
+
+### Docs
+
+- [ ] Update `modules/api/README.md` run sections: one host path, one Compose path; remove stale “when routers land”
+- [ ] Update `environments/README.md` with host vs Compose Redis URL split + uvicorn notes
+- [ ] Short ops note (README or `docs/ops/`) on workers vs Redis rate-limit / denylist fail-closed
+
+### API package (minimal)
+
+- [ ] Only if needed: tiny `__main__.py` or script module that reads Settings and execs uvicorn programmatically (optional; Make + uvicorn CLI is enough)
+
+## API / infra integration
+
+- [ ] B0: `make redis-up` + host `api-up` → `/health/ready` true; optional `make redis-smoke`
+- [ ] B0: `make stack-up` → container healthcheck + ready
+- [ ] Env examples already document `HOST`/`PORT` or explicitly defer to uvicorn flags
+- [ ] No secrets committed (`.env` stays gitignored)
+
+## Requirements traceability
+
+| ID      | Scope                                           |
+| ------- | ----------------------------------------------- |
+| NFR-04  | Operability — reproducible local/Compose start  |
+| NFR-ops | Process packaging; readiness probes remain gate |
+| PPT-043 | Lifespan Redis pool must start under uvicorn    |
+
+## Out of scope
+
+- Kubernetes / ECS / systemd unit files
+- TLS termination / reverse proxy (Caddy, nginx, Traefik)
+- gunicorn + uvicorn worker fleet (unless a short ADR justifies it)
+- Changing REST routes or business logic in `papita_txnsmodel`
+- Registrar, DuckDB, RLS (B3)
+- Full PPT-044 security pack (CORS/TrustedHost/docs lockdown) — track on #89
+
+## Acceptance criteria
+
+- [ ] Documented **one** canonical host command and **one** Compose path
+- [ ] Dockerfile/Compose CMD aligned with Settings `HOST`/`PORT` **or** explicitly documented exception
+- [ ] Make and/or Poetry convenience target(s) for local run
+- [ ] Worker guidance written (single-worker default; Redis required before multi-worker)
+- [ ] B0 smoke: API up → ready → optional `make redis-smoke`
+- [ ] README (+ env README) updated; no secrets in git
+
+## References
+
+- `modules/api/src/papita_txnsapi/main.py` — `create_app`, lifespan, module `app`
+- `docker/api/Dockerfile` — current uvicorn `CMD` + live healthcheck
+- `docker/docker-compose.yml` — `api` service env (Auth, DB, Redis)
+- `Makefile` — `stack-up`, `redis-up`, `redis-smoke`
+- `modules/api/README.md` — host uvicorn snippets
+- [#83](https://github.com/Elmorralito/save-ma-money/issues/83) PPT-043 Redis
+- [#89](https://github.com/Elmorralito/save-ma-money/issues/89) PPT-044 hardening
+- Epic [#42](https://github.com/Elmorralito/save-ma-money/issues/42) PPT-032

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -13,6 +13,7 @@ Live issue status (open/closed, closing PR summaries) is mirrored in the root [C
 | [`PPT-031-C-supabase-decision-brief.md`](PPT-031-C-supabase-decision-brief.md)                                                               | [#31](https://github.com/Elmorralito/save-ma-money/issues/31) | **Complete — awaiting G7 sign-off on #28** |
 | [`PPT-043-redis-integration-brief.md`](PPT-043-redis-integration-brief.md)                                                                   | [#83](https://github.com/Elmorralito/save-ma-money/issues/83) | Open (post-MVP)                            |
 | [`PPT-044-api-hardening-brief.md`](PPT-044-api-hardening-brief.md)                                                                           | [#89](https://github.com/Elmorralito/save-ma-money/issues/89) | Open (post-MVP API-wide hardening)         |
+| [`PPT-045-uvicorn-process-packaging-brief.md`](PPT-045-uvicorn-process-packaging-brief.md)                                                   | [#93](https://github.com/Elmorralito/save-ma-money/issues/93) | Open (uvicorn host/Compose packaging)      |
 
 See [`../design/README.md`](../design/README.md) for the full document registry including planned deliverables ([#32](https://github.com/Elmorralito/save-ma-money/issues/32)–[#34](https://github.com/Elmorralito/save-ma-money/issues/34)).
 

--- a/docs/ops/redis-deploy-checklist.md
+++ b/docs/ops/redis-deploy-checklist.md
@@ -1,0 +1,63 @@
+# Redis B0 deploy checklist (PPT-043)
+
+Local Redis is part of the Compose stack. Managed Redis is used for staging/prod.
+
+## B0 — Docker Compose
+
+```bash
+cp environments/local/.env.example environments/local/.env
+# Ensure REDIS_ENABLED=true and REDIS_URL=redis://localhost:6379/0 for host uvicorn
+
+# Full stack (API Redis URL is hardcoded to redis://redis:6379/0)
+make stack-up
+make redis-smoke
+
+# Or infra only + host API
+make redis-up
+# then: uvicorn with PAPITA_ENV=local (reads environments/local/.env)
+```
+
+| Piece                          | Path                                                               |
+| ------------------------------ | ------------------------------------------------------------------ |
+| Redis image + volume           | `docker/docker-compose.yml` / `docker/database/docker-compose.yml` |
+| Server config (AOF, maxmemory) | `docker/redis/redis.conf`                                          |
+| Smoke script                   | `deploy/redis_smoke.sh`                                            |
+
+## B1 — Managed Redis
+
+1. Provision Upstash / ElastiCache / compatible Redis 7 with TLS.
+2. Set in `environments/staging/.env` or `production/.env` (never commit):
+
+```bash
+REDIS_URL="rediss://default:<password>@<host>:6379"
+REDIS_ENABLED="true"
+REDIS_RATE_LIMIT_ENABLED="true"
+REDIS_CACHE_TTL_ACCOUNTS_SECONDS="60"
+REDIS_CACHE_TTL_CATEGORIES_SECONDS="300"
+REDIS_CACHE_TTL_REPORTS_SECONDS="180"
+REDIS_CACHE_TTL_TRANSACTIONS_SECONDS="15"
+REDIS_MAX_CONNECTIONS="10"
+# PAPITA_ENV=staging|production — all keys are papita:{env}:…
+```
+
+3. Restart API; confirm `GET /api/v1/health/redis` → `api-redis link healthy`.
+4. Postgres remains source of truth; Redis is additive (cache, rate limits, JWT denylist).
+
+## Hardening notes
+
+| Concern                   | Policy                                         |
+| ------------------------- | ---------------------------------------------- |
+| Key prefix                | `papita:{PAPITA_ENV}:…` (isolate shared Redis) |
+| Rate limit                | Atomic Lua ZSET (no multi-pipeline race)       |
+| Cache / rate-limit errors | Fail open                                      |
+| JWT denylist errors       | Fail closed (503) when `REDIS_ENABLED`         |
+| Client                    | Sync `redis` for now; `redis.asyncio` later    |
+
+## App wiring
+
+| Capability                                | Flag / path                                   |
+| ----------------------------------------- | --------------------------------------------- |
+| Connection pool                           | `REDIS_ENABLED` + lifespan `init_redis`       |
+| Distributed auth/API rate limits          | `REDIS_RATE_LIMIT_ENABLED` + Lua limiter      |
+| Cache-aside (per-route TTL)               | automatic when Redis enabled                  |
+| JWT denylist on logout / protected routes | `SessionStore` fail-closed when Redis enabled |

--- a/environments/README.md
+++ b/environments/README.md
@@ -32,9 +32,26 @@ PAPITA_ENV=staging make b1-smoke     # optional pooler connectivity; not Auth Do
 Compose:
 
 ```bash
+# Full stack (Postgres + Redis + API). Redis is enabled for the API container by default.
 docker compose --env-file environments/local/.env -f docker/docker-compose.yml up --build
+# Or: make stack-up
+
+# Postgres + Redis only (host uvicorn)
 docker compose --env-file environments/local/.env -f docker/database/docker-compose.yml up -d
+# Or: make redis-up   # Redis service only
+
+make redis-smoke   # GET /health/ready + /health/redis against a running API
 ```
+
+### Redis (PPT-043)
+
+| Context                      | `REDIS_URL`                        | Notes                                                   |
+| ---------------------------- | ---------------------------------- | ------------------------------------------------------- |
+| Compose `api` service        | `redis://redis:6379/0` (hardcoded) | `REDIS_ENABLED` / rate-limit default **true**           |
+| Host uvicorn + Compose Redis | `redis://localhost:6379/0`         | Set in `environments/local/.env`                        |
+| Staging / production         | Managed `rediss://…`               | Placeholders in `staging` / `production` `.env.example` |
+
+Config file: [`docker/redis/redis.conf`](../docker/redis/redis.conf) (AOF, 256mb maxmemory, allkeys-lru).
 
 ## Setup
 

--- a/environments/local/.env.example
+++ b/environments/local/.env.example
@@ -61,6 +61,31 @@ ALLOWED_ORIGINS='["*"]'
 # AUTH_OAUTH_RATE_LIMIT_PER_MINUTE="20"
 # AUTH_COOKIE_SECURE="true"  # omit to follow not DEBUG; set true behind HTTPS
 
+# -----------------------------------------------------------------------------
+# Redis (PPT-043) — B0 local deploy
+# Host uvicorn → localhost. Compose API service always uses redis://redis:6379/0
+# (hardcoded in docker/docker-compose.yml so this host URL is not injected).
+# B1: managed Redis URL (Upstash / ElastiCache / etc.) — never commit secrets
+# -----------------------------------------------------------------------------
+REDIS_URL="redis://localhost:6379/0"
+REDIS_ENABLED="true"
+REDIS_DEFAULT_TTL_SECONDS="60"
+REDIS_CACHE_TTL_ACCOUNTS_SECONDS="60"
+REDIS_CACHE_TTL_CATEGORIES_SECONDS="300"
+REDIS_CACHE_TTL_REPORTS_SECONDS="180"
+REDIS_CACHE_TTL_TRANSACTIONS_SECONDS="15"
+REDIS_IDEMPOTENCY_TTL_SECONDS="86400"
+REDIS_RATE_LIMIT_ENABLED="true"
+REDIS_MAX_CONNECTIONS="10"
+REDIS_PORT=6379
+# Tenant API quotas (accounts/categories/transactions/movements/reports)
+API_RATE_LIMIT_ENABLED="true"
+API_RATE_LIMIT_DEFAULT_TIER="free"
+API_RATE_LIMIT_FREE_PER_MINUTE="60"
+API_RATE_LIMIT_FREE_PER_DAY="1000"
+API_RATE_LIMIT_PRO_PER_MINUTE="300"
+API_RATE_LIMIT_PRO_PER_DAY="10000"
+
 
 # -----------------------------------------------------------------------------
 # Docker Compose + Alembic (DB_* / COMPOSE_*)
@@ -78,6 +103,7 @@ POSTGRES_USER=admin
 POSTGRES_PASSWORD=admin
 POSTGRES_DB=papita
 POSTGRES_PORT=5435
+REDIS_PORT=6379
 
 # -----------------------------------------------------------------------------
 # Supabase (B1 pooler / optional B2 Auth) — placeholders for local dual-target work

--- a/environments/production/.env.example
+++ b/environments/production/.env.example
@@ -24,3 +24,12 @@ DATABASE_POOL_SIZE="5"
 LOG_LEVEL="WARNING"
 # Never use "*" with credentials in production
 ALLOWED_ORIGINS='["https://app.example.com"]'
+
+# Redis (PPT-043) — managed Redis URL from secrets manager (never commit real values)
+# REDIS_URL="rediss://default:<password>@<host>:6379"
+# REDIS_ENABLED="true"
+# REDIS_DEFAULT_TTL_SECONDS="60"
+# REDIS_RATE_LIMIT_ENABLED="true"
+# REDIS_MAX_CONNECTIONS="20"
+# API_RATE_LIMIT_ENABLED="true"
+# API_RATE_LIMIT_DEFAULT_TIER="free"

--- a/environments/staging/.env.example
+++ b/environments/staging/.env.example
@@ -30,3 +30,12 @@ DATABASE_URL="postgresql+psycopg2://admin:admin@localhost:5435/papita"
 DATABASE_POOL_SIZE="5"
 LOG_LEVEL="INFO"
 ALLOWED_ORIGINS='["http://localhost:3000"]'
+
+# Redis (PPT-043) — managed Redis for staging horizontal scale (Upstash / ElastiCache / etc.)
+# REDIS_URL="rediss://default:<password>@<host>:6379"
+# REDIS_ENABLED="true"
+# REDIS_DEFAULT_TTL_SECONDS="60"
+# REDIS_RATE_LIMIT_ENABLED="true"
+# REDIS_MAX_CONNECTIONS="10"
+# API_RATE_LIMIT_ENABLED="true"
+# API_RATE_LIMIT_DEFAULT_TIER="free"

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -1651,19 +1651,93 @@ Returned for deferred MVP endpoints (budgets, auth refresh/logout, transaction s
 
 ## Rate Limiting
 
+**Auth** (`/auth/login`, `/auth/register`, OAuth) uses a **per-IP** sliding window
+(`AUTH_*_RATE_LIMIT_*`). **Protected CRUD/report routes** use **tenant-scoped**
+Free / Pro / Enterprise quotas (`API_RATE_LIMIT_*`) keyed by `owner_id` (minute + day
+windows). Counters are in-memory by default; with `REDIS_ENABLED=true` and
+`REDIS_RATE_LIMIT_ENABLED=true` they are shared across replicas via Redis.
+
 | Tier       | Requests/Minute | Requests/Day |
 | ---------- | --------------- | ------------ |
 | Free       | 60              | 1,000        |
 | Pro        | 300             | 10,000       |
 | Enterprise | Unlimited       | Unlimited    |
 
-Rate limit headers:
+Default tier is `API_RATE_LIMIT_DEFAULT_TIER` (usually `free`). Optional Redis override:
+`papita:{env}:{owner_id}:api_tier` → `free` \| `pro` \| `enterprise`. Disable tenant
+quotas with `API_RATE_LIMIT_ENABLED=false`.
+
+Rate limit headers (success and 429):
 
 ```
 X-RateLimit-Limit: 60
 X-RateLimit-Remaining: 45
 X-RateLimit-Reset: 1707058440
+X-RateLimit-Tier: free
+Retry-After: 12   # on 429 only
 ```
+
+---
+
+## Redis (PPT-043)
+
+Optional shared infrastructure for cache-aside, distributed rate limits, and
+(session denylist / broker scaffolds). PostgreSQL remains the source of truth.
+
+```
+[ Client ] → [ API Server ] → [ Redis ]     (hit: fast return)
+                    ↓ miss
+            [ PostgreSQL B0/B1 ]
+```
+
+| Variable                               | Default                                     | Purpose                                           |
+| -------------------------------------- | ------------------------------------------- | ------------------------------------------------- |
+| `REDIS_URL`                            | unset                                       | Redis connection URL (`redis://…` / `rediss://…`) |
+| `REDIS_ENABLED`                        | `false` (unit tests) / `true` (Compose API) | Init pool + include Redis in `/health/ready`      |
+| `REDIS_DEFAULT_TTL_SECONDS`            | `60`                                        | Legacy; unused — prefer per-namespace TTLs below  |
+| `REDIS_CACHE_TTL_ACCOUNTS_SECONDS`     | `60`                                        | `GET /accounts` list TTL                          |
+| `REDIS_CACHE_TTL_CATEGORIES_SECONDS`   | `300`                                       | `GET /categories` list TTL                        |
+| `REDIS_CACHE_TTL_REPORTS_SECONDS`      | `180`                                       | Reports TTL (tune 120–300s)                       |
+| `REDIS_CACHE_TTL_TRANSACTIONS_SECONDS` | `15`                                        | Short TTL for `GET /transactions` list/detail     |
+| `REDIS_IDEMPOTENCY_TTL_SECONDS`        | `86400`                                     | Replay window for `Idempotency-Key` on creates    |
+| `REDIS_RATE_LIMIT_ENABLED`             | `false` (unit tests) / `true` (Compose API) | Use Redis for auth/API rate-limit counters        |
+| `REDIS_MAX_CONNECTIONS`                | `10`                                        | Connection pool size                              |
+
+B0 deploy: `make stack-up` (or `make redis-up` + host uvicorn). Compose API always
+uses `redis://redis:6379/0`. Host uvicorn uses `REDIS_URL=redis://localhost:6379/0`
+from `environments/local/.env`. Smoke: `make redis-smoke`. Checklist:
+[`docs/ops/redis-deploy-checklist.md`](../../docs/ops/redis-deploy-checklist.md).
+
+When `REDIS_ENABLED=false`, the API keeps in-memory rate limiting and skips
+caching/denylist; unit tests remain green without Redis.
+
+**Key prefix:** all Redis keys are `papita:{PAPITA_ENV}:…` so local/staging/production
+do not collide on shared Redis.
+
+**Fail policy:** cache and rate limits **fail open** (miss / allow) on Redis errors.
+JWT denylist **fails closed** when Redis is required (`REDIS_ENABLED=true`): Redis
+errors → HTTP 503 on protected routes so a blip cannot resurrect a revoked token.
+
+**Client model:** sync `redis` via lifespan; fine while most handlers are sync
+(threadpool). Prefer `redis.asyncio` when more routes are async-heavy.
+
+Protected cache keys are tenant-scoped, env-prefixed, and **versioned**:
+`papita:{env}:{owner_id}:{route}:v{version}:{hash(params)}`. Mutations bump a
+per-tenant namespace counter so prior entries miss without SCAN. Successful GETs
+may return `X-Cache: HIT|MISS|BYPASS`.
+
+| Mutation                      | Invalidates                                      |
+| ----------------------------- | ------------------------------------------------ |
+| Account create/update/delete  | `accounts`, `reports`                            |
+| Category create/update/delete | `categories`, `reports`                          |
+| Transaction / movement writes | `transactions`, `reports`, `accounts` (balances) |
+
+`POST /transactions` and `POST /transactions/bulk` accept optional
+`Idempotency-Key` (when Redis is enabled) so safe retries replay the original
+201 body without double-inserting.
+
+Logout denylists access tokens in Redis (local + Supabase); protected routes
+reject revoked JWTs until TTL expires.
 
 ---
 

--- a/modules/api/pyproject.toml
+++ b/modules/api/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "python-multipart (>=0.0.32,<0.0.33)",
     "httpx (>=0.28.1,<0.29.0)",
     "supabase (>=2.13.0,<3.0.0)",
+    "redis (>=5.0.0,<6.0.0)",
 ]
 
 [project.urls]

--- a/modules/api/src/papita_txnsapi/config/settings.py
+++ b/modules/api/src/papita_txnsapi/config/settings.py
@@ -106,6 +106,22 @@ class Settings(BaseSettings):
         AUTH_RATE_LIMIT_WINDOW_SECONDS: Sliding window length for auth limits.
         AUTH_LOGIN_RATE_LIMIT_PER_MINUTE: Max login attempts per window per IP.
         AUTH_REGISTER_RATE_LIMIT_PER_MINUTE: Max register attempts per window per IP.
+        REDIS_URL: Redis connection URL when shared infra is enabled (PPT-043).
+        REDIS_ENABLED: When ``True``, initialize a Redis pool and include Redis in readiness.
+        REDIS_DEFAULT_TTL_SECONDS: Legacy unused fallback; prefer per-namespace TTLs.
+        REDIS_CACHE_TTL_ACCOUNTS_SECONDS: Cache TTL for accounts list (default 60s).
+        REDIS_CACHE_TTL_CATEGORIES_SECONDS: Cache TTL for categories list (default 300s).
+        REDIS_CACHE_TTL_REPORTS_SECONDS: Cache TTL for reports (default 180s; range 120–300).
+        REDIS_CACHE_TTL_TRANSACTIONS_SECONDS: Short cache TTL for transactions (default 15s).
+        REDIS_IDEMPOTENCY_TTL_SECONDS: TTL for ``Idempotency-Key`` replay records.
+        REDIS_RATE_LIMIT_ENABLED: When ``True`` (and Redis enabled), use distributed rate limits.
+        REDIS_MAX_CONNECTIONS: Max connections in the Redis pool.
+        API_RATE_LIMIT_ENABLED: Tenant-scoped Free/Pro/Enterprise API quotas on protected routes.
+        API_RATE_LIMIT_DEFAULT_TIER: Default plan when no Redis ``papita:{env}:{owner_id}:api_tier`` override.
+        API_RATE_LIMIT_FREE_PER_MINUTE: Free tier requests per rolling minute.
+        API_RATE_LIMIT_FREE_PER_DAY: Free tier requests per rolling day.
+        API_RATE_LIMIT_PRO_PER_MINUTE: Pro tier requests per rolling minute.
+        API_RATE_LIMIT_PRO_PER_DAY: Pro tier requests per rolling day.
     """
 
     model_config = SettingsConfigDict(env_file_encoding="utf-8", extra="ignore")
@@ -138,7 +154,7 @@ class Settings(BaseSettings):
     ALLOWED_ORIGINS: list[str] = ["*"]
     FALLBACK_ACTION: FallbackAction = FallbackAction.LOG
 
-    # Auth hardening — per-IP sliding window (single-instance B0; use Redis post-MVP)
+    # Auth hardening — per-IP sliding window (Redis when REDIS_RATE_LIMIT_ENABLED)
     AUTH_RATE_LIMIT_ENABLED: bool = True
     AUTH_RATE_LIMIT_WINDOW_SECONDS: int = 60
     AUTH_LOGIN_RATE_LIMIT_PER_MINUTE: int = 10
@@ -146,6 +162,26 @@ class Settings(BaseSettings):
     AUTH_OAUTH_RATE_LIMIT_PER_MINUTE: int = 20
     # When None, OAuth PKCE cookies use Secure when DEBUG is false.
     AUTH_COOKIE_SECURE: bool | None = None
+
+    # Redis (PPT-043) — optional; in-memory fallbacks when disabled
+    REDIS_URL: str | None = None
+    REDIS_ENABLED: bool = False
+    REDIS_DEFAULT_TTL_SECONDS: int = 60
+    REDIS_CACHE_TTL_ACCOUNTS_SECONDS: int = 60
+    REDIS_CACHE_TTL_CATEGORIES_SECONDS: int = 300
+    REDIS_CACHE_TTL_REPORTS_SECONDS: int = 180
+    REDIS_CACHE_TTL_TRANSACTIONS_SECONDS: int = 15
+    REDIS_IDEMPOTENCY_TTL_SECONDS: int = 86_400
+    REDIS_RATE_LIMIT_ENABLED: bool = False
+    REDIS_MAX_CONNECTIONS: int = 10
+
+    # Tenant API rate limits (README Free / Pro / Enterprise)
+    API_RATE_LIMIT_ENABLED: bool = True
+    API_RATE_LIMIT_DEFAULT_TIER: Literal["free", "pro", "enterprise"] = "free"
+    API_RATE_LIMIT_FREE_PER_MINUTE: int = 60
+    API_RATE_LIMIT_FREE_PER_DAY: int = 1_000
+    API_RATE_LIMIT_PRO_PER_MINUTE: int = 300
+    API_RATE_LIMIT_PRO_PER_DAY: int = 10_000
 
     @field_validator("DATABASE_URL", mode="before")
     @classmethod
@@ -186,6 +222,23 @@ class Settings(BaseSettings):
             return value.strip().rstrip("/")
         return None
 
+    @field_validator("REDIS_URL", mode="before")
+    @classmethod
+    def coerce_redis_url(cls, value: str | None) -> str | None:
+        """Normalize blank Redis URLs to ``None``.
+
+        Args:
+            value: Raw env string or ``None``.
+
+        Returns:
+            Stripped URL or ``None``.
+        """
+        if value is None:
+            return None
+        if isinstance(value, str) and value.strip() != "":
+            return value.strip()
+        return None
+
     @model_validator(mode="before")
     @classmethod
     def prefer_supabase_when_url_configured(cls, data: Any) -> Any:
@@ -218,10 +271,13 @@ class Settings(BaseSettings):
             The validated settings instance with ``DATABASE_URL`` as a connector class.
 
         Raises:
-            ValueError: When ``AUTH_PROVIDER=supabase`` without ``SUPABASE_URL``.
+            ValueError: When ``AUTH_PROVIDER=supabase`` without ``SUPABASE_URL``, or
+                when ``REDIS_ENABLED`` without ``REDIS_URL``.
         """
         if self.AUTH_PROVIDER == "supabase" and not self.SUPABASE_URL:
             raise ValueError("SUPABASE_URL is required when AUTH_PROVIDER=supabase")
+        if self.REDIS_ENABLED and not self.REDIS_URL:
+            raise ValueError("REDIS_URL is required when REDIS_ENABLED=true")
 
         url_or_connector = self.DATABASE_URL
         if isinstance(url_or_connector, type) and issubclass(url_or_connector, SQLDatabaseConnector):

--- a/modules/api/src/papita_txnsapi/core/__init__.py
+++ b/modules/api/src/papita_txnsapi/core/__init__.py
@@ -1,5 +1,5 @@
 """Core API infrastructure shared across routers and dependencies.
 
-Includes JWT security, exception handlers, database health probes, and in-process
-rate limiting used by authentication routes.
+Includes JWT security, exception handlers, database/Auth/Redis health probes,
+in-process and Redis rate limiting, and cache-aside helpers.
 """

--- a/modules/api/src/papita_txnsapi/core/api_tier.py
+++ b/modules/api/src/papita_txnsapi/core/api_tier.py
@@ -1,0 +1,110 @@
+"""API subscription tier helpers for tenant rate limits (PPT-043).
+
+Tiers follow the API README Free / Pro / Enterprise matrix. Until billing lands,
+the default tier comes from settings; optional per-tenant overrides can be stored
+in Redis at ``papita:{env}:{owner_id}:api_tier``.
+
+Key exports:
+    ApiTier: Allowed plan names.
+    TierLimits: Per-minute and per-day quotas.
+    resolve_api_tier: Resolve tier for an owner.
+    limits_for_tier: Map tier to numeric limits from settings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from redis import Redis
+from redis.exceptions import RedisError
+
+from papita_txnsapi.core.redis_keys import redis_key
+
+if TYPE_CHECKING:
+    from papita_txnsapi.config.settings import Settings
+
+
+class ApiTier(StrEnum):
+    """Supported API rate-limit tiers."""
+
+    FREE = "free"
+    PRO = "pro"
+    ENTERPRISE = "enterprise"
+
+
+@dataclass(frozen=True, slots=True)
+class TierLimits:
+    """Numeric quotas for a tier.
+
+    Attributes:
+        per_minute: Max requests per rolling 60s window; ``0`` or negative = unlimited.
+        per_day: Max requests per rolling 24h window; ``0`` or negative = unlimited.
+    """
+
+    per_minute: int
+    per_day: int
+
+    @property
+    def unlimited(self) -> bool:
+        """Whether both windows are unlimited."""
+        return self.per_minute <= 0 and self.per_day <= 0
+
+
+def resolve_api_tier(
+    settings: Settings,
+    owner_id: UUID | str,
+    redis: Redis | None = None,
+) -> ApiTier:
+    """Resolve the API tier for a tenant.
+
+    Prefers Redis override ``papita:{env}:{owner_id}:api_tier`` when present and
+    valid; otherwise uses ``settings.API_RATE_LIMIT_DEFAULT_TIER``.
+
+    Args:
+        settings: Application settings with default tier.
+        owner_id: Authenticated tenant id.
+        redis: Optional Redis client for per-tenant overrides.
+
+    Returns:
+        Resolved :class:`ApiTier`.
+    """
+    if redis is not None:
+        try:
+            raw = redis.get(redis_key(owner_id, "api_tier"))
+            if isinstance(raw, str):
+                try:
+                    return ApiTier(raw)
+                except ValueError:
+                    pass
+        except RedisError:
+            pass
+    try:
+        return ApiTier(settings.API_RATE_LIMIT_DEFAULT_TIER)
+    except ValueError:
+        return ApiTier.FREE
+
+
+def limits_for_tier(settings: Settings, tier: ApiTier) -> TierLimits:
+    """Return configured minute/day limits for ``tier``.
+
+    Args:
+        settings: Application settings with tier quota fields.
+        tier: Resolved API tier.
+
+    Returns:
+        :class:`TierLimits` for enforcement.
+    """
+    if tier is ApiTier.ENTERPRISE:
+        return TierLimits(per_minute=0, per_day=0)
+    if tier is ApiTier.PRO:
+        return TierLimits(
+            per_minute=settings.API_RATE_LIMIT_PRO_PER_MINUTE,
+            per_day=settings.API_RATE_LIMIT_PRO_PER_DAY,
+        )
+    return TierLimits(
+        per_minute=settings.API_RATE_LIMIT_FREE_PER_MINUTE,
+        per_day=settings.API_RATE_LIMIT_FREE_PER_DAY,
+    )

--- a/modules/api/src/papita_txnsapi/core/broker.py
+++ b/modules/api/src/papita_txnsapi/core/broker.py
@@ -1,0 +1,92 @@
+"""Queue / pub-sub broker scaffold for Redis (PPT-043 P3).
+
+Interface-only placeholders for background jobs and cache-invalidation
+broadcasts. No worker fleet is deployed in this issue.
+
+Key exports:
+    BrokerSettings: Feature flags for future broker wiring.
+    RedisBroker: Minimal enqueue / publish stubs.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from redis import Redis
+from redis.exceptions import RedisError
+
+from papita_txnsapi.core.redis_keys import redis_key
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerSettings:
+    """Broker feature flags (scaffold).
+
+    Attributes:
+        enabled: Whether broker operations should attempt Redis writes.
+        default_queue: Default list key for simple LPUSH enqueue (env-prefixed).
+    """
+
+    enabled: bool = False
+    default_queue: str = ""  # resolved to papita:{env}:jobs when empty
+
+
+class RedisBroker:
+    """Minimal Redis list / pub-sub scaffold.
+
+    Args:
+        client: Optional Redis client.
+        settings: Broker feature flags.
+    """
+
+    def __init__(self, client: Redis | None, settings: BrokerSettings | None = None) -> None:
+        self._client = client
+        self._settings = settings or BrokerSettings()
+
+    @property
+    def available(self) -> bool:
+        """Whether broker writes can run."""
+        return bool(self._settings.enabled and self._client is not None)
+
+    def enqueue(self, payload: str, *, queue: str | None = None) -> bool:
+        """Push a job payload onto a Redis list (scaffold).
+
+        Args:
+            payload: Opaque job payload string.
+            queue: Optional queue key override.
+
+        Returns:
+            ``True`` when LPUSH succeeded; ``False`` when disabled or on error.
+        """
+        if not self.available or self._client is None:
+            return False
+        key = queue or self._settings.default_queue or redis_key("jobs")
+        try:
+            self._client.lpush(key, payload)
+            return True
+        except RedisError:
+            logger.exception("Broker enqueue failed")
+            return False
+
+    def publish(self, channel: str, message: str) -> bool:
+        """Publish a message on a Redis channel (scaffold).
+
+        Args:
+            channel: Pub/sub channel name (env-prefixed when not already namespaced).
+            message: Message body.
+
+        Returns:
+            ``True`` when PUBLISH succeeded; ``False`` when disabled or on error.
+        """
+        if not self.available or self._client is None:
+            return False
+        channel_key = channel if channel.startswith("papita:") else redis_key("channel", channel)
+        try:
+            self._client.publish(channel_key, message)
+            return True
+        except RedisError:
+            logger.exception("Broker publish failed")
+            return False

--- a/modules/api/src/papita_txnsapi/core/cache.py
+++ b/modules/api/src/papita_txnsapi/core/cache.py
@@ -1,0 +1,258 @@
+"""Cache-aside helpers for tenant-scoped Redis caching (PPT-043).
+
+Uses per-tenant, per-namespace version counters so mutations invalidate related
+entries without SCAN/DELETE of hashed keys. Keys are namespaced as
+``papita:{env}:{owner_id}:…`` (see :mod:`redis_keys`). Cache reads/writes
+**fail open** (miss / skip) on Redis errors.
+
+Per-route TTLs (not a single global default): accounts 60s, categories 300s,
+reports 120–300s (default 180s), transactions 15s.
+
+Key exports:
+    CacheNamespace: Logical cache groups (accounts, categories, reports, transactions).
+    build_cache_key: Compose ``papita:{env}:{owner_id}:{route}:v{version}:{hash}``.
+    get_cache_version / bump_cache_versions: Version counter helpers.
+    cache_get_json / cache_set_json: JSON get/set with TTL.
+    ttl_for_namespace: Resolve TTL from settings or defaults.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Mapping
+from uuid import UUID
+
+from redis import Redis
+from redis.exceptions import RedisError
+
+from papita_txnsapi.core.redis_keys import redis_key
+
+if TYPE_CHECKING:
+    from papita_txnsapi.config.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+# Fallback TTLs when settings fields are unavailable (per-route, not global).
+_DEFAULT_TTL_SECONDS: dict[str, int] = {
+    "accounts": 60,
+    "categories": 300,
+    "reports": 180,
+    "transactions": 15,
+}
+
+
+class CacheNamespace(StrEnum):
+    """Logical cache groups invalidated together after mutations."""
+
+    ACCOUNTS = "accounts"
+    CATEGORIES = "categories"
+    REPORTS = "reports"
+    TRANSACTIONS = "transactions"
+
+
+def version_key(owner_id: UUID | str, namespace: CacheNamespace | str) -> str:
+    """Return the Redis key for a tenant namespace version counter."""
+    return redis_key(owner_id, "cache_ver", namespace)
+
+
+def get_cache_version(client: Redis | None, owner_id: UUID | str, namespace: CacheNamespace | str) -> int:
+    """Read the current cache version for ``owner_id`` + ``namespace``.
+
+    Args:
+        client: Redis client, or ``None`` (returns ``0``).
+        owner_id: Tenant primary key.
+        namespace: Cache namespace.
+
+    Returns:
+        Integer version (``0`` when missing or Redis unavailable).
+    """
+    if client is None:
+        return 0
+    try:
+        raw = client.get(version_key(owner_id, namespace))
+    except RedisError:
+        logger.exception("Redis cache version read failed")
+        return 0
+    if raw is None:
+        return 0
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
+def bump_cache_versions(
+    client: Redis | None,
+    owner_id: UUID | str | None,
+    *namespaces: CacheNamespace | str,
+) -> None:
+    """Increment version counters so prior hashed keys become unreachable.
+
+    Args:
+        client: Redis client, or ``None`` to no-op.
+        owner_id: Tenant primary key; no-op when ``None``.
+        namespaces: One or more namespaces to invalidate.
+    """
+    if client is None or owner_id is None or not namespaces:
+        return
+    try:
+        pipe = client.pipeline()
+        for namespace in namespaces:
+            pipe.incr(version_key(owner_id, namespace))
+        pipe.execute()
+    except RedisError:
+        logger.exception("Redis cache version bump failed for owner %s", owner_id)
+
+
+def build_cache_key(
+    owner_id: UUID | str,
+    route: str,
+    params: Mapping[str, Any] | None = None,
+    *,
+    version: int = 0,
+) -> str:
+    """Build a tenant-scoped, versioned cache key for a route and parameters.
+
+    Args:
+        owner_id: Authenticated tenant primary key (JWT ``sub`` / owner id).
+        route: Stable route label (e.g. ``accounts:list``).
+        params: Optional query/path parameters included in the hash.
+        version: Namespace version from :func:`get_cache_version`.
+
+    Returns:
+        Key of the form ``papita:{env}:{owner_id}:{route}:v{version}:{sha256}``.
+    """
+    payload = json.dumps(params or {}, sort_keys=True, default=str, separators=(",", ":"))
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
+    return redis_key(owner_id, route, f"v{version}", digest)
+
+
+def cache_get_json(client: Redis | None, key: str) -> dict[str, Any] | None:
+    """Fetch a JSON object from Redis.
+
+    Args:
+        client: Redis client, or ``None`` to skip (cache miss).
+        key: Full cache key from :func:`build_cache_key`.
+
+    Returns:
+        Deserialized mapping on hit; ``None`` on miss, disabled client, or error.
+    """
+    if client is None:
+        return None
+    try:
+        raw = client.get(key)
+    except RedisError:
+        logger.exception("Redis cache get failed for key prefix %s", key.split(":", 1)[0])
+        return None
+    if raw is None:
+        return None
+    try:
+        loaded = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        logger.warning("Invalid JSON in cache for key hash segment")
+        return None
+    if not isinstance(loaded, dict):
+        return None
+    return loaded
+
+
+def cache_set_json(
+    client: Redis | None,
+    key: str,
+    value: Mapping[str, Any],
+    *,
+    ttl_seconds: int,
+) -> bool:
+    """Store a JSON-serializable mapping in Redis with a TTL.
+
+    Args:
+        client: Redis client, or ``None`` to skip.
+        key: Full cache key from :func:`build_cache_key`.
+        value: Mapping to serialize (typically ``model_dump(mode=\"json\")``).
+        ttl_seconds: Expiration in seconds; non-positive skips the write.
+
+    Returns:
+        ``True`` when the write succeeded; ``False`` when skipped or on error.
+    """
+    if client is None or ttl_seconds <= 0:
+        return False
+    try:
+        payload = json.dumps(value, default=str, separators=(",", ":"))
+        client.setex(key, ttl_seconds, payload)
+        return True
+    except (TypeError, RedisError):
+        logger.exception("Redis cache set failed for key prefix %s", key.split(":", 1)[0])
+        return False
+
+
+def ttl_for_namespace(settings: Settings | None, namespace: CacheNamespace | str) -> int:
+    """Resolve cache TTL seconds for a namespace from settings or defaults.
+
+    Args:
+        settings: Optional application settings with per-namespace TTL fields.
+        namespace: Cache namespace.
+
+    Returns:
+        Positive TTL in seconds.
+    """
+    ns = namespace if isinstance(namespace, CacheNamespace) else CacheNamespace(str(namespace))
+    if settings is not None:
+        if ns is CacheNamespace.ACCOUNTS:
+            return max(1, settings.REDIS_CACHE_TTL_ACCOUNTS_SECONDS)
+        if ns is CacheNamespace.CATEGORIES:
+            return max(1, settings.REDIS_CACHE_TTL_CATEGORIES_SECONDS)
+        if ns is CacheNamespace.REPORTS:
+            return max(1, settings.REDIS_CACHE_TTL_REPORTS_SECONDS)
+        if ns is CacheNamespace.TRANSACTIONS:
+            return max(1, settings.REDIS_CACHE_TTL_TRANSACTIONS_SECONDS)
+    return _DEFAULT_TTL_SECONDS.get(ns.value, 60)
+
+
+def get_versioned_cached_json(
+    client: Redis | None,
+    owner_id: UUID | str,
+    namespace: CacheNamespace,
+    route: str,
+    params: Mapping[str, Any] | None = None,
+) -> tuple[dict[str, Any] | None, str]:
+    """Read a versioned cache entry.
+
+    Args:
+        client: Redis client or ``None``.
+        owner_id: Tenant id.
+        namespace: Cache namespace for version lookup.
+        route: Route label.
+        params: Query/path parameters.
+
+    Returns:
+        ``(payload, \"HIT\"|\"MISS\"|\"BYPASS\")`` where BYPASS means Redis disabled.
+    """
+    if client is None:
+        return None, "BYPASS"
+    version = get_cache_version(client, owner_id, namespace)
+    key = build_cache_key(owner_id, route, params, version=version)
+    cached = cache_get_json(client, key)
+    if cached is None:
+        return None, "MISS"
+    return cached, "HIT"
+
+
+def set_versioned_cached_json(
+    client: Redis | None,
+    owner_id: UUID | str,
+    namespace: CacheNamespace,
+    route: str,
+    params: Mapping[str, Any] | None,
+    *,
+    value: Mapping[str, Any],
+    ttl_seconds: int,
+) -> bool:
+    """Write a versioned cache entry under the current namespace version."""
+    if client is None:
+        return False
+    version = get_cache_version(client, owner_id, namespace)
+    key = build_cache_key(owner_id, route, params, version=version)
+    return cache_set_json(client, key, value, ttl_seconds=ttl_seconds)

--- a/modules/api/src/papita_txnsapi/core/idempotency.py
+++ b/modules/api/src/papita_txnsapi/core/idempotency.py
@@ -1,0 +1,168 @@
+"""Redis idempotency helpers for mutating API routes (PPT-043).
+
+Stores completed response payloads keyed by tenant + client ``Idempotency-Key``
+so retries replay the same result without double-creating ledger rows.
+
+Key exports:
+    IdempotencyResult: Outcome of begin/complete helpers.
+    begin_idempotency: Claim or replay a key.
+    complete_idempotency: Persist the successful response body.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping
+from uuid import UUID
+
+from redis import Redis
+from redis.exceptions import RedisError
+
+from papita_txnsapi.core.redis_keys import redis_key
+
+logger = logging.getLogger(__name__)
+
+_PENDING = {"status": "pending"}
+
+
+@dataclass(frozen=True, slots=True)
+class IdempotencyResult:
+    """Outcome of an idempotency begin check.
+
+    Attributes:
+        state: ``bypass`` (no Redis/key), ``miss`` (claimed), ``hit`` (replay),
+            or ``conflict`` (another request still pending).
+        payload: Cached completed response body when ``state`` is ``hit``.
+    """
+
+    state: Literal["bypass", "miss", "hit", "conflict"]
+    payload: dict[str, Any] | None = None
+
+
+def _idempotency_redis_key(owner_id: UUID | str, scope: str, key: str) -> str:
+    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+    return redis_key(owner_id, "idem", scope, digest)
+
+
+def _result_from_stored(raw: str | bytes | None) -> IdempotencyResult:
+    """Map a stored Redis value to hit/conflict (never miss)."""
+    if raw is None:
+        return IdempotencyResult(state="conflict")
+    try:
+        loaded = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return IdempotencyResult(state="conflict")
+    if not isinstance(loaded, dict):
+        return IdempotencyResult(state="conflict")
+    if loaded.get("status") == "pending":
+        return IdempotencyResult(state="conflict")
+    body = loaded.get("body")
+    if isinstance(body, dict):
+        return IdempotencyResult(state="hit", payload=body)
+    return IdempotencyResult(state="conflict")
+
+
+def begin_idempotency(
+    client: Redis | None,
+    owner_id: UUID | str,
+    *,
+    scope: str,
+    key: str | None,
+    ttl_seconds: int,
+) -> IdempotencyResult:
+    """Claim an idempotency key or return a prior completed payload.
+
+    Args:
+        client: Redis client, or ``None`` to bypass.
+        owner_id: Tenant primary key.
+        scope: Logical operation scope (e.g. ``transactions:create``).
+        key: Client-supplied ``Idempotency-Key``; blank/None bypasses.
+        ttl_seconds: Expiration for lock and completed records.
+
+    Returns:
+        :class:`IdempotencyResult` describing whether to proceed, replay, or conflict.
+    """
+    if client is None or key is None or not str(key).strip() or ttl_seconds <= 0:
+        return IdempotencyResult(state="bypass")
+
+    storage_key = _idempotency_redis_key(owner_id, scope, str(key).strip())
+    try:
+        existing = client.get(storage_key)
+        if existing is not None:
+            return _result_from_stored(existing)
+
+        acquired = client.set(storage_key, json.dumps(_PENDING, separators=(",", ":")), nx=True, ex=ttl_seconds)
+        if acquired:
+            return IdempotencyResult(state="miss")
+
+        # Lost the race — re-read; treat vanished key as a fresh miss.
+        raced = client.get(storage_key)
+        if raced is None:
+            return IdempotencyResult(state="miss")
+        return _result_from_stored(raced)
+    except RedisError:
+        logger.exception("Idempotency begin failed; proceeding without lock")
+        return IdempotencyResult(state="bypass")
+
+
+def complete_idempotency(
+    client: Redis | None,
+    owner_id: UUID | str,
+    *,
+    scope: str,
+    key: str | None,
+    body: Mapping[str, Any],
+    ttl_seconds: int,
+    http_status: int = 201,
+) -> None:
+    """Persist a completed response for later idempotent replays.
+
+    Args:
+        client: Redis client, or ``None`` to no-op.
+        owner_id: Tenant primary key.
+        scope: Logical operation scope matching :func:`begin_idempotency`.
+        key: Client-supplied ``Idempotency-Key``.
+        body: JSON-serializable response body.
+        ttl_seconds: Expiration for the completed record.
+        http_status: HTTP status stored alongside the body (informational).
+    """
+    if client is None or key is None or not str(key).strip() or ttl_seconds <= 0:
+        return
+    storage_key = _idempotency_redis_key(owner_id, scope, str(key).strip())
+    try:
+        payload = {"status": "completed", "http_status": http_status, "body": dict(body)}
+        client.setex(storage_key, ttl_seconds, json.dumps(payload, default=str, separators=(",", ":")))
+    except (TypeError, RedisError):
+        logger.exception("Idempotency complete failed")
+
+
+def clear_idempotency_pending(
+    client: Redis | None,
+    owner_id: UUID | str,
+    *,
+    scope: str,
+    key: str | None,
+) -> None:
+    """Drop a pending lock after a failed create so the client may retry.
+
+    Args:
+        client: Redis client, or ``None`` to no-op.
+        owner_id: Tenant primary key.
+        scope: Logical operation scope.
+        key: Client-supplied ``Idempotency-Key``.
+    """
+    if client is None or key is None or not str(key).strip():
+        return
+    storage_key = _idempotency_redis_key(owner_id, scope, str(key).strip())
+    try:
+        raw = client.get(storage_key)
+        if raw is None:
+            return
+        loaded = json.loads(raw)
+        if isinstance(loaded, dict) and loaded.get("status") == "pending":
+            client.delete(storage_key)
+    except (TypeError, json.JSONDecodeError, RedisError):
+        logger.exception("Idempotency pending clear failed")

--- a/modules/api/src/papita_txnsapi/core/rate_limit.py
+++ b/modules/api/src/papita_txnsapi/core/rate_limit.py
@@ -1,23 +1,72 @@
-"""In-memory sliding-window rate limiter for auth endpoints (B0 single-instance).
+"""Sliding-window rate limiters for auth and tenant API quotas (B0 + Redis).
 
-Thread-safe per-key counter suitable for single-process deployments. Tracks request
-timestamps in a sliding window and exposes standard ``X-RateLimit-*`` header values via
-``RateLimitResult``. Disabled or bypassed when limits are non-positive.
+Thread-safe in-memory limiter for single-process deployments, plus a Redis-backed
+limiter for multi-replica consistency when ``REDIS_RATE_LIMIT_ENABLED`` is set.
+The Redis path uses a single Lua script so prune/check/incr cannot race under load.
+Cache and rate-limit paths **fail open** on Redis errors; JWT denylist uses a
+separate fail-closed policy when Redis is required (see :mod:`session_store`).
 
 Key exports:
     RateLimitResult: Immutable outcome of a limit check.
     InMemoryRateLimiter: Process-wide singleton limiter (``MetaSingleton``).
-    get_rate_limiter: Accessor for the shared limiter instance.
+    RedisRateLimiter: Distributed sliding-window limiter via atomic Lua + ZSET.
+    get_rate_limiter: Accessor for the shared in-memory limiter instance.
+    get_rate_limiter_for_request: Factory selecting Redis vs in-memory.
 """
 
 from __future__ import annotations
 
+import logging
 import threading
 import time
 from collections import defaultdict
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
 
+from redis import Redis
+from redis.exceptions import RedisError
+
+from papita_txnsapi.core.redis_keys import redis_key
 from papita_txnsmodel.utils.classutils import MetaSingleton
+
+if TYPE_CHECKING:
+    from fastapi import Request
+
+    from papita_txnsapi.config.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+# Atomic prune → count → optional ZADD → expire. Returns {allowed, count_after, oldest_score}.
+_RATE_LIMIT_LUA = """
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local window_start = tonumber(ARGV[2])
+local limit = tonumber(ARGV[3])
+local window_seconds = tonumber(ARGV[4])
+local member = ARGV[5]
+
+redis.call('ZREMRANGEBYSCORE', key, 0, window_start)
+local count = redis.call('ZCARD', key)
+local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+local oldest_score = now
+if #oldest >= 2 then
+  oldest_score = tonumber(oldest[2])
+end
+
+local allowed = 0
+local count_after = count
+if count < limit then
+  redis.call('ZADD', key, now, member)
+  redis.call('EXPIRE', key, window_seconds)
+  count_after = count + 1
+  allowed = 1
+  if count == 0 then
+    oldest_score = now
+  end
+end
+
+return {allowed, count_after, tostring(oldest_score)}
+"""
 
 
 @dataclass(frozen=True)
@@ -35,6 +84,13 @@ class RateLimitResult:
     limit: int
     remaining: int
     reset_at: int
+
+
+class RateLimiter(Protocol):
+    """Protocol for rate limiters used by auth dependencies."""
+
+    def check(self, key: str, *, limit: int, window_seconds: int = 60) -> RateLimitResult:
+        """Evaluate whether ``key`` is within ``limit`` for the sliding window."""
 
 
 class InMemoryRateLimiter(metaclass=MetaSingleton):
@@ -99,6 +155,100 @@ class InMemoryRateLimiter(metaclass=MetaSingleton):
         )
 
 
+class RedisRateLimiter:
+    """Distributed sliding-window limiter using an atomic Lua script over a ZSET.
+
+    Fail-open on Redis errors (allow the request and log) so auth/API traffic is not
+    fully blocked by a cache blip. Prefer healthy Redis + readiness probes in prod.
+    """
+
+    def __init__(self, client: Redis) -> None:
+        self._client = client
+        # Prefer EVALSHA via register_script; fall back to EVAL for clients that
+        # support Lua but not SCRIPT LOAD (e.g. some FakeRedis builds).
+        self._script = client.register_script(_RATE_LIMIT_LUA)
+
+    def _eval_limit(
+        self,
+        namespaced: str,
+        *,
+        epoch_now: float,
+        window_start: float,
+        limit: int,
+        window_seconds: int,
+        member: str,
+    ) -> list:
+        """Run the atomic rate-limit script (EVALSHA, with EVAL fallback)."""
+        args = [
+            f"{epoch_now:.6f}",
+            f"{window_start:.6f}",
+            str(limit),
+            str(window_seconds),
+            member,
+        ]
+        try:
+            return self._script(keys=[namespaced], args=args)
+        except RedisError as exc:
+            if "evalsha" not in str(exc).lower() and "noscript" not in str(exc).lower():
+                raise
+            return self._client.eval(_RATE_LIMIT_LUA, 1, namespaced, *args)
+
+    def check(self, key: str, *, limit: int, window_seconds: int = 60) -> RateLimitResult:
+        """Evaluate whether ``key`` is within ``limit`` using Redis ZSET timestamps.
+
+        Args:
+            key: Opaque identifier (typically scope plus client IP).
+            limit: Maximum requests permitted per window; non-positive limits always allow.
+            window_seconds: Sliding window length in seconds.
+
+        Returns:
+            ``RateLimitResult`` describing allowance, quota, and reset epoch.
+        """
+        epoch_now = time.time()
+        if limit <= 0:
+            return RateLimitResult(
+                allowed=True,
+                limit=limit,
+                remaining=limit,
+                reset_at=int(epoch_now) + window_seconds,
+            )
+
+        namespaced = redis_key("ratelimit", key)
+        window_start = epoch_now - window_seconds
+        member = f"{epoch_now:.6f}:{id(self)}"
+
+        try:
+            raw = self._eval_limit(
+                namespaced,
+                epoch_now=epoch_now,
+                window_start=window_start,
+                limit=limit,
+                window_seconds=window_seconds,
+                member=member,
+            )
+            allowed_flag = int(raw[0])
+            count_after = int(raw[1])
+            oldest_score = float(raw[2])
+            allowed = allowed_flag == 1
+            remaining = max(0, limit - count_after) if allowed else 0
+            reset_at = int(oldest_score) + window_seconds
+            return RateLimitResult(
+                allowed=allowed,
+                limit=limit,
+                remaining=remaining,
+                reset_at=max(int(epoch_now) + 1, reset_at),
+            )
+        except RedisError:
+            # Fail open for rate limits (availability over strict throttling).
+            logger.exception("Redis rate limit check failed; failing open for key scope")
+            return RateLimitResult(
+                allowed=True,
+                limit=limit,
+                remaining=limit,
+                reset_at=int(epoch_now) + window_seconds,
+            )
+
+
 def get_rate_limiter() -> InMemoryRateLimiter:
     """Return the process-wide ``InMemoryRateLimiter`` singleton.
 
@@ -106,3 +256,21 @@ def get_rate_limiter() -> InMemoryRateLimiter:
         Shared limiter instance used by auth rate-limit dependencies.
     """
     return InMemoryRateLimiter()
+
+
+def get_rate_limiter_for_request(request: Request, settings: Settings) -> RateLimiter:
+    """Select Redis or in-memory limiter based on settings and app state.
+
+    Args:
+        request: Incoming request (reads ``app.state.redis``).
+        settings: Application settings with Redis rate-limit flags.
+
+    Returns:
+        ``RedisRateLimiter`` when enabled and a client is available; otherwise
+        the in-memory singleton.
+    """
+    if settings.REDIS_ENABLED and settings.REDIS_RATE_LIMIT_ENABLED:
+        client = getattr(request.app.state, "redis", None)
+        if isinstance(client, Redis):
+            return RedisRateLimiter(client)
+    return get_rate_limiter()

--- a/modules/api/src/papita_txnsapi/core/redis.py
+++ b/modules/api/src/papita_txnsapi/core/redis.py
@@ -1,0 +1,184 @@
+"""Redis connection pool helpers for optional shared infrastructure (PPT-043).
+
+Provides a **sync** ``redis`` client lifecycle for FastAPI lifespan and
+dependencies. Sync calls from async routes are acceptable for now (Starlette
+runs sync endpoints in a threadpool); migrate to ``redis.asyncio`` when more
+routes are async-heavy. When ``REDIS_ENABLED`` is false, helpers are no-ops so
+the API keeps in-memory fallbacks. Postgres remains the source of truth.
+
+Key naming uses ``papita:{PAPITA_ENV}:…`` (see :mod:`redis_keys`).
+
+Fail policy (by concern):
+    * Cache / rate-limit — **fail open** (miss / allow) on Redis errors.
+    * JWT denylist — **fail closed** when Redis is required (503), so revoked
+      tokens cannot be resurrected during a Redis blip.
+
+Key exports:
+    init_redis: Create a pooled client when Redis is enabled.
+    close_redis: Close the client and its connection pool.
+    get_redis_from_app: Read ``app.state.redis`` safely.
+    ping_redis: Lightweight readiness probe with latency.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from redis import Redis
+from redis.connection import ConnectionPool
+from redis.exceptions import RedisError
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+    from papita_txnsapi.config.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+_MAX_LATENCY_MS = 60_000.0
+
+
+class RedisProbeDetail(StrEnum):
+    """Allowlisted Redis probe detail strings returned to HTTP clients."""
+
+    HEALTHY = "api-redis link healthy"
+    DISABLED = "redis disabled"
+    CLIENT_UNAVAILABLE = "redis client unavailable"
+    PROBE_FAILED = "probe failed"
+
+
+@dataclass(frozen=True, slots=True)
+class RedisProbeResult:
+    """Outcome of a Redis connectivity probe.
+
+    Attributes:
+        connected: ``True`` when ``PING`` succeeded.
+        latency_ms: Round-trip duration in milliseconds when connected.
+        detail: Allowlisted status label (never raw exception text).
+        required: Whether Redis is required for readiness (``REDIS_ENABLED``).
+    """
+
+    connected: bool
+    latency_ms: float | None
+    detail: RedisProbeDetail
+    required: bool = False
+
+
+def _safe_latency_ms(elapsed_seconds: float) -> float:
+    """Convert elapsed seconds to a finite, non-negative millisecond latency."""
+    latency_ms = round(elapsed_seconds * 1000.0, 3)
+    if not math.isfinite(latency_ms) or latency_ms < 0.0:
+        return 0.0
+    return min(latency_ms, _MAX_LATENCY_MS)
+
+
+def init_redis(settings: Settings) -> Redis | None:
+    """Create a pooled Redis client when ``REDIS_ENABLED`` is true.
+
+    Args:
+        settings: Application settings with Redis URL and pool size.
+
+    Returns:
+        Connected ``Redis`` client, or ``None`` when Redis is disabled.
+
+    Raises:
+        ValueError: When Redis is enabled without a ``REDIS_URL``.
+        RedisError: When the initial ``PING`` fails (caller may treat as startup failure).
+    """
+    if not settings.REDIS_ENABLED:
+        logger.info("Redis disabled (REDIS_ENABLED=false)")
+        return None
+
+    if not settings.REDIS_URL:
+        raise ValueError("REDIS_URL is required when REDIS_ENABLED=true")
+
+    pool = ConnectionPool.from_url(
+        settings.REDIS_URL,
+        max_connections=settings.REDIS_MAX_CONNECTIONS,
+        decode_responses=True,
+    )
+    client = Redis(connection_pool=pool)
+    client.ping()
+    logger.info("Redis connection pool ready (max_connections=%s)", settings.REDIS_MAX_CONNECTIONS)
+    return client
+
+
+def close_redis(client: Redis | None) -> None:
+    """Close a Redis client and its underlying connection pool.
+
+    Args:
+        client: Client previously returned by :func:`init_redis`, or ``None``.
+    """
+    if client is None:
+        return
+    try:
+        client.close()
+        pool = getattr(client, "connection_pool", None)
+        if pool is not None:
+            pool.disconnect()
+    except Exception:
+        logger.exception("Error while closing Redis client")
+    else:
+        logger.info("Redis connection pool closed")
+
+
+def get_redis_from_app(app: FastAPI) -> Redis | None:
+    """Return the Redis client stored on ``app.state``, if any.
+
+    Args:
+        app: FastAPI application instance.
+
+    Returns:
+        ``Redis`` client or ``None`` when unset/disabled.
+    """
+    return getattr(app.state, "redis", None)
+
+
+def ping_redis(client: Redis | None, *, required: bool = False) -> RedisProbeResult:
+    """Probe Redis connectivity and measure round-trip latency.
+
+    Args:
+        client: Optional Redis client from application state.
+        required: Whether Redis is required for readiness (``REDIS_ENABLED``).
+
+    Returns:
+        :class:`RedisProbeResult` with allowlisted detail only.
+    """
+    if not required and client is None:
+        return RedisProbeResult(
+            connected=True,
+            latency_ms=None,
+            detail=RedisProbeDetail.DISABLED,
+            required=False,
+        )
+
+    if client is None:
+        return RedisProbeResult(
+            connected=False,
+            latency_ms=None,
+            detail=RedisProbeDetail.CLIENT_UNAVAILABLE,
+            required=required,
+        )
+
+    try:
+        started = time.perf_counter()
+        client.ping()
+        return RedisProbeResult(
+            connected=True,
+            latency_ms=_safe_latency_ms(time.perf_counter() - started),
+            detail=RedisProbeDetail.HEALTHY,
+            required=required,
+        )
+    except RedisError:
+        logger.exception("Redis readiness check failed")
+        return RedisProbeResult(
+            connected=False,
+            latency_ms=None,
+            detail=RedisProbeDetail.PROBE_FAILED,
+            required=required,
+        )

--- a/modules/api/src/papita_txnsapi/core/redis_keys.py
+++ b/modules/api/src/papita_txnsapi/core/redis_keys.py
@@ -1,0 +1,41 @@
+"""Environment-scoped Redis key namespacing (PPT-043 hardening).
+
+All Redis keys use ``papita:{env}:…`` so local / staging / production (or shared
+managed Redis) do not collide. ``env`` follows :data:`PAPITA_ENV`
+(``local`` | ``staging`` | ``production``).
+
+Key exports:
+    redis_key: Join path segments under the ``papita:{env}:`` prefix.
+    redis_key_prefix: Return the bare ``papita:{env}:`` prefix string.
+"""
+
+from __future__ import annotations
+
+from papita_txnsapi.config.environment import active_environment, normalize_environment_name
+
+
+def redis_key_prefix(*, env: str | None = None) -> str:
+    """Return the Redis key prefix ``papita:{env}:``.
+
+    Args:
+        env: Optional environment name; defaults to active ``PAPITA_ENV``.
+
+    Returns:
+        Prefix including the trailing colon.
+    """
+    name = normalize_environment_name(env) if env is not None else active_environment()
+    return f"papita:{name}:"
+
+
+def redis_key(*parts: object, env: str | None = None) -> str:
+    """Build a fully namespaced Redis key.
+
+    Args:
+        parts: Path segments joined with ``:`` (e.g. ``owner_id``, ``cache_ver``, ``accounts``).
+        env: Optional environment override for the ``papita:{env}:`` prefix.
+
+    Returns:
+        Key of the form ``papita:{env}:{part}:{part}:…``.
+    """
+    suffix = ":".join(str(part) for part in parts)
+    return f"{redis_key_prefix(env=env)}{suffix}"

--- a/modules/api/src/papita_txnsapi/core/session_store.py
+++ b/modules/api/src/papita_txnsapi/core/session_store.py
@@ -1,0 +1,113 @@
+"""JWT denylist / session store for Redis (PPT-043).
+
+Provides a Redis-backed revocation set for access tokens. When Redis is required
+(``REDIS_ENABLED=true``), denylist checks **fail closed** on Redis errors so a
+blip cannot resurrect a revoked token. Cache and rate-limit paths remain fail-open.
+
+Key exports:
+    SessionStoreUnavailableError: Raised when fail-closed denylist cannot consult Redis.
+    SessionStore: Denylist helper with TTL aligned to JWT lifetime.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+
+from redis import Redis
+from redis.exceptions import RedisError
+
+from papita_txnsapi.core.redis_keys import redis_key
+
+logger = logging.getLogger(__name__)
+
+
+class SessionStoreUnavailableError(RuntimeError):
+    """Raised when a fail-closed denylist check cannot reach Redis."""
+
+
+def _token_digest(token: str) -> str:
+    """Return a stable SHA-256 hex digest for a bearer token."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+class SessionStore:
+    """Redis SET-based JWT denylist with per-token TTL.
+
+    Args:
+        client: Redis client (required for operations to succeed).
+        default_ttl_seconds: TTL applied when revoking tokens.
+        fail_closed: When ``True``, Redis errors during :meth:`is_revoked` raise
+            :class:`SessionStoreUnavailableError` instead of treating the token as
+            valid (security tradeoff vs cache/rate-limit fail-open).
+    """
+
+    def __init__(
+        self,
+        client: Redis | None,
+        *,
+        default_ttl_seconds: int,
+        fail_closed: bool = False,
+    ) -> None:
+        self._client = client
+        self._default_ttl_seconds = max(1, default_ttl_seconds)
+        self._fail_closed = fail_closed
+
+    @property
+    def available(self) -> bool:
+        """Whether a Redis client is configured."""
+        return self._client is not None
+
+    @property
+    def fail_closed(self) -> bool:
+        """Whether denylist checks reject traffic when Redis is unreachable."""
+        return self._fail_closed
+
+    def revoke(self, token: str, *, ttl_seconds: int | None = None) -> bool:
+        """Add ``token`` to the denylist until TTL expires.
+
+        Args:
+            token: Raw bearer access token.
+            ttl_seconds: Optional override TTL; defaults to store TTL.
+
+        Returns:
+            ``True`` when the token was recorded; ``False`` when Redis is unavailable.
+        """
+        if self._client is None or not token:
+            return False
+        ttl = self._default_ttl_seconds if ttl_seconds is None else max(1, ttl_seconds)
+        key = redis_key("jwt", "denylist", _token_digest(token))
+        try:
+            self._client.setex(key, ttl, "1")
+            return True
+        except RedisError:
+            logger.exception("Failed to revoke token in session store")
+            return False
+
+    def is_revoked(self, token: str) -> bool:
+        """Return whether ``token`` is present in the denylist.
+
+        Args:
+            token: Raw bearer access token.
+
+        Returns:
+            ``True`` when revoked; ``False`` when not found.
+
+        Raises:
+            SessionStoreUnavailableError: When ``fail_closed`` is enabled and Redis
+                is missing or errors (prefer rejecting the request with 503).
+        """
+        if not token:
+            return False
+        if self._client is None:
+            if self._fail_closed:
+                raise SessionStoreUnavailableError("JWT denylist Redis client unavailable")
+            return False
+        key = redis_key("jwt", "denylist", _token_digest(token))
+        try:
+            return bool(self._client.exists(key))
+        except RedisError as exc:
+            logger.exception("Failed to check token denylist")
+            if self._fail_closed:
+                raise SessionStoreUnavailableError("JWT denylist Redis check failed") from exc
+            return False

--- a/modules/api/src/papita_txnsapi/core/supabase_auth.py
+++ b/modules/api/src/papita_txnsapi/core/supabase_auth.py
@@ -1,20 +1,31 @@
 """Supabase Auth client helpers for register, login, OAuth, and sessions.
 
-When ``AUTH_PROVIDER=supabase``, API ``/auth/*`` delegates credential and session
-work to GoTrue via the official Supabase Python client:
+When ``AUTH_PROVIDER=supabase``, API ``/auth/*`` routes delegate credential and
+session work to GoTrue through the official Supabase Python client. This module
+normalizes SDK responses into Papita DTOs, maps Auth errors to stable HTTP
+status/detail pairs, and provides Admin helpers for orphan Auth-user cleanup.
 
-* Password: ``sign_up``, ``sign_in_with_password``, ``refresh_session``, ``sign_out``
-* OAuth PKCE: ``sign_in_with_oauth``, ``exchange_code_for_session``
-* SSO handoff: ``set_session`` + user lookup
-* Admin orphan cleanup: ``admin.delete_user`` / ``admin.get_user_by_id``
+Covered Auth operations:
+    * Password — ``sign_up``, ``sign_in_with_password``, ``refresh_session``, ``sign_out``
+    * OAuth PKCE — ``sign_in_with_oauth``, ``exchange_code_for_session``
+    * SSO handoff — ``set_session`` plus user lookup for email backfill
+    * Admin orphan cleanup — ``admin.delete_user`` / ``admin.get_user_by_id``
 
-JWT verification on protected routes still uses JWKS in
-:mod:`papita_txnsapi.core.security`. Anon and service-role clients are
-process-cached by ``(url, key)`` under a lock; call
+JWT verification on protected routes is **not** performed here; that stays in
+:mod:`papita_txnsapi.core.security` (JWKS). Anon and service-role clients are
+process-cached by ``(url, key)`` under a lock. Call
 :func:`clear_supabase_client_cache` in tests or after credential rotation.
 
-Public types:
-    ``SupabaseAuthResult``, ``SupabaseOAuthStart``, ``SupabaseSignUpProfile``.
+Key exports:
+    SupabaseAuthResult: Normalized Auth outcome for register/login/refresh/OAuth.
+    SupabaseOAuthStart: Authorize URL plus PKCE verifier for OAuth start.
+    SupabaseSignUpProfile: Optional Auth ``user_metadata`` / phone for ``sign_up``.
+    create_supabase_auth_client / create_supabase_admin_client: Cached SDK clients.
+    classify_supabase_auth_error: Map Auth exceptions to HTTP status + detail.
+    supabase_sign_up / supabase_sign_in / supabase_refresh_session / supabase_sign_out.
+    supabase_oauth_authorize_url / supabase_exchange_code_for_session.
+    supabase_establish_session: Attach an existing client-held session.
+    supabase_admin_delete_user / supabase_auth_user_created_recently: Orphan cleanup.
 """
 
 from __future__ import annotations
@@ -40,7 +51,10 @@ _ADMIN_CLIENT_CACHE: dict[tuple[str, str], Client] = {}
 
 @dataclass(frozen=True, slots=True)
 class SupabaseAuthResult:
-    """Normalized Auth outcome for Papita register/login/refresh/OAuth.
+    """Normalized Auth outcome for Papita register, login, refresh, and OAuth.
+
+    Routers map this into API token envelopes. Session fields may be absent when
+    Supabase requires email confirmation before issuing tokens.
 
     Attributes:
         user_id: Auth subject UUID (``auth.users.id`` / JWT ``sub``).
@@ -48,7 +62,7 @@ class SupabaseAuthResult:
         access_token: Bearer JWT when a session was issued; ``None`` on confirm-only signup.
         refresh_token: Opaque refresh token when a session was issued.
         expires_in: Access-token lifetime in seconds when provided by Auth.
-        raw: Underlying SDK response object for debugging / tests.
+        raw: Underlying SDK response object for debugging and tests.
     """
 
     user_id: uuid.UUID
@@ -63,6 +77,9 @@ class SupabaseAuthResult:
 class SupabaseOAuthStart:
     """Authorize URL plus PKCE verifier for a server-mediated OAuth start.
 
+    The caller must persist ``code_verifier`` (response body or HttpOnly cookie)
+    and present it to :func:`supabase_exchange_code_for_session` after redirect.
+
     Attributes:
         provider: Supabase provider id (e.g. ``google``, ``github``).
         url: Browser authorize URL including the PKCE challenge.
@@ -76,7 +93,10 @@ class SupabaseOAuthStart:
 
 @dataclass(frozen=True, slots=True)
 class SupabaseSignUpProfile:
-    """Optional Auth ``user_metadata`` / phone fields for ``sign_up``.
+    """Optional Auth ``user_metadata`` and phone fields for ``sign_up``.
+
+    Does not create a Papita ``users`` row; callers still provision via
+    ``UsersService.ensure_from_auth_subject`` after Auth succeeds.
 
     Attributes:
         username: Preferred handle stored in ``user_metadata.username``.
@@ -94,9 +114,11 @@ class SupabaseSignUpProfile:
 def clear_supabase_client_cache() -> None:
     """Drop cached anon and admin clients (tests or credential rotation).
 
-    Side Effects:
-        Clears process-local client caches under the shared lock. Subsequent
-        ``create_supabase_*_client`` calls build fresh SDK clients.
+    Thread-safe. Subsequent ``create_supabase_*_client`` calls build fresh SDK
+    clients for the next ``(url, key)`` lookup.
+
+    Returns:
+        None.
     """
     with _CLIENT_CACHE_LOCK:
         _AUTH_CLIENT_CACHE.clear()
@@ -106,8 +128,8 @@ def clear_supabase_client_cache() -> None:
 def create_supabase_auth_client(*, supabase_url: str, anon_key: str) -> Client:
     """Return a process-cached Supabase client for Auth API calls.
 
-    Clients are keyed by ``(url, anon_key)`` (URL trailing slash stripped) so
-    repeated register/login/refresh/OAuth avoid re-creating HTTP stacks per request.
+    Clients are keyed by ``(url, anon_key)`` with the URL trailing slash stripped
+    so register/login/refresh/OAuth reuse one HTTP stack per credential pair.
     Thread-safe via a module lock.
 
     Args:
@@ -130,8 +152,8 @@ def create_supabase_auth_client(*, supabase_url: str, anon_key: str) -> Client:
 def create_supabase_admin_client(*, supabase_url: str, service_role_key: str) -> Client:
     """Return a process-cached Supabase client with the service-role key.
 
-    Used only for Admin Auth operations (orphan delete / created_at inspection).
-    Never pass the service role key to browsers or anon Auth paths.
+    Used only for Admin Auth operations (orphan delete and ``created_at``
+    inspection). Never pass the service role key to browsers or anon Auth paths.
 
     Args:
         supabase_url: Project URL.
@@ -154,15 +176,16 @@ def classify_supabase_auth_error(exc: Exception, *, fallback: str) -> tuple[int,
     """Map a Supabase Auth exception to an HTTP status code and public detail.
 
     Recognizes conflict (email exists), rate limits, and invalid credentials so
-    routers can return stable client messages. Other 4xx Auth statuses are
-    passed through (422 coerced to 400); unknown failures become 502 + fallback.
+    routers can return stable client messages. Other 4xx Auth statuses are passed
+    through (422 coerced to 400). Unmapped or empty Auth messages become
+    ``502`` with ``fallback``.
 
     Args:
-        exc: Raised ``AuthApiError`` / ``AuthError`` (or wrapper).
+        exc: Raised ``AuthApiError``, ``AuthError``, or a wrapping exception.
         fallback: Detail used when the Auth message is empty or unmapped (502).
 
     Returns:
-        ``(http_status, detail)`` suitable for ``HTTPException``.
+        ``(http_status, detail)`` suitable for ``fastapi.HTTPException``.
     """
     message = str(getattr(exc, "message", None) or exc or fallback).strip() or fallback
     lower = message.lower()
@@ -189,15 +212,22 @@ def supabase_admin_delete_user(
 ) -> None:
     """Hard-delete an Auth user via the Admin API (orphan cleanup).
 
+    Invoked after Papita provision fails so Auth does not keep a user without a
+    matching local ``users`` row. Soft-delete is disabled.
+
     Args:
         supabase_url: Project URL.
         service_role_key: Service role key.
         user_id: Auth subject to delete.
         client: Optional pre-built admin client (tests).
 
+    Returns:
+        None.
+
     Raises:
-        AuthApiError / AuthError: Admin delete rejected.
-        ValueError: Missing service role key or user id.
+        ValueError: Missing service role key or empty ``user_id``.
+        AuthApiError: Admin delete rejected by GoTrue.
+        AuthError: Non-API Auth failure from the SDK.
     """
     if not service_role_key or not str(service_role_key).strip():
         raise ValueError("SUPABASE_SERVICE_ROLE_KEY is required to delete Auth users")
@@ -221,8 +251,9 @@ def supabase_auth_user_created_recently(
 ) -> bool:
     """Return whether an Auth user was created within ``max_age``.
 
-    Used to scope orphan cleanup on login (avoid deleting older Auth accounts
-    after a transient Papita provision failure).
+    Scopes orphan cleanup on login so older Auth accounts are not deleted after
+    a transient Papita provision failure. Failures consulting Admin Auth are
+    treated as “not recent” (returns ``False``).
 
     Args:
         supabase_url: Project URL.
@@ -232,8 +263,8 @@ def supabase_auth_user_created_recently(
         client: Optional pre-built admin client (tests).
 
     Returns:
-        ``True`` when ``created_at`` is within ``max_age``; ``False`` on missing
-        metadata or Admin API errors.
+        ``True`` when ``created_at`` is within ``max_age``; ``False`` when the
+        service role is missing, metadata is absent, or the Admin probe errors.
     """
     if not service_role_key or not str(service_role_key).strip():
         return False
@@ -346,15 +377,16 @@ def supabase_sign_up(
         anon_key: Anon key.
         email: User email.
         password: Plain-text password.
-        profile: Optional username / display_name / phone / provider metadata.
+        profile: Optional username, display_name, phone, and provider metadata.
         client: Optional pre-built client (tests).
 
     Returns:
-        Normalized Auth result (session tokens may be ``None`` when email confirm
-        is required).
+        Normalized Auth result. Session tokens may be ``None`` when email
+        confirmation is required before Auth issues a session.
 
     Raises:
-        AuthApiError / AuthError: Supabase Auth rejected the signup.
+        AuthApiError: Supabase Auth rejected the signup (API error).
+        AuthError: Non-API Auth failure from the SDK.
         ValueError: Response missing user id.
     """
     sign_up_profile = profile or SupabaseSignUpProfile()
@@ -394,7 +426,8 @@ def supabase_sign_in(
         Normalized Auth result including access and refresh tokens.
 
     Raises:
-        AuthApiError / AuthError: Invalid credentials or Auth failure.
+        AuthApiError: Invalid credentials or Auth API failure.
+        AuthError: Non-API Auth failure from the SDK.
         ValueError: Response missing user id or access token.
     """
     auth_client = client or create_supabase_auth_client(supabase_url=supabase_url, anon_key=anon_key)
@@ -425,8 +458,9 @@ def supabase_refresh_session(
         New access/refresh pair and user id.
 
     Raises:
-        AuthApiError / AuthError: Refresh token rejected or expired.
-        ValueError: Response missing access token.
+        AuthApiError: Refresh token rejected or expired.
+        AuthError: Non-API Auth failure from the SDK.
+        ValueError: Empty ``refresh_token`` or response missing access token.
     """
     if not refresh_token or not refresh_token.strip():
         raise ValueError("refresh_token is required")
@@ -448,7 +482,7 @@ def supabase_sign_out(
     scope: str = "global",
     client: Client | None = None,
 ) -> None:
-    """Revoke the Supabase session via ``set_session`` + ``sign_out``.
+    """Revoke the Supabase session via ``set_session`` then ``sign_out``.
 
     Args:
         supabase_url: Project URL.
@@ -458,9 +492,13 @@ def supabase_sign_out(
         scope: Sign-out scope passed to GoTrue (``global`` or ``local``).
         client: Optional pre-built client (tests).
 
+    Returns:
+        None.
+
     Raises:
-        AuthApiError / AuthError: Auth rejected the sign-out.
-        ValueError: Missing tokens.
+        AuthApiError: Auth rejected the sign-out (API error).
+        AuthError: Non-API Auth failure from the SDK.
+        ValueError: Missing tokens, or ``set_session`` failed on a malformed JWT.
     """
     if not access_token or not access_token.strip():
         raise ValueError("access_token is required for logout")
@@ -486,11 +524,11 @@ def supabase_oauth_authorize_url(
     scopes: str | None = None,
     client: Client | None = None,
 ) -> SupabaseOAuthStart:
-    """Start Supabase OAuth (PKCE) and return the authorize URL + verifier.
+    """Start Supabase OAuth (PKCE) and return the authorize URL plus verifier.
 
     Uses ``sign_in_with_oauth`` / GoTrue authorize with ``code_challenge``. The
     SDK stores the PKCE verifier in client storage; this helper reads it back so
-    the API can return it (or set an HttpOnly cookie). The caller must present
+    the API can return it or set an HttpOnly cookie. The caller must present
     ``code_verifier`` later to :func:`supabase_exchange_code_for_session`.
 
     Args:
@@ -505,7 +543,8 @@ def supabase_oauth_authorize_url(
         ``SupabaseOAuthStart`` with authorize URL and PKCE ``code_verifier``.
 
     Raises:
-        AuthApiError / AuthError: Auth rejected the OAuth start.
+        AuthApiError: Auth rejected the OAuth start (API error).
+        AuthError: Non-API Auth failure from the SDK.
         ValueError: Response missing URL or PKCE verifier in client storage.
     """
     auth_client = client or create_supabase_auth_client(supabase_url=supabase_url, anon_key=anon_key)
@@ -557,7 +596,8 @@ def supabase_exchange_code_for_session(
         Normalized Auth result with access/refresh tokens and email.
 
     Raises:
-        AuthApiError / AuthError: Code or verifier rejected.
+        AuthApiError: Code or verifier rejected by Auth.
+        AuthError: Non-API Auth failure from the SDK.
         ValueError: Missing inputs or response missing session/email.
     """
     if not auth_code or not auth_code.strip():
@@ -605,7 +645,7 @@ def supabase_establish_session(
 
     Used when the client already holds Auth tokens (e.g. after a client-side
     OAuth hash/fragment flow). Prefer :func:`supabase_exchange_code_for_session`
-    when the App receives an authorization ``code``.
+    when the app receives an authorization ``code``.
 
     Args:
         supabase_url: Project URL.
@@ -618,7 +658,8 @@ def supabase_establish_session(
         Normalized Auth result including tokens and email.
 
     Raises:
-        AuthApiError / AuthError: Session rejected.
+        AuthApiError: Session rejected by Auth.
+        AuthError: Non-API Auth failure from the SDK.
         ValueError: Missing tokens or user email.
     """
     if not access_token or not access_token.strip():

--- a/modules/api/src/papita_txnsapi/dependencies/__init__.py
+++ b/modules/api/src/papita_txnsapi/dependencies/__init__.py
@@ -1,12 +1,13 @@
 """FastAPI dependency injection surface for the Papita Transactions API.
 
-Re-exports auth, pagination, service factory, and tenant-context dependencies
-used by route handlers. Import from this package rather than individual
-``dependencies.*`` modules to keep router wiring consistent.
+Re-exports auth, pagination, service factory, tenant-context, and Redis
+dependencies used by route handlers. Import from this package rather than
+individual ``dependencies.*`` modules to keep router wiring consistent.
 
 Exported symbols:
     Auth: ``get_auth_manager``, ``get_current_owner``, ``oauth2_scheme``
     Pagination: ``PaginationParams``, ``get_pagination``
+    Redis: ``get_optional_redis``, ``get_session_store``
     Services: ``get_accounts_service``, ``get_categories_service``,
         ``get_connector``, ``get_report_service``, ``get_transactions_service``,
         ``get_users_service``
@@ -15,6 +16,7 @@ Exported symbols:
 
 from papita_txnsapi.dependencies.auth import get_auth_manager, get_current_owner, oauth2_scheme
 from papita_txnsapi.dependencies.pagination import PaginationParams, get_pagination
+from papita_txnsapi.dependencies.redis import get_optional_redis
 from papita_txnsapi.dependencies.services import (
     get_accounts_service,
     get_categories_service,
@@ -23,6 +25,7 @@ from papita_txnsapi.dependencies.services import (
     get_transactions_service,
     get_users_service,
 )
+from papita_txnsapi.dependencies.session_store import get_session_store
 from papita_txnsapi.dependencies.tenant import TenantContext
 
 __all__ = [
@@ -33,8 +36,10 @@ __all__ = [
     "get_categories_service",
     "get_connector",
     "get_current_owner",
+    "get_optional_redis",
     "get_pagination",
     "get_report_service",
+    "get_session_store",
     "get_transactions_service",
     "get_users_service",
     "oauth2_scheme",

--- a/modules/api/src/papita_txnsapi/dependencies/auth.py
+++ b/modules/api/src/papita_txnsapi/dependencies/auth.py
@@ -23,7 +23,9 @@ from fastapi.security import OAuth2PasswordBearer
 
 from papita_txnsapi.config.settings import Settings, get_settings
 from papita_txnsapi.core.security import AuthSecurityManager
+from papita_txnsapi.core.session_store import SessionStore, SessionStoreUnavailableError
 from papita_txnsapi.dependencies.services import get_users_service
+from papita_txnsapi.dependencies.session_store import get_session_store
 from papita_txnsmodel.access.users.dto import UsersDTO
 from papita_txnsmodel.model.enums import ProviderType
 from papita_txnsmodel.services.users import UsersService
@@ -82,22 +84,29 @@ def get_current_owner(
     token: Annotated[str | None, Depends(oauth2_scheme)],
     settings: Annotated[Settings, Depends(get_settings)],
     users_service: Annotated[UsersService, Depends(get_users_service)],
+    session_store: Annotated[SessionStore, Depends(get_session_store)],
 ) -> UsersDTO:
     """Decode bearer JWT and resolve the active tenant owner for protected routes.
 
     Local mode validates signature, token-type claim, and loads ``sub``. Supabase
     mode validates JWKS claims and provisions a local ``UsersDTO`` on first seen.
+    When Redis is enabled, revoked access tokens in the denylist are rejected
+    (PPT-043). Denylist checks **fail closed** when Redis is required: Redis
+    errors or a missing client yield HTTP 503 so a blip cannot resurrect a
+    revoked token (unlike cache/rate-limit fail-open).
 
     Args:
         token: Bearer token from the ``Authorization`` header (may be ``None``).
         settings: Injected API settings for JWT validation parameters.
         users_service: Injected service used to load/provision the owner.
+        session_store: Optional Redis-backed JWT denylist.
 
     Returns:
         Active ``UsersDTO`` representing the authenticated tenant owner.
 
     Raises:
-        HTTPException: 401 when the token is missing, invalid, or the owner is not active.
+        HTTPException: 401 when the token is missing, invalid, revoked, or the
+            owner is not active; 503 when Redis denylist is required but unavailable.
     """
     if not token:
         raise HTTPException(
@@ -105,6 +114,21 @@ def get_current_owner(
             detail="Could not validate credentials",
             headers=_UNAUTHORIZED_HEADERS,
         )
+
+    try:
+        if settings.REDIS_ENABLED and not session_store.available:
+            raise SessionStoreUnavailableError("JWT denylist Redis client unavailable")
+        if session_store.is_revoked(token):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Could not validate credentials",
+                headers=_UNAUTHORIZED_HEADERS,
+            )
+    except SessionStoreUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Token revocation store unavailable",
+        ) from exc
 
     auth_manager = AuthSecurityManager(settings)
     expected_type = settings.JWT_TOKEN_TYPE if settings.AUTH_PROVIDER == "local" else None

--- a/modules/api/src/papita_txnsapi/dependencies/rate_limit.py
+++ b/modules/api/src/papita_txnsapi/dependencies/rate_limit.py
@@ -1,13 +1,12 @@
-"""Rate-limit dependencies for authentication routes.
+"""Rate-limit dependencies for auth (per-IP) and tenant API tiers (PPT-043).
 
-FastAPI dependencies that enforce per-IP sliding-window limits on login, register,
-OAuth/SSO, and refresh endpoints. Emits ``X-RateLimit-*`` and ``Retry-After``
-headers; no-ops when rate limiting is disabled in settings.
+Auth endpoints use a per-IP sliding window. Protected CRUD/report routes use
+tenant-scoped Free/Pro/Enterprise quotas (minute + day windows) with Redis when
+``REDIS_RATE_LIMIT_ENABLED`` is on.
 
 Key exports:
-    enforce_auth_login_rate_limit: Guard ``/auth/login`` attempts.
-    enforce_auth_register_rate_limit: Guard ``/auth/register`` attempts.
-    enforce_auth_oauth_rate_limit: Guard OAuth start/callback/SSO/refresh.
+    enforce_auth_login_rate_limit / register / oauth: Auth IP guards.
+    enforce_tenant_api_rate_limit: Tenant API tier guard for protected routers.
 """
 
 from __future__ import annotations
@@ -18,7 +17,11 @@ from typing import Annotated
 from fastapi import Depends, HTTPException, Request, status
 
 from papita_txnsapi.config.settings import Settings, get_settings
-from papita_txnsapi.core.rate_limit import RateLimitResult, get_rate_limiter
+from papita_txnsapi.core.api_tier import limits_for_tier, resolve_api_tier
+from papita_txnsapi.core.rate_limit import RateLimitResult, get_rate_limiter_for_request
+from papita_txnsapi.core.redis import get_redis_from_app
+from papita_txnsapi.dependencies.auth import get_current_owner
+from papita_txnsmodel.access.users.dto import UsersDTO
 
 
 def _client_ip(request: Request) -> str:
@@ -69,7 +72,7 @@ def _enforce_rate_limit(request: Request, settings: Settings, *, scope: str, lim
         return
 
     key = f"{scope}:{_client_ip(request)}"
-    result = get_rate_limiter().check(
+    result = get_rate_limiter_for_request(request, settings).check(
         key,
         limit=limit,
         window_seconds=settings.AUTH_RATE_LIMIT_WINDOW_SECONDS,
@@ -144,3 +147,85 @@ def enforce_auth_oauth_rate_limit(
         scope="auth-oauth",
         limit=settings.AUTH_OAUTH_RATE_LIMIT_PER_MINUTE,
     )
+
+
+def _merge_limit_headers(minute: RateLimitResult, day: RateLimitResult) -> dict[str, str]:
+    """Prefer the tighter remaining quota for response headers."""
+    if minute.limit <= 0 and day.limit <= 0:
+        return {}
+    if minute.limit <= 0:
+        return _rate_limit_headers(day)
+    if day.limit <= 0:
+        return _rate_limit_headers(minute)
+    # Report the window with fewer remaining requests (normalized by limit).
+    minute_ratio = minute.remaining / minute.limit if minute.limit else 1.0
+    day_ratio = day.remaining / day.limit if day.limit else 1.0
+    chosen = minute if minute_ratio <= day_ratio else day
+    return _rate_limit_headers(chosen)
+
+
+def enforce_tenant_api_rate_limit(
+    request: Request,
+    owner: Annotated[UsersDTO, Depends(get_current_owner)],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> None:
+    """Enforce tenant-scoped Free/Pro/Enterprise API quotas on protected routes.
+
+    Applies rolling per-minute and per-day windows keyed by ``owner_id``. Stores
+    ``X-RateLimit-*`` headers on ``request.state`` for response middleware. Enterprise
+    (unlimited) is a no-op. When ``API_RATE_LIMIT_ENABLED`` is false, skips checks.
+
+    Args:
+        request: Incoming HTTP request.
+        owner: Authenticated tenant from JWT.
+        settings: API settings with tier quotas and feature flags.
+
+    Raises:
+        HTTPException: 401 when owner id is missing; 429 when a quota is exceeded.
+    """
+    if not settings.API_RATE_LIMIT_ENABLED:
+        return
+    if owner.id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    redis = get_redis_from_app(request.app) if settings.REDIS_ENABLED else None
+    tier = resolve_api_tier(settings, owner.id, redis)
+    limits = limits_for_tier(settings, tier)
+    if limits.unlimited:
+        request.state.rate_limit_headers = {
+            "X-RateLimit-Limit": "0",
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "0",
+            "X-RateLimit-Tier": tier.value,
+        }
+        return
+
+    limiter = get_rate_limiter_for_request(request, settings)
+    owner_key = str(owner.id)
+    minute = limiter.check(
+        f"api:{owner_key}:min",
+        limit=limits.per_minute,
+        window_seconds=60,
+    )
+    day = limiter.check(
+        f"api:{owner_key}:day",
+        limit=limits.per_day,
+        window_seconds=86_400,
+    )
+    headers = {**_merge_limit_headers(minute, day), "X-RateLimit-Tier": tier.value}
+    request.state.rate_limit_headers = headers
+
+    if not minute.allowed or not day.allowed:
+        denied = minute if not minute.allowed else day
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="API rate limit exceeded for your plan. Try again later.",
+            headers={
+                **headers,
+                "Retry-After": str(max(1, denied.reset_at - int(time.time()))),
+            },
+        )

--- a/modules/api/src/papita_txnsapi/dependencies/redis.py
+++ b/modules/api/src/papita_txnsapi/dependencies/redis.py
@@ -1,0 +1,29 @@
+"""FastAPI dependencies for optional Redis client access (PPT-043)."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends, Request
+from redis import Redis
+
+from papita_txnsapi.config.settings import Settings, get_settings
+from papita_txnsapi.core.redis import get_redis_from_app
+
+
+def get_optional_redis(
+    request: Request,
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> Redis | None:
+    """Return the app Redis client when enabled; otherwise ``None``.
+
+    Args:
+        request: Incoming request (``app.state.redis``).
+        settings: Application settings controlling ``REDIS_ENABLED``.
+
+    Returns:
+        ``Redis`` client or ``None`` when Redis is disabled or not initialized.
+    """
+    if not settings.REDIS_ENABLED:
+        return None
+    return get_redis_from_app(request.app)

--- a/modules/api/src/papita_txnsapi/dependencies/session_store.py
+++ b/modules/api/src/papita_txnsapi/dependencies/session_store.py
@@ -1,0 +1,35 @@
+"""FastAPI dependencies for Redis session / JWT denylist store (PPT-043)."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends, Request
+
+from papita_txnsapi.config.settings import Settings, get_settings
+from papita_txnsapi.core.redis import get_redis_from_app
+from papita_txnsapi.core.session_store import SessionStore
+
+
+def get_session_store(
+    request: Request,
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> SessionStore:
+    """Return a JWT denylist store backed by Redis when enabled.
+
+    When ``REDIS_ENABLED`` is true, the store uses **fail-closed** denylist checks
+    so Redis errors cannot resurrect a revoked token (503 at the auth dependency).
+
+    Args:
+        request: Incoming request (``app.state.redis``).
+        settings: Application settings (Redis flags and JWT TTL).
+
+    Returns:
+        ``SessionStore``; ``available`` is ``False`` when Redis is disabled.
+    """
+    client = get_redis_from_app(request.app) if settings.REDIS_ENABLED else None
+    return SessionStore(
+        client,
+        default_ttl_seconds=settings.JWT_EXPIRATION_TIME_SECONDS,
+        fail_closed=settings.REDIS_ENABLED,
+    )

--- a/modules/api/src/papita_txnsapi/main.py
+++ b/modules/api/src/papita_txnsapi/main.py
@@ -1,8 +1,8 @@
 """FastAPI application factory for papita_txnsapi.
 
 Constructs the runnable API with CORS, request logging, global exception handlers,
-and v1 routers mounted at ``/api/v1``. Bootstraps password hashing on startup
-(NFR-08) via the application lifespan context.
+and v1 routers mounted at ``/api/v1``. Bootstraps password hashing and optional
+Redis on startup via the application lifespan context.
 
 Key exports:
     lifespan: Async context manager for startup/shutdown hooks.
@@ -21,6 +21,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from papita_txnsapi.config.settings import Settings, get_settings
 from papita_txnsapi.core.handlers import register_exception_handlers
+from papita_txnsapi.core.redis import close_redis, init_redis
 from papita_txnsapi.middleware.request_logging import RequestLoggingMiddleware
 from papita_txnsapi.routers.v1 import api_v1_router
 from papita_txnsmodel.services.users import UsersService
@@ -28,23 +29,36 @@ from papita_txnsmodel.services.users import UsersService
 logger = logging.getLogger(__name__)
 
 
-@asynccontextmanager
-async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
-    """Bootstrap shared resources on startup and log shutdown.
+def _build_lifespan(settings: Settings):
+    """Build a lifespan context that binds Redis to the given settings."""
 
-    Ensures ``UsersService`` password manager is initialized before auth routes accept
-    traffic (NFR-08).
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        """Bootstrap shared resources on startup and release them on shutdown.
 
-    Args:
-        _app: FastAPI application instance (unused; required by lifespan signature).
+        Ensures ``UsersService`` password manager is initialized before auth routes
+        accept traffic (NFR-08). Optionally opens a Redis pool when enabled (PPT-043).
 
-    Yields:
-        Control back to FastAPI while the application is serving requests.
-    """
-    UsersService.ensure_password_manager()
-    logger.info("Application lifespan started — password manager ready")
-    yield
-    logger.info("Application lifespan shutdown")
+        Args:
+            app: FastAPI application instance; ``app.state.redis`` is set when enabled.
+
+        Yields:
+            Control back to FastAPI while the application is serving requests.
+        """
+        UsersService.ensure_password_manager()
+        app.state.redis = init_redis(settings)
+        logger.info(
+            "Application lifespan started — password manager ready (redis=%s)",
+            "on" if app.state.redis is not None else "off",
+        )
+        try:
+            yield
+        finally:
+            close_redis(getattr(app.state, "redis", None))
+            app.state.redis = None
+            logger.info("Application lifespan shutdown")
+
+    return lifespan
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
@@ -65,11 +79,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         title=app_settings.APP_NAME,
         version=app_settings.APP_VERSION,
         debug=app_settings.DEBUG,
-        lifespan=lifespan,
+        lifespan=_build_lifespan(app_settings),
         docs_url="/api/docs",
         redoc_url="/api/redoc",
         openapi_url="/api/openapi.json",
     )
+    app.state.settings = app_settings
 
     app.add_middleware(
         CORSMiddleware,

--- a/modules/api/src/papita_txnsapi/middleware/request_logging.py
+++ b/modules/api/src/papita_txnsapi/middleware/request_logging.py
@@ -40,6 +40,11 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         """
         start = time.perf_counter()
         response = await call_next(request)
+        rate_headers = getattr(request.state, "rate_limit_headers", None)
+        if isinstance(rate_headers, dict):
+            for header_name, header_value in rate_headers.items():
+                if header_name not in response.headers:
+                    response.headers[header_name] = str(header_value)
         elapsed_ms = (time.perf_counter() - start) * 1000
         logger.info(
             "%s %s -> %s (%.1f ms)",

--- a/modules/api/src/papita_txnsapi/routers/v1/accounts.py
+++ b/modules/api/src/papita_txnsapi/routers/v1/accounts.py
@@ -27,10 +27,21 @@ from __future__ import annotations
 import uuid
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from redis import Redis
 
+from papita_txnsapi.config.settings import Settings, get_settings
+from papita_txnsapi.core.cache import (
+    CacheNamespace,
+    bump_cache_versions,
+    get_versioned_cached_json,
+    set_versioned_cached_json,
+    ttl_for_namespace,
+)
 from papita_txnsapi.dependencies.auth import get_current_owner
 from papita_txnsapi.dependencies.pagination import PaginationParams, get_pagination
+from papita_txnsapi.dependencies.rate_limit import enforce_tenant_api_rate_limit
+from papita_txnsapi.dependencies.redis import get_optional_redis
 from papita_txnsapi.dependencies.services import get_accounts_service
 from papita_txnsapi.schemas.accounts import (
     AccountCreate,
@@ -48,7 +59,11 @@ from papita_txnsmodel.access.accounts.dto import AccountsDTO
 from papita_txnsmodel.access.users.dto import UsersDTO
 from papita_txnsmodel.services.accounts import AccountsService
 
-router = APIRouter(prefix="/accounts", tags=["Accounts"])
+router = APIRouter(
+    prefix="/accounts",
+    tags=["Accounts"],
+    dependencies=[Depends(enforce_tenant_api_rate_limit)],
+)
 
 
 def _account_not_found() -> HTTPException:
@@ -136,11 +151,19 @@ def _balance_for_account(
     return 0.0
 
 
+def _invalidate_account_caches(redis: Redis | None, owner: UsersDTO) -> None:
+    """Bump accounts + reports cache versions after account or balance-affecting writes."""
+    bump_cache_versions(redis, owner.id, CacheNamespace.ACCOUNTS, CacheNamespace.REPORTS)
+
+
 @router.get("", response_model=PaginatedResponse[AccountResponse])
-def list_accounts(
+def list_accounts(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     pagination: Annotated[PaginationParams, Depends(get_pagination)],
     accounts_service: Annotated[AccountsService, Depends(get_accounts_service)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
+    response: Response,
     *,
     account_kind: Annotated[str | None, Query(description="Filter by account kind slug")] = None,
     ledger_side: Annotated[str | None, Query(description="Filter by asset or liability")] = None,
@@ -148,10 +171,16 @@ def list_accounts(
 ) -> PaginatedResponse[AccountResponse]:
     """List tenant accounts with optional filters and balances from ``account_balances``.
 
+    When Redis is enabled, responses are cached per owner and query params (cache-aside).
+    Mutations bump the accounts namespace version so prior entries miss.
+
     Args:
         owner: Authenticated tenant from JWT.
         pagination: Skip/limit window for the response page.
         accounts_service: Injected accounts service scoped to the request lifecycle.
+        settings: Application settings (cache TTL).
+        redis: Optional Redis client when ``REDIS_ENABLED``.
+        response: FastAPI response used to set ``X-Cache`` status.
         account_kind: Optional filter by account kind slug.
         ledger_side: Optional filter by asset or liability slug.
         is_active: Optional filter by active status.
@@ -159,6 +188,24 @@ def list_accounts(
     Returns:
         Paginated account rows enriched with effective balances per item.
     """
+    cache_params = {
+        "skip": pagination.skip,
+        "limit": pagination.limit,
+        "account_kind": account_kind,
+        "ledger_side": ledger_side,
+        "is_active": is_active,
+    }
+    owner_id = owner.id
+    if owner_id is not None:
+        cached, cache_status = get_versioned_cached_json(
+            redis, owner_id, CacheNamespace.ACCOUNTS, "accounts:list", cache_params
+        )
+        response.headers["X-Cache"] = cache_status
+        if cached is not None:
+            return PaginatedResponse[AccountResponse].model_validate(cached)
+    else:
+        response.headers["X-Cache"] = "BYPASS"
+
     filter_dto = _build_account_filter_dto(
         account_kind=account_kind,
         ledger_side=ledger_side,
@@ -177,12 +224,23 @@ def list_accounts(
         AccountResponse.from_dto(account, balance=effective_account_balance(account, balance_map=balance_map))
         for account in accounts
     ]
-    return PaginatedResponse(
+    payload: PaginatedResponse[AccountResponse] = PaginatedResponse(
         items=items,
         total=total,
         skip=pagination.skip,
         limit=pagination.limit,
     )
+    if owner_id is not None:
+        set_versioned_cached_json(
+            redis,
+            owner_id,
+            CacheNamespace.ACCOUNTS,
+            "accounts:list",
+            cache_params,
+            value=payload.model_dump(mode="json"),
+            ttl_seconds=ttl_for_namespace(settings, CacheNamespace.ACCOUNTS),
+        )
+    return payload
 
 
 @router.get("/{account_id}", response_model=AccountResponse)
@@ -221,6 +279,7 @@ def create_account(
     body: AccountCreate,
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     accounts_service: Annotated[AccountsService, Depends(get_accounts_service)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
 ) -> AccountResponse:
     """Create an account and optional kind-specific extension row.
 
@@ -228,6 +287,7 @@ def create_account(
         body: Validated create payload including core account fields and extension data.
         owner: Authenticated tenant from JWT; used as ``owner_id`` on the new record.
         accounts_service: Injected accounts service scoped to the request lifecycle.
+        redis: Optional Redis client for cache invalidation.
 
     Returns:
         Created account with extension details and initial effective balance.
@@ -245,6 +305,7 @@ def create_account(
     created_id = _require_uuid(created.id)
     _, extension = accounts_service.get_with_extension(obj=created_id, owner=owner)
     balance = _balance_for_account(accounts_service, owner, created_id, account=created)
+    _invalidate_account_caches(redis, owner)
     return AccountResponse.from_dto(created, balance=balance, extension=extension)
 
 
@@ -254,6 +315,7 @@ def update_account(
     body: AccountUpdate,
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     accounts_service: Annotated[AccountsService, Depends(get_accounts_service)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
 ) -> AccountResponse:
     """Update an account and optional extension row.
 
@@ -262,6 +324,7 @@ def update_account(
         body: Partial update payload merged onto the existing DTO.
         owner: Authenticated tenant from JWT.
         accounts_service: Injected accounts service scoped to the request lifecycle.
+        redis: Optional Redis client for cache invalidation.
 
     Returns:
         Updated account with extension details and current effective balance.
@@ -283,6 +346,7 @@ def update_account(
     updated_id = _require_uuid(updated.id)
     _, extension = accounts_service.get_with_extension(obj=updated_id, owner=owner)
     balance = _balance_for_account(accounts_service, owner, updated_id, account=updated)
+    _invalidate_account_caches(redis, owner)
     return AccountResponse.from_dto(updated, balance=balance, extension=extension)
 
 
@@ -291,6 +355,7 @@ def delete_account(
     account_id: uuid.UUID,
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     accounts_service: Annotated[AccountsService, Depends(get_accounts_service)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
 ) -> None:
     """Soft-delete an account owned by the authenticated tenant.
 
@@ -298,6 +363,7 @@ def delete_account(
         account_id: Primary key of the account to delete.
         owner: Authenticated tenant from JWT.
         accounts_service: Injected accounts service scoped to the request lifecycle.
+        redis: Optional Redis client for cache invalidation.
 
     Returns:
         ``None``; response body is empty on success.
@@ -309,6 +375,7 @@ def delete_account(
     if existing is None:
         raise _account_not_found()
     accounts_service.delete(obj=AccountsDTO.model_construct(id=account_id), owner=owner)
+    _invalidate_account_caches(redis, owner)
 
 
 @router.get("/{account_id}/balance", response_model=BalanceResponse)

--- a/modules/api/src/papita_txnsapi/routers/v1/auth.py
+++ b/modules/api/src/papita_txnsapi/routers/v1/auth.py
@@ -8,7 +8,8 @@ Exposes identity endpoints under ``/api/v1/auth``. Behavior depends on
   Failed Papita provision after Auth signup may trigger Admin orphan cleanup when
   ``SUPABASE_SERVICE_ROLE_KEY`` is set.
 * ``local`` — register/login against ``UsersService`` and issue HS256 JWTs
-  (tests / B0 only). Refresh, logout, and OAuth/SSO return HTTP 501.
+  (tests / B0 only). Refresh and OAuth/SSO return HTTP 501. Logout returns 501
+  unless Redis is enabled (JWT denylist via PPT-043).
 
 Routes:
     ``POST /auth/register`` — create user (email + password; username derived).
@@ -19,11 +20,15 @@ Routes:
     ``POST /auth/sso`` — hand off when the client already holds session tokens.
     ``GET /auth/me`` — authenticated profile smoke test.
     ``POST /auth/refresh`` — Supabase session rotation (501 when local).
-    ``POST /auth/logout`` — Supabase session revoke (501 when local).
+    ``POST /auth/logout`` — Supabase session revoke and/or Redis JWT denylist.
 
-Rate limits apply to register, login, and OAuth/SSO/refresh helpers via FastAPI
+Rate limits apply to register, login, and OAuth/SSO/refresh via FastAPI
 dependencies. OAuth ``redirect_to`` is allowlisted to the API callback URL and
-optional ``SUPABASE_OAUTH_REDIRECT_TO``.
+optional ``SUPABASE_OAUTH_REDIRECT_TO``. Business logic stays in
+``papita_txnsmodel`` / ``core.supabase_auth``; this module maps HTTP ↔ helpers.
+
+Key exports:
+    router: FastAPI ``APIRouter`` mounted at ``/auth`` by the v1 package.
 """
 
 from __future__ import annotations
@@ -38,6 +43,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer, OAuth2Pas
 
 from papita_txnsapi.config.settings import Settings, get_settings
 from papita_txnsapi.core.security import AuthSecurityManager
+from papita_txnsapi.core.session_store import SessionStore
 from papita_txnsapi.core.supabase_auth import (
     AuthApiError,
     AuthError,
@@ -60,6 +66,7 @@ from papita_txnsapi.dependencies.rate_limit import (
     enforce_auth_register_rate_limit,
 )
 from papita_txnsapi.dependencies.services import get_users_service
+from papita_txnsapi.dependencies.session_store import get_session_store
 from papita_txnsapi.schemas.auth import (
     LogoutRequest,
     OAuthCodeExchangeRequest,
@@ -93,11 +100,28 @@ _OAUTH_COOKIE_PATH = "/api/v1/auth"
 
 
 def _require_supabase_auth_settings(settings: Settings) -> None:
+    """Ensure Supabase URL and anon key are configured for session Auth APIs.
+
+    Args:
+        settings: Application settings with ``SUPABASE_URL`` / ``SUPABASE_ANON_KEY``.
+
+    Raises:
+        HTTPException: 503 when either required Supabase Auth setting is missing.
+    """
     if not settings.SUPABASE_URL or not settings.SUPABASE_ANON_KEY:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=_SUPABASE_AUTH_REQUIRED)
 
 
 def _auth_error_detail(exc: Exception, *, fallback: str) -> str:
+    """Extract a public-facing Auth error message from an SDK exception.
+
+    Args:
+        exc: Raised Auth or wrapper exception.
+        fallback: Detail when the exception carries no usable message.
+
+    Returns:
+        Non-empty detail string suitable for ``HTTPException.detail``.
+    """
     message = getattr(exc, "message", None) or str(exc) or fallback
     return str(message)
 
@@ -109,6 +133,17 @@ def _token_response_from_auth(
     expires_in: int | None,
     settings: Settings,
 ) -> TokenResponse:
+    """Build an OAuth2-compatible ``TokenResponse`` from Auth session fields.
+
+    Args:
+        access_token: Bearer access JWT from Supabase (or local issuer).
+        refresh_token: Opaque refresh token when issued; ``None`` for local login.
+        expires_in: Access TTL seconds from Auth, or ``None`` to use Settings default.
+        settings: Supplies ``JWT_TOKEN_TYPE`` and default expiration.
+
+    Returns:
+        ``TokenResponse`` with ``expires_in`` clamped to at least 1 second.
+    """
     resolved_expires = int(expires_in or settings.JWT_EXPIRATION_TIME_SECONDS)
     return TokenResponse(
         access_token=access_token,
@@ -119,6 +154,14 @@ def _token_response_from_auth(
 
 
 def _api_oauth_callback_url(request: Request) -> str:
+    """Absolute URL for the named ``GET /auth/oauth/callback`` route.
+
+    Args:
+        request: Incoming request used to reverse-lookup the callback path.
+
+    Returns:
+        Absolute callback URI (scheme/host from the request).
+    """
     return str(request.url_for("oauth_callback_get"))
 
 
@@ -168,6 +211,16 @@ def _set_oauth_pkce_cookies(
     ``redirect_to`` must already be allowlisted via ``_resolve_oauth_redirect_to``.
     Cookies are HttpOnly, SameSite=Lax, path-scoped, and optionally Secure — not
     clear-text password storage; the verifier is bound to the OAuth handshake.
+
+    Args:
+        response: Mutable response that receives ``Set-Cookie`` headers.
+        code_verifier: PKCE verifier from ``sign_in_with_oauth``.
+        provider: OAuth channel stored for the GET callback.
+        redirect_to: Allowlisted redirect URI used at authorize time.
+        secure: When ``True``, set the Secure cookie flag (HTTPS).
+
+    Returns:
+        None.
     """
     cookie_kwargs = {
         "max_age": _OAUTH_COOKIE_MAX_AGE,
@@ -183,11 +236,30 @@ def _set_oauth_pkce_cookies(
 
 
 def _clear_oauth_pkce_cookies(response: Response) -> None:
+    """Delete PKCE cookies after a successful browser OAuth callback.
+
+    Args:
+        response: Mutable response that clears the OAuth cookie names.
+
+    Returns:
+        None.
+    """
     for key in (_OAUTH_VERIFIER_COOKIE, _OAUTH_PROVIDER_COOKIE, _OAUTH_REDIRECT_COOKIE):
         response.delete_cookie(key=key, path=_OAUTH_COOKIE_PATH)
 
 
 def _parse_oauth_provider(raw: str) -> ProviderType:
+    """Parse a path/cookie provider string into an OAuth ``ProviderType``.
+
+    Args:
+        raw: Provider id such as ``google`` or ``github`` (case-insensitive).
+
+    Returns:
+        ``ProviderType`` that reports ``is_oauth()`` as true.
+
+    Raises:
+        HTTPException: 404 when the value is unknown or not an OAuth channel.
+    """
     try:
         oauth_provider = ProviderType(raw.strip().lower())
     except ValueError as exc:
@@ -198,6 +270,14 @@ def _parse_oauth_provider(raw: str) -> ProviderType:
 
 
 def _http_status_for_provision_error(exc: ValueError) -> int:
+    """Map Papita provision ``ValueError`` messages to HTTP status codes.
+
+    Args:
+        exc: Raised during ``ensure_from_auth_subject`` or related provision.
+
+    Returns:
+        409 for username/email conflicts, 401 for inactive/deleted users, else 502.
+    """
     message = str(exc)
     if message in {"Username already registered", "Email already registered"}:
         return status.HTTP_409_CONFLICT
@@ -215,12 +295,19 @@ def _cleanup_orphan_auth_user(
 ) -> None:
     """Best-effort Admin delete of a half-created Auth identity.
 
+    No-ops when the service role key is unset. Login cleanup can require the
+    Auth user to be younger than the orphan window so established accounts are
+    not wiped after a transient DB blip.
+
     Args:
         settings: Must include ``SUPABASE_SERVICE_ROLE_KEY`` for cleanup to run.
         user_id: Auth subject created before Papita provision failed.
         reason: Short label for logs (``register`` / ``login``).
         require_recent: When ``True`` (login), only delete Auth users younger than
             the orphan window so a transient DB blip does not wipe established accounts.
+
+    Returns:
+        None. Failures are logged; they do not raise to the client.
     """
     service_key = (settings.SUPABASE_SERVICE_ROLE_KEY or "").strip()
     if not service_key or not settings.SUPABASE_URL:
@@ -282,7 +369,8 @@ def _complete_oauth_provision(
         OAuth2-compatible ``TokenResponse`` with Supabase access/refresh tokens.
 
     Raises:
-        AuthApiError / AuthError: Supabase rejected the code exchange.
+        AuthApiError: Supabase rejected the code exchange (API error).
+        AuthError: Non-API Auth failure from the SDK.
         ValueError: Response missing user/session fields or provision failed.
     """
     auth_result = supabase_exchange_code_for_session(
@@ -322,6 +410,7 @@ def register_user(
 
     Args:
         body: Registration payload (email, password, optional profile fields).
+        _rate_limit: Per-IP register rate-limit dependency (side effect only).
         settings: Selects ``supabase`` vs ``local`` Auth mode.
         users_service: Creates or links the tenant ``users`` row.
 
@@ -407,6 +496,7 @@ def login(
 
     Args:
         form: OAuth2 password form (``username`` + ``password``).
+        _rate_limit: Per-IP login rate-limit dependency (side effect only).
         settings: Selects Auth mode and JWT/session defaults.
         users_service: Verifies credentials (local) or ensures Auth-linked user.
         auth_manager: Issues HS256 access tokens in local mode only.
@@ -507,6 +597,7 @@ def oauth_callback_post(
     Args:
         body: Provider, auth code, PKCE verifier, optional redirect and name.
         request: Used to allowlist ``redirect_to`` against the API callback URL.
+        _rate_limit: Per-IP OAuth rate-limit dependency (side effect only).
         settings: Must be ``AUTH_PROVIDER=supabase`` with URL and anon key.
         users_service: Provisions or refreshes the tenant profile.
 
@@ -565,6 +656,7 @@ def oauth_callback_get(
 
     Args:
         request: Incoming redirect; cookies supply verifier/provider/redirect.
+        _rate_limit: Per-IP OAuth rate-limit dependency (side effect only).
         settings: Must be ``AUTH_PROVIDER=supabase`` with URL and anon key.
         users_service: Provisions or refreshes the tenant profile.
         code: Authorization code query param from the IdP.
@@ -650,6 +742,7 @@ def start_oauth(
     Args:
         provider: Path segment (``google`` or ``github``).
         request: Used to resolve the allowlisted redirect URI.
+        _rate_limit: Per-IP OAuth rate-limit dependency (side effect only).
         settings: Must be ``AUTH_PROVIDER=supabase`` with URL and anon key.
         redirect_to: Optional allowlisted redirect override.
         follow: When ``True``, 302-redirect and set PKCE cookies.
@@ -715,6 +808,7 @@ def complete_sso(
 
     Args:
         body: Provider, access token, refresh token, optional display name.
+        _rate_limit: Per-IP OAuth rate-limit dependency (side effect only).
         settings: Must be ``AUTH_PROVIDER=supabase`` with URL and anon key.
         users_service: Provisions or refreshes the tenant profile.
 
@@ -768,13 +862,18 @@ def get_current_user(
     """Return the authenticated user profile (protected route smoke test).
 
     Uses ``get_current_owner``, which verifies the bearer JWT and may refresh
-    Auth-linked profile fields under Supabase mode.
+    Auth-linked profile fields under Supabase mode. When Redis is required,
+    revoked tokens are rejected (denylist fail-closed).
 
     Args:
         owner: Authenticated tenant user resolved from the bearer JWT.
 
     Returns:
         Public ``UserResponse`` for the current session user (never includes password).
+
+    Raises:
+        HTTPException: 401 when credentials are missing/invalid/revoked; 503 when
+            the Redis denylist is required but unavailable.
     """
     return UserResponse.from_dto(owner)
 
@@ -791,6 +890,7 @@ def refresh_token(
 
     Args:
         body: Current Supabase refresh token.
+        _rate_limit: Per-IP OAuth/refresh rate-limit dependency (side effect only).
         settings: Application settings selecting Auth provider.
 
     Returns:
@@ -834,32 +934,47 @@ def logout(
     body: LogoutRequest,
     settings: Annotated[Settings, Depends(get_settings)],
     credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(_optional_bearer)],
+    session_store: Annotated[SessionStore, Depends(get_session_store)],
 ) -> Response | JSONResponse:
-    """Revoke the Supabase Auth session (global sign-out).
+    """Revoke the session: Supabase Auth sign-out and/or Redis JWT denylist.
 
-    When ``AUTH_PROVIDER=local``, returns HTTP 501. Access token may be supplied
-    in the JSON body or as ``Authorization: Bearer``. On success returns 204 with
-    an empty body.
+    * ``AUTH_PROVIDER=supabase`` — calls Supabase ``sign_out``, then denylists the
+      access token when Redis is enabled so remaining JWT TTL cannot be reused.
+    * ``AUTH_PROVIDER=local`` — when Redis is enabled, denylists the access token
+      and returns 204; otherwise returns HTTP 501 (no refresh/session store).
+
+    Access token may be supplied in the JSON body or as ``Authorization: Bearer``.
 
     Args:
-        body: Refresh token (required) and optional access token.
+        body: Refresh token (required for Supabase) and optional access token.
         settings: Application settings selecting Auth provider.
         credentials: Optional bearer credentials for the access JWT.
+        session_store: Redis-backed JWT denylist (no-op when Redis disabled).
 
     Returns:
-        Empty 204 response on success, or deferred JSON with status 501 in local mode.
+        Empty 204 response on success, or deferred JSON with status 501 in local
+        mode without Redis.
 
     Raises:
         HTTPException: 400 when access token missing; 401 on Auth errors;
             503 when Auth misconfigured.
     """
-    if settings.AUTH_PROVIDER != "supabase":
-        return JSONResponse(status_code=status.HTTP_501_NOT_IMPLEMENTED, content=_AUTH_DEFERRED.model_dump())
-
-    _require_supabase_auth_settings(settings)
     access_token = (body.access_token or "").strip() or (
         credentials.credentials.strip() if credentials and credentials.credentials else ""
     )
+
+    if settings.AUTH_PROVIDER != "supabase":
+        if not session_store.available:
+            return JSONResponse(status_code=status.HTTP_501_NOT_IMPLEMENTED, content=_AUTH_DEFERRED.model_dump())
+        if not access_token:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="access_token is required (body.access_token or Authorization: Bearer)",
+            )
+        session_store.revoke(access_token, ttl_seconds=settings.JWT_EXPIRATION_TIME_SECONDS)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    _require_supabase_auth_settings(settings)
     if not access_token:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -879,4 +994,7 @@ def logout(
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=detail) from exc
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    if session_store.available:
+        session_store.revoke(access_token, ttl_seconds=settings.JWT_EXPIRATION_TIME_SECONDS)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/modules/api/src/papita_txnsapi/routers/v1/categories.py
+++ b/modules/api/src/papita_txnsapi/routers/v1/categories.py
@@ -27,10 +27,21 @@ from __future__ import annotations
 import uuid
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from redis import Redis
 
+from papita_txnsapi.config.settings import Settings, get_settings
+from papita_txnsapi.core.cache import (
+    CacheNamespace,
+    bump_cache_versions,
+    get_versioned_cached_json,
+    set_versioned_cached_json,
+    ttl_for_namespace,
+)
 from papita_txnsapi.dependencies.auth import get_current_owner
 from papita_txnsapi.dependencies.pagination import PaginationParams, get_pagination
+from papita_txnsapi.dependencies.rate_limit import enforce_tenant_api_rate_limit
+from papita_txnsapi.dependencies.redis import get_optional_redis
 from papita_txnsapi.dependencies.services import get_categories_service
 from papita_txnsapi.schemas.categories import (
     CategoryCreate,
@@ -45,7 +56,11 @@ from papita_txnsmodel.access.categories.dto import CategoriesDTO
 from papita_txnsmodel.access.users.dto import UsersDTO
 from papita_txnsmodel.services.categories import CategoriesService
 
-router = APIRouter(prefix="/categories", tags=["Categories"])
+router = APIRouter(
+    prefix="/categories",
+    tags=["Categories"],
+    dependencies=[Depends(enforce_tenant_api_rate_limit)],
+)
 
 _GLOBAL_CATEGORY_MESSAGES = frozenset(
     {
@@ -78,20 +93,33 @@ def _reject_global_category(category) -> None:
         raise _category_not_found()
 
 
+def _invalidate_category_caches(redis: Redis | None, owner: UsersDTO) -> None:
+    """Bump categories + reports versions after category mutations."""
+    bump_cache_versions(redis, owner.id, CacheNamespace.CATEGORIES, CacheNamespace.REPORTS)
+
+
 @router.get("", response_model=PaginatedResponse[CategoryResponse])
-def list_categories(
+def list_categories(  # pylint: disable=too-many-positional-arguments,too-many-locals
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     pagination: Annotated[PaginationParams, Depends(get_pagination)],
     categories_service: Annotated[CategoriesService, Depends(get_categories_service)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
+    response: Response,
     parent_id: Annotated[uuid.UUID | None, Query(description="Filter by parent category")] = None,
     category_type: Annotated[str | None, Query(description="Filter by income or expense")] = None,
 ) -> PaginatedResponse[CategoryResponse]:
     """List tenant and global seed categories with optional hierarchy nesting.
 
+    When Redis is enabled, list responses are cache-aside with versioned keys.
+
     Args:
         owner: Authenticated tenant from JWT.
         pagination: Skip/limit window for the response page.
         categories_service: Injected categories service scoped to the request lifecycle.
+        settings: Application settings (cache TTL).
+        redis: Optional Redis client when ``REDIS_ENABLED``.
+        response: FastAPI response used to set ``X-Cache`` status.
         parent_id: Optional parent category id; when omitted, returns top-level categories
             with nested subcategory summaries.
         category_type: Optional income/expense slug filter.
@@ -100,6 +128,23 @@ def list_categories(
         Paginated categories; top-level rows include embedded subcategory lists when
         ``parent_id`` is not set.
     """
+    cache_params = {
+        "skip": pagination.skip,
+        "limit": pagination.limit,
+        "parent_id": str(parent_id) if parent_id is not None else None,
+        "category_type": category_type,
+    }
+    owner_id = owner.id
+    if owner_id is not None:
+        cached, cache_status = get_versioned_cached_json(
+            redis, owner_id, CacheNamespace.CATEGORIES, "categories:list", cache_params
+        )
+        response.headers["X-Cache"] = cache_status
+        if cached is not None:
+            return PaginatedResponse[CategoryResponse].model_validate(cached)
+    else:
+        response.headers["X-Cache"] = "BYPASS"
+
     records_df = categories_service.get_records(None, owner=owner)
     all_categories = categories_from_dataframe(records_df)
 
@@ -112,6 +157,7 @@ def list_categories(
 
     subcategory_map = build_subcategory_map(all_categories)
 
+    payload: PaginatedResponse[CategoryResponse]
     if parent_id is None:
         top_level = [category for category in filtered if category.parent_id is None]
         page = top_level[pagination.skip : pagination.skip + pagination.limit]
@@ -122,21 +168,33 @@ def list_categories(
             )
             for category in page
         ]
-        return PaginatedResponse(
+        payload = PaginatedResponse(
             items=items,
             total=len(top_level),
             skip=pagination.skip,
             limit=pagination.limit,
         )
+    else:
+        page = filtered[pagination.skip : pagination.skip + pagination.limit]
+        items = [CategoryResponse.from_dto(category) for category in page]
+        payload = PaginatedResponse(
+            items=items,
+            total=len(filtered),
+            skip=pagination.skip,
+            limit=pagination.limit,
+        )
 
-    page = filtered[pagination.skip : pagination.skip + pagination.limit]
-    items = [CategoryResponse.from_dto(category) for category in page]
-    return PaginatedResponse(
-        items=items,
-        total=len(filtered),
-        skip=pagination.skip,
-        limit=pagination.limit,
-    )
+    if owner_id is not None:
+        set_versioned_cached_json(
+            redis,
+            owner_id,
+            CacheNamespace.CATEGORIES,
+            "categories:list",
+            cache_params,
+            value=payload.model_dump(mode="json"),
+            ttl_seconds=ttl_for_namespace(settings, CacheNamespace.CATEGORIES),
+        )
+    return payload
 
 
 @router.get("/{category_id}", response_model=CategoryResponse)
@@ -169,6 +227,7 @@ def create_category(
     body: CategoryCreate,
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     categories_service: Annotated[CategoriesService, Depends(get_categories_service)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
 ) -> CategoryResponse:
     """Create a tenant-owned category.
 
@@ -176,6 +235,7 @@ def create_category(
         body: Validated create payload converted to a categories DTO.
         owner: Authenticated tenant from JWT.
         categories_service: Injected categories service scoped to the request lifecycle.
+        redis: Optional Redis client for cache invalidation.
 
     Returns:
         Newly created category owned by the authenticated tenant.
@@ -190,6 +250,7 @@ def create_category(
         if str(exc) in _GLOBAL_CATEGORY_MESSAGES:
             raise _category_not_found() from exc
         raise
+    _invalidate_category_caches(redis, owner)
     return CategoryResponse.from_dto(created)
 
 
@@ -199,6 +260,7 @@ def update_category(
     body: CategoryUpdate,
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     categories_service: Annotated[CategoriesService, Depends(get_categories_service)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
 ) -> CategoryResponse:
     """Update a tenant-owned category.
 
@@ -207,6 +269,7 @@ def update_category(
         body: Partial update payload merged onto the existing DTO.
         owner: Authenticated tenant from JWT.
         categories_service: Injected categories service scoped to the request lifecycle.
+        redis: Optional Redis client for cache invalidation.
 
     Returns:
         Updated category owned by the authenticated tenant.
@@ -227,6 +290,7 @@ def update_category(
         if str(exc) in _GLOBAL_CATEGORY_MESSAGES:
             raise _category_not_found() from exc
         raise
+    _invalidate_category_caches(redis, owner)
     return CategoryResponse.from_dto(updated)
 
 
@@ -235,6 +299,7 @@ def delete_category(
     category_id: uuid.UUID,
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     categories_service: Annotated[CategoriesService, Depends(get_categories_service)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
 ) -> None:
     """Soft-delete a tenant-owned category.
 
@@ -242,6 +307,7 @@ def delete_category(
         category_id: Primary key of the category to delete.
         owner: Authenticated tenant from JWT.
         categories_service: Injected categories service scoped to the request lifecycle.
+        redis: Optional Redis client for cache invalidation.
 
     Returns:
         ``None``; response body is empty on success.
@@ -254,3 +320,4 @@ def delete_category(
         raise _category_not_found()
     _reject_global_category(existing)
     categories_service.delete(obj=CategoriesDTO.model_construct(id=category_id), owner=owner)
+    _invalidate_category_caches(redis, owner)

--- a/modules/api/src/papita_txnsapi/routers/v1/health.py
+++ b/modules/api/src/papita_txnsapi/routers/v1/health.py
@@ -1,23 +1,25 @@
 """Health check endpoints for load balancers and orchestrators (P1).
 
-Unauthenticated probes under ``/health`` report process, database, and (when
-``AUTH_PROVIDER=supabase``) Supabase Auth readiness. Routes do not apply tenant
-scoping and never accept client input that reaches SQL or Auth URLs.
+Unauthenticated probes under ``/health`` report process, database, Auth, and
+(when enabled) Redis readiness. Routes do not apply tenant scoping and never
+accept client input that reaches SQL, Auth, or Redis URLs.
 
 Routes:
-    ``GET /health`` — composite status with app version, database, and Auth.
+    ``GET /health`` — composite status with app version, database, Auth, Redis.
     ``GET /health/database`` — API↔database probe with latency (503 when down).
     ``GET /health/auth`` — API↔Supabase Auth probe with latency (503 when down).
-    ``GET /health/ready`` — readiness; 503 when DB or required Auth is down.
+    ``GET /health/redis`` — API↔Redis probe with latency (503 when required and down).
+    ``GET /health/ready`` — readiness; 503 when DB, required Auth, or required Redis down.
     ``GET /health/live`` — liveness; always 200 while the process is running.
 
 Service delegation:
     Database checks use :func:`~papita_txnsapi.core.db_health.probe_database`.
     Auth checks use :func:`~papita_txnsapi.core.auth_health.probe_supabase_auth`.
+    Redis checks use :func:`~papita_txnsapi.core.redis.ping_redis`.
 
 Security:
     Failures return allowlisted ``detail`` / connectivity labels only. Exception
-    text and Auth response bodies stay in server logs and are never reflected.
+    text and Auth/Redis response bodies stay in server logs and are never reflected.
 """
 
 from __future__ import annotations
@@ -25,12 +27,14 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Annotated, Literal, Type
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Request, status
 from fastapi.responses import JSONResponse
+from redis import Redis
 
 from papita_txnsapi.config.settings import Settings, get_settings
 from papita_txnsapi.core.auth_health import AuthProbeDetail, AuthProbeResult, probe_supabase_auth
 from papita_txnsapi.core.db_health import probe_database
+from papita_txnsapi.core.redis import RedisProbeDetail, RedisProbeResult, get_redis_from_app, ping_redis
 from papita_txnsapi.dependencies.services import get_connector
 from papita_txnsapi.schemas.health import (
     AuthHealthResponse,
@@ -38,6 +42,7 @@ from papita_txnsapi.schemas.health import (
     HealthResponse,
     LivenessResponse,
     ReadinessResponse,
+    RedisHealthResponse,
 )
 from papita_txnsmodel.database.connector import SQLDatabaseConnector
 
@@ -48,7 +53,7 @@ _JSON_CONTENT_TYPE = "application/json; charset=utf-8"
 
 def _json_response(
     status_code: int,
-    payload: HealthResponse | DatabaseHealthResponse | AuthHealthResponse | ReadinessResponse,
+    payload: HealthResponse | DatabaseHealthResponse | AuthHealthResponse | RedisHealthResponse | ReadinessResponse,
 ) -> JSONResponse:
     """Serialize a health schema as JSON without an HTML content type.
 
@@ -82,6 +87,12 @@ def _probe_auth(settings: Settings) -> AuthProbeResult:
     )
 
 
+def _probe_redis(request: Request, settings: Settings) -> RedisProbeResult:
+    """Run the Redis probe using application state and settings."""
+    client: Redis | None = get_redis_from_app(request.app)
+    return ping_redis(client, required=settings.REDIS_ENABLED)
+
+
 def _auth_connectivity_label(probe: AuthProbeResult) -> Literal["connected", "disconnected", "skipped"]:
     """Map an Auth probe result to the composite ``GET /health`` auth label."""
     if probe.detail == AuthProbeDetail.SKIPPED_LOCAL:
@@ -89,28 +100,39 @@ def _auth_connectivity_label(probe: AuthProbeResult) -> Literal["connected", "di
     return "connected" if probe.reachable else "disconnected"
 
 
+def _redis_connectivity_label(probe: RedisProbeResult) -> Literal["connected", "disconnected", "skipped"]:
+    """Map a Redis probe result to the composite ``GET /health`` redis label."""
+    if probe.detail == RedisProbeDetail.DISABLED:
+        return "skipped"
+    return "connected" if probe.connected else "disconnected"
+
+
 @router.get("", response_model=HealthResponse, response_class=JSONResponse)
 def get_health(
+    request: Request,
     settings: Annotated[Settings, Depends(get_settings)],
     connector: Annotated[Type[SQLDatabaseConnector], Depends(get_connector)],
 ) -> HealthResponse:
-    """Return application status, version, database, and Auth connectivity.
+    """Return application status, version, database, Auth, and Redis connectivity.
 
     Always returns HTTP 200 with ``status`` of ``healthy`` or ``degraded``. Use
     ``/health/ready`` when orchestrators should fail traffic on dependency loss.
 
     Args:
-        settings: Application settings supplying version and Auth configuration.
+        request: Incoming request (reads ``app.state.redis``).
+        settings: Application settings supplying version and Auth/Redis configuration.
         connector: Database connector class used for a lightweight readiness query.
 
     Returns:
-        Composite ``HealthResponse`` marked ``degraded`` when the database is down
-        or required Supabase Auth is unreachable (local Auth probe counts as ok).
+        Composite ``HealthResponse`` marked ``degraded`` when the database is down,
+        required Supabase Auth is unreachable, or required Redis is down.
     """
     db_probe = probe_database(connector)
     auth_probe = _probe_auth(settings)
+    redis_probe = _probe_redis(request, settings)
     database: Literal["connected", "disconnected"] = "connected" if db_probe.connected else "disconnected"
-    dependencies_ok = db_probe.connected and auth_probe.reachable
+    redis_ok = redis_probe.connected if settings.REDIS_ENABLED else True
+    dependencies_ok = db_probe.connected and auth_probe.reachable and redis_ok
     status_label: Literal["healthy", "degraded"] = "healthy" if dependencies_ok else "degraded"
     return HealthResponse(
         status=status_label,
@@ -121,6 +143,9 @@ def get_health(
         auth=_auth_connectivity_label(auth_probe),
         auth_latency_ms=auth_probe.latency_ms,
         auth_detail=auth_probe.detail,
+        redis=_redis_connectivity_label(redis_probe),
+        redis_latency_ms=redis_probe.latency_ms,
+        redis_detail=redis_probe.detail,
     )
 
 
@@ -185,18 +210,54 @@ def get_auth_health(
     return _json_response(status.HTTP_503_SERVICE_UNAVAILABLE, payload)
 
 
+@router.get("/redis", response_model=RedisHealthResponse, response_class=JSONResponse)
+def get_redis_health(
+    request: Request,
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> RedisHealthResponse | JSONResponse:
+    """Probe API↔Redis communication health.
+
+    When ``REDIS_ENABLED=false``, reports healthy with a disabled/skipped detail.
+    When enabled, issues ``PING`` against the lifespan client.
+
+    Args:
+        request: Incoming request (reads ``app.state.redis``).
+        settings: Application settings with Redis flags.
+
+    Returns:
+        ``RedisHealthResponse`` with ``status=healthy`` when Redis is up (or skipped);
+        otherwise a 503 ``JSONResponse`` with ``status=unhealthy``.
+    """
+    probe = _probe_redis(request, settings)
+    reachable = probe.connected if settings.REDIS_ENABLED else True
+    status_label: Literal["healthy", "unhealthy"] = "healthy" if reachable else "unhealthy"
+    payload = RedisHealthResponse(
+        status=status_label,
+        reachable=reachable,
+        latency_ms=probe.latency_ms,
+        checked_at=datetime.now(timezone.utc),
+        detail=probe.detail,
+        required=settings.REDIS_ENABLED,
+    )
+    if reachable:
+        return payload
+    return _json_response(status.HTTP_503_SERVICE_UNAVAILABLE, payload)
+
+
 @router.get("/ready", response_model=ReadinessResponse, response_class=JSONResponse)
 def get_readiness(
+    request: Request,
     settings: Annotated[Settings, Depends(get_settings)],
     connector: Annotated[Type[SQLDatabaseConnector], Depends(get_connector)],
 ) -> ReadinessResponse | JSONResponse:
-    """Readiness probe — fail open traffic when the database or required Auth is down.
+    """Readiness probe — fail open traffic when DB, required Auth, or required Redis is down.
 
-    Both database connectivity and Auth reachability (including local skip as ok)
-    must succeed for ``ready=True``. Suitable for Kubernetes readiness gates.
+    Database connectivity, Auth reachability (including local skip as ok), and Redis
+    (when ``REDIS_ENABLED``) must succeed for ``ready=True``.
 
     Args:
-        settings: Application settings selecting Auth provider requirements.
+        request: Incoming request (reads ``app.state.redis``).
+        settings: Application settings selecting Auth/Redis requirements.
         connector: Database connector class used for a lightweight readiness query.
 
     Returns:
@@ -205,7 +266,8 @@ def get_readiness(
     """
     db_ok = probe_database(connector).connected
     auth_ok = _probe_auth(settings).reachable
-    if db_ok and auth_ok:
+    redis_ok = _probe_redis(request, settings).connected if settings.REDIS_ENABLED else True
+    if db_ok and auth_ok and redis_ok:
         return ReadinessResponse(ready=True)
     return _json_response(status.HTTP_503_SERVICE_UNAVAILABLE, ReadinessResponse(ready=False))
 
@@ -214,7 +276,7 @@ def get_readiness(
 def get_liveness() -> LivenessResponse:
     """Liveness probe — confirm the API process is running.
 
-    Does not check database or Auth. Use ``/health/ready`` for dependency gates.
+    Does not check database, Auth, or Redis. Use ``/health/ready`` for dependency gates.
 
     Returns:
         ``LivenessResponse`` with ``alive=True`` when the process can serve HTTP.

--- a/modules/api/src/papita_txnsapi/routers/v1/movements.py
+++ b/modules/api/src/papita_txnsapi/routers/v1/movements.py
@@ -26,9 +26,13 @@ from datetime import timezone
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from redis import Redis
 
+from papita_txnsapi.core.cache import CacheNamespace, bump_cache_versions
 from papita_txnsapi.dependencies.auth import get_current_owner
 from papita_txnsapi.dependencies.pagination import PaginationParams, get_pagination
+from papita_txnsapi.dependencies.rate_limit import enforce_tenant_api_rate_limit
+from papita_txnsapi.dependencies.redis import get_optional_redis
 from papita_txnsapi.dependencies.services import get_accounts_service, get_transactions_service
 from papita_txnsapi.schemas.common import PaginatedResponse
 from papita_txnsapi.schemas.movements import (
@@ -46,7 +50,22 @@ from papita_txnsmodel.model.enums import TransactionKind, TransactionStatus
 from papita_txnsmodel.services.accounts import AccountsService
 from papita_txnsmodel.services.transactions import TransactionsService
 
-router = APIRouter(prefix="/movements", tags=["Movements"])
+router = APIRouter(
+    prefix="/movements",
+    tags=["Movements"],
+    dependencies=[Depends(enforce_tenant_api_rate_limit)],
+)
+
+
+def _invalidate_ledger_caches(redis: Redis | None, owner: UsersDTO) -> None:
+    """Bump transactions, reports, and accounts caches after transfer mutations."""
+    bump_cache_versions(
+        redis,
+        owner.id,
+        CacheNamespace.TRANSACTIONS,
+        CacheNamespace.REPORTS,
+        CacheNamespace.ACCOUNTS,
+    )
 
 
 def _movement_not_found() -> HTTPException:
@@ -220,6 +239,7 @@ def create_movement(
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     transactions_service: Annotated[TransactionsService, Depends(get_transactions_service)],
     accounts_service: Annotated[AccountsService, Depends(get_accounts_service)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
 ) -> MovementResponse:
     """Create a transfer between two tenant-owned accounts.
 
@@ -231,6 +251,7 @@ def create_movement(
         owner: Authenticated tenant that will own the transfer.
         transactions_service: Injected service for create/complete helpers.
         accounts_service: Injected service used to validate account ownership.
+        redis: Optional Redis client for cache invalidation.
 
     Returns:
         MovementResponse for the created (and possibly completed) transfer.
@@ -249,16 +270,18 @@ def create_movement(
     created = transactions_service.create_transfer(obj=dto, owner=owner)
     if not body.scheduled:
         created = transactions_service.complete_transfer(transaction_id=created, owner=owner)
+    _invalidate_ledger_caches(redis, owner)
     return MovementResponse.from_dto(created)
 
 
 @router.put("/{movement_id}", response_model=MovementResponse)
-def update_movement(
+def update_movement(  # pylint: disable=too-many-positional-arguments
     movement_id: uuid.UUID,
     body: MovementUpdate,
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     transactions_service: Annotated[TransactionsService, Depends(get_transactions_service)],
     accounts_service: Annotated[AccountsService, Depends(get_accounts_service)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
 ) -> MovementResponse:
     """Update a pending transfer via upsert of the merged DTO.
 
@@ -268,6 +291,7 @@ def update_movement(
         owner: Authenticated tenant that must own the transfer.
         transactions_service: Injected service for load and upsert.
         accounts_service: Injected service used to re-validate account legs.
+        redis: Optional Redis client for cache invalidation.
 
     Returns:
         MovementResponse for the updated transfer row.
@@ -292,6 +316,7 @@ def update_movement(
         currency=merged.currency,
     )
     updated = transactions_service.create(obj=merged, owner=owner)
+    _invalidate_ledger_caches(redis, owner)
     return MovementResponse.from_dto(updated)
 
 
@@ -300,6 +325,7 @@ def delete_movement(
     movement_id: uuid.UUID,
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     transactions_service: Annotated[TransactionsService, Depends(get_transactions_service)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
 ) -> None:
     """Cancel a pending transfer by setting status to CANCELLED.
 
@@ -310,6 +336,7 @@ def delete_movement(
         movement_id: Transfer primary key from the path.
         owner: Authenticated tenant that must own the transfer.
         transactions_service: Injected service providing ``cancel``.
+        redis: Optional Redis client for cache invalidation.
 
     Raises:
         HTTPException: 404 when missing or cancel fails; 422 when not PENDING.
@@ -320,6 +347,7 @@ def delete_movement(
         transactions_service.cancel(transaction_id=movement_id, owner=owner)
     except ValueError as exc:
         raise _movement_not_found() from exc
+    _invalidate_ledger_caches(redis, owner)
 
 
 @router.post("/{movement_id}/execute", response_model=MovementExecuteResponse)
@@ -327,6 +355,7 @@ def execute_movement(
     movement_id: uuid.UUID,
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     transactions_service: Annotated[TransactionsService, Depends(get_transactions_service)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
 ) -> MovementExecuteResponse:
     """Complete a pending scheduled transfer.
 
@@ -334,6 +363,7 @@ def execute_movement(
         movement_id: Transfer primary key from the path.
         owner: Authenticated tenant that must own the transfer.
         transactions_service: Injected service providing ``complete_transfer``.
+        redis: Optional Redis client for cache invalidation.
 
     Returns:
         MovementExecuteResponse with completed status and execution timestamp.
@@ -351,6 +381,7 @@ def execute_movement(
     executed_at = completed.transaction_ts
     if executed_at.tzinfo is None:
         executed_at = executed_at.replace(tzinfo=timezone.utc)
+    _invalidate_ledger_caches(redis, owner)
     return MovementExecuteResponse(
         id=_require_uuid(completed.id),
         status="completed",

--- a/modules/api/src/papita_txnsapi/routers/v1/reports.py
+++ b/modules/api/src/papita_txnsapi/routers/v1/reports.py
@@ -25,8 +25,18 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Response, status
 from fastapi.responses import JSONResponse
+from redis import Redis
 
+from papita_txnsapi.config.settings import Settings, get_settings
+from papita_txnsapi.core.cache import (
+    CacheNamespace,
+    get_versioned_cached_json,
+    set_versioned_cached_json,
+    ttl_for_namespace,
+)
 from papita_txnsapi.dependencies.auth import get_current_owner
+from papita_txnsapi.dependencies.rate_limit import enforce_tenant_api_rate_limit
+from papita_txnsapi.dependencies.redis import get_optional_redis
 from papita_txnsapi.dependencies.services import get_report_service
 from papita_txnsapi.schemas.common import DeferredResponse
 from papita_txnsapi.schemas.query_params import (
@@ -43,28 +53,43 @@ from papita_txnsapi.schemas.reports import CashFlowReportResponse, SpendingRepor
 from papita_txnsmodel.access.users.dto import UsersDTO
 from papita_txnsmodel.services.reports import ReportService
 
-router = APIRouter(prefix="/reports", tags=["Reports"])
+router = APIRouter(
+    prefix="/reports",
+    tags=["Reports"],
+    dependencies=[Depends(enforce_tenant_api_rate_limit)],
+)
 
 _DEFERRED_BUDGET = DeferredResponse(deferred_reason="FR-09 / FR-12 budget-performance deferred to v4.1 budgets")
 _DEFERRED_EXPORT = DeferredResponse(deferred_reason="Export formats xlsx/pdf deferred — use csv or json")
 
 
+def _report_cache_params(route: str, filters: ReportSpendingQuery | ReportCashFlowQuery | ReportTrendsQuery) -> dict:
+    """Build a JSON-safe cache param map from report query models."""
+    return {"route": route, **filters.model_dump(mode="json")}
+
+
 @router.get("/spending", response_model=SpendingReportResponse)
-def get_spending_report(
+def get_spending_report(  # pylint: disable=too-many-positional-arguments
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     report_service: Annotated[ReportService, Depends(get_report_service)],
     filters: Annotated[ReportSpendingQuery, Depends(get_report_spending_query)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
+    response: Response,
 ) -> SpendingReportResponse:
     """Return spending and income totals for the authenticated tenant only.
 
     Aggregates COMPLETED EXPENSE rows (plus separate INCOME totals) via
     ``ReportService.spending``. Response shaping and stub enrichment fields are
-    applied in ``SpendingReportResponse.from_service``.
+    applied in ``SpendingReportResponse.from_service``. Cached in Redis when enabled.
 
     Args:
         owner: Authenticated tenant from JWT; required for all ledger reads.
         report_service: Injected report aggregation service.
         filters: Date window, optional ``account_id``, and ``group_by`` parameters.
+        settings: Application settings (cache TTL).
+        redis: Optional Redis client when ``REDIS_ENABLED``.
+        response: FastAPI response used to set ``X-Cache`` status.
 
     Returns:
         SpendingReportResponse mapped from the lean service payload.
@@ -73,31 +98,60 @@ def get_spending_report(
         HTTPException: 401 without JWT; 400 when ``account_id`` is not owned by
             the tenant or date/group validation fails in query models.
     """
+    cache_params = _report_cache_params("spending", filters)
+    owner_id = owner.id
+    if owner_id is not None:
+        cached, cache_status = get_versioned_cached_json(
+            redis, owner_id, CacheNamespace.REPORTS, "reports:spending", cache_params
+        )
+        response.headers["X-Cache"] = cache_status
+        if cached is not None:
+            return SpendingReportResponse.model_validate(cached)
+    else:
+        response.headers["X-Cache"] = "BYPASS"
+
     payload = report_service.spending(owner=owner, **filters.service_kwargs())
-    return SpendingReportResponse.from_service(
+    result = SpendingReportResponse.from_service(
         payload,
         start_date=filters.start_date,
         end_date=filters.end_date,
     )
+    if owner_id is not None:
+        set_versioned_cached_json(
+            redis,
+            owner_id,
+            CacheNamespace.REPORTS,
+            "reports:spending",
+            cache_params,
+            value=result.model_dump(mode="json"),
+            ttl_seconds=ttl_for_namespace(settings, CacheNamespace.REPORTS),
+        )
+    return result
 
 
 @router.get("/cash-flow", response_model=CashFlowReportResponse)
-def get_cash_flow_report(
+def get_cash_flow_report(  # pylint: disable=too-many-positional-arguments
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     report_service: Annotated[ReportService, Depends(get_report_service)],
     filters: Annotated[ReportCashFlowQuery, Depends(get_report_cash_flow_query)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
+    response: Response,
 ) -> CashFlowReportResponse:
     """Return cash-flow summary for the authenticated tenant (G9 refresh by default).
 
     Inflows/outflows include TRANSFER legs. Balance freshness uses
     ``refresh_balance_materialized_views`` when ``refresh_balances`` is true.
     ``closing_balance`` maps from service ``portfolio_total``; opening/by-account
-    fields may be stubbed in MVP.
+    fields may be stubbed in MVP. Cached in Redis when enabled.
 
     Args:
         owner: Authenticated tenant from JWT.
         report_service: Injected report aggregation service.
         filters: Date window, optional ``account_id``, and refresh flag.
+        settings: Application settings (cache TTL).
+        redis: Optional Redis client when ``REDIS_ENABLED``.
+        response: FastAPI response used to set ``X-Cache`` status.
 
     Returns:
         CashFlowReportResponse for the tenant (and optional account filter).
@@ -105,29 +159,59 @@ def get_cash_flow_report(
     Raises:
         HTTPException: 401 without JWT; 400 when tenant account validation fails.
     """
+    cache_params = _report_cache_params("cash-flow", filters)
+    owner_id = owner.id
+    if owner_id is not None:
+        cached, cache_status = get_versioned_cached_json(
+            redis, owner_id, CacheNamespace.REPORTS, "reports:cash-flow", cache_params
+        )
+        response.headers["X-Cache"] = cache_status
+        if cached is not None:
+            return CashFlowReportResponse.model_validate(cached)
+    else:
+        response.headers["X-Cache"] = "BYPASS"
+
     payload = report_service.cash_flow(owner=owner, **filters.service_kwargs())
-    return CashFlowReportResponse.from_service(
+    result = CashFlowReportResponse.from_service(
         payload,
         start_date=filters.start_date,
         end_date=filters.end_date,
     )
+    if owner_id is not None:
+        set_versioned_cached_json(
+            redis,
+            owner_id,
+            CacheNamespace.REPORTS,
+            "reports:cash-flow",
+            cache_params,
+            value=result.model_dump(mode="json"),
+            ttl_seconds=ttl_for_namespace(settings, CacheNamespace.REPORTS),
+        )
+    return result
 
 
 @router.get("/trends", response_model=TrendsReportResponse)
-def get_trends_report(
+def get_trends_report(  # pylint: disable=too-many-positional-arguments
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     report_service: Annotated[ReportService, Depends(get_report_service)],
     filters: Annotated[ReportTrendsQuery, Depends(get_report_trends_query)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
+    response: Response,
 ) -> TrendsReportResponse:
     """Return income/expense time-series trends for the authenticated tenant only.
 
     ``months`` (or explicit dates) define the analysis window; series buckets use
     the requested ``period``. Category insights remain stubbed empty in MVP.
+    Cached in Redis when enabled.
 
     Args:
         owner: Authenticated tenant from JWT.
         report_service: Injected report aggregation service.
         filters: Period, date window (or months), optional account/category filters.
+        settings: Application settings (cache TTL).
+        redis: Optional Redis client when ``REDIS_ENABLED``.
+        response: FastAPI response used to set ``X-Cache`` status.
 
     Returns:
         TrendsReportResponse with ``monthly_trends`` derived from the service series.
@@ -135,13 +219,36 @@ def get_trends_report(
     Raises:
         HTTPException: 401 without JWT; 400 when filters or ownership checks fail.
     """
+    cache_params = _report_cache_params("trends", filters)
+    owner_id = owner.id
+    if owner_id is not None:
+        cached, cache_status = get_versioned_cached_json(
+            redis, owner_id, CacheNamespace.REPORTS, "reports:trends", cache_params
+        )
+        response.headers["X-Cache"] = cache_status
+        if cached is not None:
+            return TrendsReportResponse.model_validate(cached)
+    else:
+        response.headers["X-Cache"] = "BYPASS"
+
     payload = report_service.trends(owner=owner, **filters.service_kwargs())
     assert filters.start_date is not None and filters.end_date is not None
-    return TrendsReportResponse.from_service(
+    result = TrendsReportResponse.from_service(
         payload,
         start_date=filters.start_date,
         end_date=filters.end_date,
     )
+    if owner_id is not None:
+        set_versioned_cached_json(
+            redis,
+            owner_id,
+            CacheNamespace.REPORTS,
+            "reports:trends",
+            cache_params,
+            value=result.model_dump(mode="json"),
+            ttl_seconds=ttl_for_namespace(settings, CacheNamespace.REPORTS),
+        )
+    return result
 
 
 @router.get("/export")
@@ -154,7 +261,7 @@ def export_report(
 
     Delegates to ``ReportService.export`` for spending, cash-flow, or trends.
     ``xlsx`` and ``pdf`` return HTTP 501 with ``DeferredResponse`` and do not
-    call the service.
+    call the service. Export is not cached (streaming / large payloads).
 
     Args:
         owner: Authenticated tenant from JWT.

--- a/modules/api/src/papita_txnsapi/routers/v1/transactions.py
+++ b/modules/api/src/papita_txnsapi/routers/v1/transactions.py
@@ -9,8 +9,8 @@ are excluded from default list responses; use ``/movements`` or
 Routes:
     ``GET /transactions`` — paginated list with G4 filters; excludes TRANSFER by default.
     ``GET /transactions/{transaction_id}`` — single transaction with linked names.
-    ``POST /transactions`` — create INCOME/EXPENSE row.
-    ``POST /transactions/bulk`` — bulk create INCOME/EXPENSE rows.
+    ``POST /transactions`` — create INCOME/EXPENSE row (optional ``Idempotency-Key``).
+    ``POST /transactions/bulk`` — bulk create INCOME/EXPENSE rows (optional ``Idempotency-Key``).
     ``PUT /transactions/{transaction_id}`` — update tenant-owned transaction.
     ``DELETE /transactions/{transaction_id}`` — soft-delete tenant-owned transaction.
     ``POST /transactions/{transaction_id}/split`` — deferred 501 (v4).
@@ -25,10 +25,22 @@ from __future__ import annotations
 import uuid
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
+from redis import Redis
 
+from papita_txnsapi.config.settings import Settings, get_settings
+from papita_txnsapi.core.cache import (
+    CacheNamespace,
+    bump_cache_versions,
+    get_versioned_cached_json,
+    set_versioned_cached_json,
+    ttl_for_namespace,
+)
+from papita_txnsapi.core.idempotency import begin_idempotency, clear_idempotency_pending, complete_idempotency
 from papita_txnsapi.dependencies.auth import get_current_owner
 from papita_txnsapi.dependencies.pagination import PaginationParams, get_pagination
+from papita_txnsapi.dependencies.rate_limit import enforce_tenant_api_rate_limit
+from papita_txnsapi.dependencies.redis import get_optional_redis
 from papita_txnsapi.dependencies.services import get_transactions_service
 from papita_txnsapi.schemas.common import DeferredResponse, PaginatedResponse
 from papita_txnsapi.schemas.query_params import TransactionListQuery, get_transaction_list_query
@@ -45,9 +57,26 @@ from papita_txnsmodel.access.users.dto import UsersDTO
 from papita_txnsmodel.model.enums import TransactionKind
 from papita_txnsmodel.services.transactions import TransactionsService
 
-router = APIRouter(prefix="/transactions", tags=["Transactions"])
+router = APIRouter(
+    prefix="/transactions",
+    tags=["Transactions"],
+    dependencies=[Depends(enforce_tenant_api_rate_limit)],
+)
 
 _DEFERRED_SPLIT = DeferredResponse(deferred_reason="Transaction split deferred to v4 transaction_splits")
+_IDEMPOTENCY_CREATE = "transactions:create"
+_IDEMPOTENCY_BULK = "transactions:bulk"
+
+
+def _invalidate_ledger_caches(redis: Redis | None, owner: UsersDTO) -> None:
+    """Bump transactions, reports, and accounts caches after ledger mutations."""
+    bump_cache_versions(
+        redis,
+        owner.id,
+        CacheNamespace.TRANSACTIONS,
+        CacheNamespace.REPORTS,
+        CacheNamespace.ACCOUNTS,
+    )
 
 
 def _transaction_not_found() -> HTTPException:
@@ -94,27 +123,57 @@ def _require_owner_id(owner: UsersDTO) -> uuid.UUID:
     return owner.id
 
 
+def _idempotency_conflict() -> HTTPException:
+    """Return 409 when an idempotency key is still pending on another request."""
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="A request with this Idempotency-Key is already in progress.",
+    )
+
+
 @router.get("", response_model=PaginatedResponse[TransactionResponse])
-def list_transactions(
+def list_transactions(  # pylint: disable=too-many-positional-arguments
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     pagination: Annotated[PaginationParams, Depends(get_pagination)],
     transactions_service: Annotated[TransactionsService, Depends(get_transactions_service)],
     filters: Annotated[TransactionListQuery, Depends(get_transaction_list_query)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
+    response: Response,
 ) -> PaginatedResponse[TransactionResponse]:
     """List tenant transactions with optional G4 filters.
 
     By default TRANSFER rows are excluded (``exclude_transfer=True``) unless the
-    client filters ``transaction_type=transfer``.
+    client filters ``transaction_type=transfer``. Short-TTL Redis cache-aside when enabled.
 
     Args:
         owner: Authenticated tenant from JWT.
         pagination: Skip/limit window for the response page.
         transactions_service: Injected service providing ``list_transactions``.
         filters: Bundled query parameters mapped to service kwargs.
+        settings: Application settings (cache TTL).
+        redis: Optional Redis client when ``REDIS_ENABLED``.
+        response: FastAPI response used to set ``X-Cache`` status.
 
     Returns:
         Paginated ``TransactionResponse`` items owned by ``owner``.
     """
+    cache_params = {
+        "skip": pagination.skip,
+        "limit": pagination.limit,
+        **filters.model_dump(mode="json"),
+    }
+    owner_id = owner.id
+    if owner_id is not None:
+        cached, cache_status = get_versioned_cached_json(
+            redis, owner_id, CacheNamespace.TRANSACTIONS, "transactions:list", cache_params
+        )
+        response.headers["X-Cache"] = cache_status
+        if cached is not None:
+            return PaginatedResponse[TransactionResponse].model_validate(cached)
+    else:
+        response.headers["X-Cache"] = "BYPASS"
+
     records_df, total = transactions_service.list_transactions(
         owner=owner,
         skip=pagination.skip,
@@ -122,49 +181,96 @@ def list_transactions(
         **filters.service_kwargs(),
     )
     items = [TransactionResponse.from_dto(txn) for txn in transactions_from_dataframe(records_df)]
-    return PaginatedResponse(
+    payload: PaginatedResponse[TransactionResponse] = PaginatedResponse(
         items=items,
         total=total,
         skip=pagination.skip,
         limit=pagination.limit,
     )
+    if owner_id is not None:
+        set_versioned_cached_json(
+            redis,
+            owner_id,
+            CacheNamespace.TRANSACTIONS,
+            "transactions:list",
+            cache_params,
+            value=payload.model_dump(mode="json"),
+            ttl_seconds=ttl_for_namespace(settings, CacheNamespace.TRANSACTIONS),
+        )
+    return payload
 
 
 @router.post("/bulk", status_code=status.HTTP_201_CREATED, response_model=TransactionBulkResponse)
-def bulk_create_transactions(
+def bulk_create_transactions(  # pylint: disable=too-many-positional-arguments
     body: TransactionBulkCreate,
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     transactions_service: Annotated[TransactionsService, Depends(get_transactions_service)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
 ) -> TransactionBulkResponse:
     """Create multiple INCOME/EXPENSE transactions for the authenticated tenant.
 
     Each item is created independently; ``ValueError`` / ``TypeError`` on an item
-    increments ``failed`` without aborting the remainder of the batch.
+    increments ``failed`` without aborting the remainder of the batch. Optional
+    ``Idempotency-Key`` replays a prior bulk response when Redis is enabled.
 
     Args:
         body: Bulk payload containing one or more ``TransactionCreate`` items.
         owner: Authenticated tenant that will own every created row.
         transactions_service: Injected service used for per-item ``create``.
+        settings: Application settings (idempotency TTL).
+        redis: Optional Redis client for cache invalidation / idempotency.
+        idempotency_key: Optional client key for safe retries.
 
     Returns:
         TransactionBulkResponse with counts and successfully created items.
 
     Raises:
-        HTTPException: 401 when the owner context lacks a primary key.
+        HTTPException: 401 when the owner context lacks a primary key; 409 when
+            an idempotency key is still pending.
     """
     owner_id = _require_owner_id(owner)
+    begun = begin_idempotency(
+        redis,
+        owner_id,
+        scope=_IDEMPOTENCY_BULK,
+        key=idempotency_key,
+        ttl_seconds=settings.REDIS_IDEMPOTENCY_TTL_SECONDS,
+    )
+    if begun.state == "hit" and begun.payload is not None:
+        return TransactionBulkResponse.model_validate(begun.payload)
+    if begun.state == "conflict":
+        raise _idempotency_conflict()
+
     created_items: list[TransactionResponse] = []
     failed = 0
 
-    for item in body.transactions:
-        try:
-            dto = item.to_transactions_dto(owner_id=owner_id)
-            result = transactions_service.create(obj=dto, owner=owner)
-            created_items.append(TransactionResponse.from_dto(result))
-        except (ValueError, TypeError):
-            failed += 1
+    try:
+        for item in body.transactions:
+            try:
+                dto = item.to_transactions_dto(owner_id=owner_id)
+                result = transactions_service.create(obj=dto, owner=owner)
+                created_items.append(TransactionResponse.from_dto(result))
+            except (ValueError, TypeError):
+                failed += 1
+    except Exception:
+        clear_idempotency_pending(redis, owner_id, scope=_IDEMPOTENCY_BULK, key=idempotency_key)
+        raise
 
-    return TransactionBulkResponse(created=len(created_items), failed=failed, transactions=created_items)
+    if created_items:
+        _invalidate_ledger_caches(redis, owner)
+    payload = TransactionBulkResponse(created=len(created_items), failed=failed, transactions=created_items)
+    complete_idempotency(
+        redis,
+        owner_id,
+        scope=_IDEMPOTENCY_BULK,
+        key=idempotency_key,
+        body=payload.model_dump(mode="json"),
+        ttl_seconds=settings.REDIS_IDEMPOTENCY_TTL_SECONDS,
+        http_status=201,
+    )
+    return payload
 
 
 @router.post("/{transaction_id}/split", status_code=status.HTTP_501_NOT_IMPLEMENTED)
@@ -182,10 +288,13 @@ def split_transaction(transaction_id: uuid.UUID) -> DeferredResponse:
 
 
 @router.get("/{transaction_id}", response_model=TransactionResponse)
-def get_transaction(
+def get_transaction(  # pylint: disable=too-many-positional-arguments
     transaction_id: uuid.UUID,
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     transactions_service: Annotated[TransactionsService, Depends(get_transactions_service)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
+    response: Response,
 ) -> TransactionResponse:
     """Retrieve a single tenant-owned transaction with linked names.
 
@@ -193,6 +302,9 @@ def get_transaction(
         transaction_id: Ledger primary key from the path.
         owner: Authenticated tenant from JWT.
         transactions_service: Injected service for owner-scoped get-by-id.
+        settings: Application settings (cache TTL).
+        redis: Optional Redis client when ``REDIS_ENABLED``.
+        response: FastAPI response used to set ``X-Cache`` status.
 
     Returns:
         TransactionResponse including account/category names when linked DTOs load.
@@ -200,35 +312,96 @@ def get_transaction(
     Raises:
         HTTPException: 404 when the row is missing or not owned by ``owner``.
     """
+    cache_params = {"transaction_id": str(transaction_id)}
+    owner_id = owner.id
+    if owner_id is not None:
+        cached, cache_status = get_versioned_cached_json(
+            redis, owner_id, CacheNamespace.TRANSACTIONS, "transactions:detail", cache_params
+        )
+        response.headers["X-Cache"] = cache_status
+        if cached is not None:
+            return TransactionResponse.model_validate(cached)
+    else:
+        response.headers["X-Cache"] = "BYPASS"
+
     transaction = transactions_service.get(obj=transaction_id, owner=owner, include_linked_dtos=True)
     if transaction is None:
         raise _transaction_not_found()
-    return TransactionResponse.from_dto(transaction, include_names=True)
+    result = TransactionResponse.from_dto(transaction, include_names=True)
+    if owner_id is not None:
+        set_versioned_cached_json(
+            redis,
+            owner_id,
+            CacheNamespace.TRANSACTIONS,
+            "transactions:detail",
+            cache_params,
+            value=result.model_dump(mode="json"),
+            ttl_seconds=ttl_for_namespace(settings, CacheNamespace.TRANSACTIONS),
+        )
+    return result
 
 
 @router.post("", status_code=status.HTTP_201_CREATED, response_model=TransactionResponse)
-def create_transaction(
+def create_transaction(  # pylint: disable=too-many-positional-arguments
     body: TransactionCreate,
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     transactions_service: Annotated[TransactionsService, Depends(get_transactions_service)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
 ) -> TransactionResponse:
     """Create an INCOME or EXPENSE transaction for the authenticated tenant.
+
+    Optional ``Idempotency-Key`` header (when Redis is enabled) makes retries safe:
+    a repeated key returns the original create response without inserting again.
 
     Args:
         body: Create payload (account, category, type, amount, date, optional fields).
         owner: Authenticated tenant that will own the new row.
         transactions_service: Injected service providing ``create``.
+        settings: Application settings (idempotency TTL).
+        redis: Optional Redis client for cache invalidation / idempotency.
+        idempotency_key: Optional client key for safe retries.
 
     Returns:
         TransactionResponse for the persisted row.
 
     Raises:
-        HTTPException: 401 when owner id is missing; domain errors may surface as
-            400 via the global ``ValueError`` handler.
+        HTTPException: 401 when owner id is missing; 409 when idempotency key is
+            pending; domain errors may surface as 400 via the global handler.
     """
-    dto = body.to_transactions_dto(owner_id=_require_owner_id(owner))
-    created = transactions_service.create(obj=dto, owner=owner)
-    return TransactionResponse.from_dto(created)
+    owner_id = _require_owner_id(owner)
+    begun = begin_idempotency(
+        redis,
+        owner_id,
+        scope=_IDEMPOTENCY_CREATE,
+        key=idempotency_key,
+        ttl_seconds=settings.REDIS_IDEMPOTENCY_TTL_SECONDS,
+    )
+    if begun.state == "hit" and begun.payload is not None:
+        return TransactionResponse.model_validate(begun.payload)
+    if begun.state == "conflict":
+        raise _idempotency_conflict()
+
+    try:
+        dto = body.to_transactions_dto(owner_id=owner_id)
+        created = transactions_service.create(obj=dto, owner=owner)
+    except Exception:
+        clear_idempotency_pending(redis, owner_id, scope=_IDEMPOTENCY_CREATE, key=idempotency_key)
+        raise
+
+    _invalidate_ledger_caches(redis, owner)
+    result = TransactionResponse.from_dto(created)
+    complete_idempotency(
+        redis,
+        owner_id,
+        scope=_IDEMPOTENCY_CREATE,
+        key=idempotency_key,
+        body=result.model_dump(mode="json"),
+        ttl_seconds=settings.REDIS_IDEMPOTENCY_TTL_SECONDS,
+        http_status=201,
+    )
+    return result
 
 
 @router.put("/{transaction_id}", response_model=TransactionResponse)
@@ -237,6 +410,7 @@ def update_transaction(
     body: TransactionUpdate,
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     transactions_service: Annotated[TransactionsService, Depends(get_transactions_service)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
 ) -> TransactionResponse:
     """Update a tenant-owned INCOME/EXPENSE transaction via upsert.
 
@@ -247,6 +421,7 @@ def update_transaction(
         body: Partial update fields applied onto the existing DTO.
         owner: Authenticated tenant that must own the row.
         transactions_service: Injected service for get and upsert.
+        redis: Optional Redis client for cache invalidation.
 
     Returns:
         TransactionResponse for the updated row.
@@ -265,6 +440,7 @@ def update_transaction(
 
     merged = body.apply_to(existing)
     updated = transactions_service.create(obj=merged, owner=owner)
+    _invalidate_ledger_caches(redis, owner)
     return TransactionResponse.from_dto(updated)
 
 
@@ -273,6 +449,7 @@ def delete_transaction(
     transaction_id: uuid.UUID,
     owner: Annotated[UsersDTO, Depends(get_current_owner)],
     transactions_service: Annotated[TransactionsService, Depends(get_transactions_service)],
+    redis: Annotated[Redis | None, Depends(get_optional_redis)],
 ) -> None:
     """Soft-delete a tenant-owned transaction.
 
@@ -280,6 +457,7 @@ def delete_transaction(
         transaction_id: Ledger primary key from the path.
         owner: Authenticated tenant that must own the row.
         transactions_service: Injected service providing soft ``delete``.
+        redis: Optional Redis client for cache invalidation.
 
     Raises:
         HTTPException: 404 when the row is missing or not owned by ``owner``.
@@ -288,3 +466,4 @@ def delete_transaction(
     if existing is None:
         raise _transaction_not_found()
     transactions_service.delete(obj=TransactionsDTO.model_construct(id=transaction_id), owner=owner)
+    _invalidate_ledger_caches(redis, owner)

--- a/modules/api/src/papita_txnsapi/schemas/auth.py
+++ b/modules/api/src/papita_txnsapi/schemas/auth.py
@@ -9,10 +9,12 @@ Passwords are accepted on write paths only and are never serialized on
 ``users.username`` is a derived handle for the schema unique constraint.
 ``AUTH_PROVIDER=local`` (tests) uses HS256 tokens; production uses Supabase Auth.
 
-Public models:
-    ``RegisterRequest``, ``RefreshRequest``, ``LogoutRequest``,
-    ``OAuthStartResponse``, ``OAuthCodeExchangeRequest``, ``SsoSessionRequest``,
-    ``UserResponse``, ``TokenResponse``.
+Key exports:
+    AuthProviderType: Wire literal for credential store (``supabase`` | ``local``).
+    RegisterRequest: ``POST /auth/register`` body.
+    RefreshRequest / LogoutRequest: Session rotation and revoke bodies.
+    OAuthStartResponse / OAuthCodeExchangeRequest / SsoSessionRequest: OAuth/SSO.
+    UserResponse / TokenResponse: Public profile and OAuth2 token envelopes.
 """
 
 from __future__ import annotations
@@ -66,6 +68,8 @@ class RegisterRequest(BaseModel):
 class RefreshRequest(BaseModel):
     """JSON body for ``POST /auth/refresh`` (Supabase Auth session rotation).
 
+    Local Auth mode does not accept this body meaningfully (route returns 501).
+
     Attributes:
         refresh_token: Opaque Supabase refresh token from login/OAuth/SSO.
     """
@@ -74,12 +78,15 @@ class RefreshRequest(BaseModel):
 
 
 class LogoutRequest(BaseModel):
-    """JSON body for ``POST /auth/logout`` (Supabase Auth session revoke).
+    """JSON body for ``POST /auth/logout`` (session revoke).
+
+    Under Supabase, ``refresh_token`` is required for GoTrue ``sign_out``.
+    ``access_token`` may also be supplied via ``Authorization: Bearer`` on the
+    route when omitted here. When Redis is enabled, the access JWT is denylisted.
 
     Attributes:
         refresh_token: Refresh token to invalidate at Supabase Auth.
-        access_token: Optional access JWT; when present, Auth can revoke that
-            session more precisely.
+        access_token: Optional access JWT for precise session revoke / denylist.
     """
 
     refresh_token: str = Field(min_length=1, max_length=4096)
@@ -201,7 +208,8 @@ class UserResponse(BaseModel):
         """Build an API response from a model ``UsersDTO``.
 
         Maps ``provider_type`` (including legacy ``phone`` → ``email``) and
-        normalizes ``auth_provider`` to the wire literal.
+        normalizes ``auth_provider`` to the wire literal. Any non-local
+        ``auth_provider`` value is treated as ``supabase``.
 
         Args:
             user: Persisted tenant user from ``UsersService``.
@@ -237,6 +245,9 @@ class UserResponse(BaseModel):
 
 class TokenResponse(BaseModel):
     """OAuth2-compatible access token payload for login, refresh, OAuth, and SSO.
+
+    Local login sets ``refresh_token`` to ``None``. Supabase paths populate both
+    access and refresh tokens when Auth issues a session.
 
     Attributes:
         access_token: Bearer JWT for protected API routes.

--- a/modules/api/src/papita_txnsapi/schemas/health.py
+++ b/modules/api/src/papita_txnsapi/schemas/health.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from papita_txnsapi.core.auth_health import AuthProbeDetail
 from papita_txnsapi.core.db_health import DatabaseProbeDetail
+from papita_txnsapi.core.redis import RedisProbeDetail
 
 __all__ = [
     "AuthHealthResponse",
@@ -26,6 +27,8 @@ __all__ = [
     "HealthResponse",
     "LivenessResponse",
     "ReadinessResponse",
+    "RedisHealthResponse",
+    "RedisProbeDetail",
 ]
 
 
@@ -41,6 +44,9 @@ class HealthResponse(BaseModel):
         auth: Supabase Auth connectivity (``connected``, ``disconnected``, or ``skipped``).
         auth_latency_ms: Auth probe latency when a live Auth check ran successfully.
         auth_detail: Allowlisted Auth probe detail.
+        redis: Redis connectivity (``connected``, ``disconnected``, or ``skipped``).
+        redis_latency_ms: Redis probe latency when a live Redis check ran successfully.
+        redis_detail: Allowlisted Redis probe detail.
     """
 
     model_config = ConfigDict(extra="forbid", use_enum_values=True)
@@ -53,6 +59,9 @@ class HealthResponse(BaseModel):
     auth: Literal["connected", "disconnected", "skipped"] = "skipped"
     auth_latency_ms: float | None = Field(default=None, ge=0.0, le=60_000.0)
     auth_detail: AuthProbeDetail = AuthProbeDetail.SKIPPED_LOCAL
+    redis: Literal["connected", "disconnected", "skipped"] = "skipped"
+    redis_latency_ms: float | None = Field(default=None, ge=0.0, le=60_000.0)
+    redis_detail: RedisProbeDetail = RedisProbeDetail.DISABLED
 
 
 class DatabaseHealthResponse(BaseModel):
@@ -100,6 +109,28 @@ class AuthHealthResponse(BaseModel):
     latency_ms: float | None = Field(default=None, ge=0.0, le=60_000.0)
     checked_at: datetime
     detail: AuthProbeDetail
+
+
+class RedisHealthResponse(BaseModel):
+    """API↔Redis communication health for ``GET /health/redis``.
+
+    Attributes:
+        status: ``healthy`` when Redis is up (or disabled skip); ``unhealthy`` otherwise.
+        reachable: Whether the Redis probe succeeded (disabled skip counts as reachable).
+        latency_ms: Round-trip Redis PING latency when a network probe ran.
+        checked_at: UTC time when the probe ran.
+        detail: Allowlisted explanation of Redis status (never raw errors).
+        required: Whether Redis is required for readiness (``REDIS_ENABLED``).
+    """
+
+    model_config = ConfigDict(extra="forbid", use_enum_values=True)
+
+    status: Literal["healthy", "unhealthy"]
+    reachable: bool
+    latency_ms: float | None = Field(default=None, ge=0.0, le=60_000.0)
+    checked_at: datetime
+    detail: RedisProbeDetail
+    required: bool = False
 
 
 class ReadinessResponse(BaseModel):

--- a/modules/api/src/papita_txnsapi/schemas/query_params.py
+++ b/modules/api/src/papita_txnsapi/schemas/query_params.py
@@ -1,22 +1,21 @@
 """FastAPI query-parameter models and dependencies for list and report routes.
 
-This module bridges HTTP query strings to service-layer keyword arguments for
-transactions, transfer movements, and reports. OpenAPI ``Query`` dependencies
-build Pydantic models; each model exposes ``service_kwargs()`` that normalizes
-enums, date windows, and defaults before calling ``TransactionsService`` /
-``ReportService``.
+Bridges HTTP query strings to service-layer keyword arguments for transactions,
+transfer movements, and reports. OpenAPI ``Query`` dependencies build Pydantic
+models; each model exposes ``service_kwargs()`` that normalizes enums, date
+windows, and defaults before calling ``TransactionsService`` / ``ReportService``.
 
-Key types:
-    * ``TransactionListQuery`` / ``MovementListQuery`` — list filters.
-    * ``ReportSpendingQuery``, ``ReportCashFlowQuery``, ``ReportTrendsQuery``,
-      ``ReportExportQuery`` — report filters with window/enum validators.
-    * Matching ``*ServiceKwargs`` TypedDicts — typed kwargs for service methods.
-    * ``get_*_query`` helpers — FastAPI ``Depends`` factories for those models.
-
-Calendar dates for reports are converted to inclusive UTC day bounds via
+Calendar dates for reports become inclusive UTC day bounds via
 ``date_to_start_datetime`` / ``date_to_end_datetime``. Export formats ``xlsx`` and
-``pdf`` are deferred (see ``DEFERRED_EXPORT_FORMATS``) and must be rejected by the
+``pdf`` are deferred (``DEFERRED_EXPORT_FORMATS``) and must be rejected by the
 router with HTTP 501 rather than forwarded to the service.
+
+Key exports:
+    DEFERRED_EXPORT_FORMATS: ``xlsx`` / ``pdf`` formats for router 501 handling.
+    date_to_start_datetime / date_to_end_datetime: Inclusive UTC day bounds.
+    TransactionListQuery / MovementListQuery (+ ``*ServiceKwargs``, ``get_*``).
+    ReportSpendingQuery / ReportCashFlowQuery / ReportTrendsQuery /
+    ReportExportQuery (+ matching TypedDicts and ``get_report_*_query`` helpers).
 """
 
 from __future__ import annotations
@@ -37,6 +36,12 @@ _ALLOWED_EXPORT_REPORT_TYPES = frozenset({"spending", "cash-flow", "trends"})
 _ALLOWED_EXPORT_FORMATS = frozenset({"csv", "json"})
 # Accepted in query validation but not implemented; routers should return HTTP 501.
 DEFERRED_EXPORT_FORMATS = frozenset({"xlsx", "pdf"})
+"""Export formats that validate on the query model but must not reach the service.
+
+Routers check ``ReportExportQuery.is_deferred_format`` (or membership in this set)
+and respond with HTTP 501. ``service_kwargs()`` raises ``ValueError`` if called
+for these formats.
+"""
 
 
 def date_to_start_datetime(value: date) -> datetime:
@@ -378,6 +383,10 @@ class ReportSpendingQuery(BaseModel):
 
         Returns:
             Typed keyword arguments with UTC-bounded ``start_date`` / ``end_date``.
+
+        Note:
+            Call after model validation; invalid windows or ``group_by`` values
+            raise ``ValueError`` during construction, not here.
         """
         return ReportSpendingServiceKwargs(
             start_date=date_to_start_datetime(self.start_date),
@@ -416,6 +425,10 @@ class ReportCashFlowQuery(BaseModel):
 
         Returns:
             Typed keyword arguments with UTC-bounded dates and refresh flag.
+
+        Note:
+            Call after model validation; an inverted date window raises
+            ``ValueError`` during construction, not here.
         """
         return ReportCashFlowServiceKwargs(
             start_date=date_to_start_datetime(self.start_date),
@@ -569,7 +582,11 @@ def get_report_spending_query(  # pylint: disable=too-many-arguments
         account_id: Optional account filter.
 
     Returns:
-        Populated ``ReportSpendingQuery`` (may raise ``ValueError`` via validators).
+        Populated ``ReportSpendingQuery`` for the route handler.
+
+    Raises:
+        ValueError: When the date window is inverted or ``group_by`` is not allowlisted
+            (raised by the model validator during construction).
     """
     return ReportSpendingQuery(
         start_date=start_date,
@@ -595,7 +612,10 @@ def get_report_cash_flow_query(
         refresh_balances: Whether to refresh balance MVs before the query.
 
     Returns:
-        Populated ``ReportCashFlowQuery`` (may raise ``ValueError`` via validators).
+        Populated ``ReportCashFlowQuery`` for the route handler.
+
+    Raises:
+        ValueError: When the date window is inverted (model validator).
     """
     return ReportCashFlowQuery(
         start_date=start_date,
@@ -626,6 +646,10 @@ def get_report_trends_query(  # pylint: disable=too-many-arguments
 
     Returns:
         Populated ``ReportTrendsQuery`` with resolved window after validation.
+
+    Raises:
+        ValueError: When ``period`` is not allowlisted or the resolved window is
+            inverted (model validator).
     """
     return ReportTrendsQuery(
         months=months,
@@ -661,7 +685,12 @@ def get_report_export_query(  # pylint: disable=too-many-arguments
         period: Trends bucket when exporting trends.
 
     Returns:
-        Populated ``ReportExportQuery`` (deferred formats remain valid for 501 handling).
+        Populated ``ReportExportQuery``. Deferred formats remain constructible so
+        the router can return HTTP 501.
+
+    Raises:
+        ValueError: When the window, report type, or non-deferred format fields
+            fail allowlist validation (model validator).
     """
     return ReportExportQuery(
         report_type=report_type,

--- a/modules/api/tests/conftest.py
+++ b/modules/api/tests/conftest.py
@@ -16,6 +16,9 @@ os.environ.setdefault("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characte
 # Force local HS256 for unit tests even when environments/local/.env has supabase Auth.
 os.environ["AUTH_PROVIDER"] = "local"
 os.environ.setdefault("AUTH_RATE_LIMIT_ENABLED", "false")
+os.environ.setdefault("API_RATE_LIMIT_ENABLED", "false")
+os.environ.setdefault("REDIS_ENABLED", "false")
+os.environ.setdefault("REDIS_RATE_LIMIT_ENABLED", "false")
 # Prefer process env over environments/$PAPITA_ENV/.env for unit tests (live tests set URLs explicitly).
 if "DATABASE_URL" not in os.environ and "TEST_DATABASE_URL" not in os.environ:
     os.environ["DATABASE_URL"] = ""
@@ -152,3 +155,11 @@ def reports_client() -> tuple[TestClient, UsersDTO, MagicMock]:
     test_client = TestClient(app)
     yield test_client, owner, mock_service
     app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def fake_redis():
+    """In-memory Redis client for unit tests (decode_responses=True)."""
+    import fakeredis
+
+    return fakeredis.FakeRedis(decode_responses=True)

--- a/modules/api/tests/test_api_rate_limit.py
+++ b/modules/api/tests/test_api_rate_limit.py
@@ -1,0 +1,148 @@
+"""Tenant API rate-limit tiers (PPT-043 Free / Pro / Enterprise)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from auth_helpers import make_user
+from papita_txnsapi.config.settings import get_settings
+from papita_txnsapi.core.api_tier import ApiTier, limits_for_tier, resolve_api_tier
+from papita_txnsapi.core.rate_limit import InMemoryRateLimiter
+from papita_txnsapi.core.redis_keys import redis_key
+from papita_txnsapi.core.security import AuthSecurityManager
+from papita_txnsapi.dependencies.auth import get_current_owner
+from papita_txnsapi.dependencies.services import get_accounts_service
+from papita_txnsapi.main import create_app
+
+
+def _enable_api_limits(monkeypatch: pytest.MonkeyPatch, *, tier: str = "free", per_minute: int = 2) -> None:
+    monkeypatch.setenv("API_RATE_LIMIT_ENABLED", "true")
+    monkeypatch.setenv("API_RATE_LIMIT_DEFAULT_TIER", tier)
+    monkeypatch.setenv("API_RATE_LIMIT_FREE_PER_MINUTE", str(per_minute))
+    monkeypatch.setenv("API_RATE_LIMIT_FREE_PER_DAY", "1000")
+    monkeypatch.setenv("API_RATE_LIMIT_PRO_PER_MINUTE", "5")
+    monkeypatch.setenv("API_RATE_LIMIT_PRO_PER_DAY", "10000")
+    get_settings.cache_clear()
+    AuthSecurityManager.reset_instances()
+    InMemoryRateLimiter().reset()
+
+
+def _accounts_client_with_owner(owner=None) -> tuple[TestClient, object, MagicMock]:
+    app = create_app()
+    owner = owner or make_user()
+    mock_service = MagicMock()
+    mock_service.get_records.return_value = pd.DataFrame([])
+    app.dependency_overrides[get_current_owner] = lambda: owner
+    app.dependency_overrides[get_accounts_service] = lambda: mock_service
+    return TestClient(app), owner, mock_service
+
+
+class TestApiTierHelpers:
+    """Unit tests for tier resolution and limits."""
+
+    def test_limits_for_free_and_pro(self) -> None:
+        settings = get_settings()
+        free = limits_for_tier(settings, ApiTier.FREE)
+        pro = limits_for_tier(settings, ApiTier.PRO)
+        enterprise = limits_for_tier(settings, ApiTier.ENTERPRISE)
+        assert free.per_minute == settings.API_RATE_LIMIT_FREE_PER_MINUTE
+        assert pro.per_minute == settings.API_RATE_LIMIT_PRO_PER_MINUTE
+        assert enterprise.unlimited is True
+
+    def test_resolve_default_tier(self) -> None:
+        settings = get_settings()
+        owner = make_user()
+        assert resolve_api_tier(settings, owner.id) == ApiTier(settings.API_RATE_LIMIT_DEFAULT_TIER)
+
+    def test_resolve_redis_override(self, fake_redis: object) -> None:
+        settings = get_settings()
+        owner = make_user()
+        fake_redis.set(redis_key(owner.id, "api_tier"), "pro")
+        assert resolve_api_tier(settings, owner.id, fake_redis) is ApiTier.PRO
+
+
+class TestTenantApiRateLimit:
+    """HTTP tests for tenant-scoped API quotas on protected routers."""
+
+    def test_allows_under_limit_and_sets_headers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _enable_api_limits(monkeypatch, per_minute=3)
+        client, _, _ = _accounts_client_with_owner()
+        try:
+            response = client.get("/api/v1/accounts")
+            assert response.status_code == 200
+            assert response.headers.get("X-RateLimit-Limit") == "3"
+            assert response.headers.get("X-RateLimit-Tier") == "free"
+            assert int(response.headers.get("X-RateLimit-Remaining", "0")) >= 0
+        finally:
+            get_settings.cache_clear()
+            monkeypatch.setenv("API_RATE_LIMIT_ENABLED", "false")
+
+    def test_returns_429_when_minute_quota_exceeded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _enable_api_limits(monkeypatch, per_minute=2)
+        client, _, _ = _accounts_client_with_owner()
+        try:
+            assert client.get("/api/v1/accounts").status_code == 200
+            assert client.get("/api/v1/accounts").status_code == 200
+            blocked = client.get("/api/v1/accounts")
+            assert blocked.status_code == 429
+            assert "Retry-After" in blocked.headers
+            assert blocked.headers.get("X-RateLimit-Tier") == "free"
+            assert "rate limit" in blocked.json()["detail"].lower()
+        finally:
+            get_settings.cache_clear()
+            monkeypatch.setenv("API_RATE_LIMIT_ENABLED", "false")
+
+    def test_enterprise_is_unlimited(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _enable_api_limits(monkeypatch, tier="enterprise", per_minute=1)
+        client, _, _ = _accounts_client_with_owner()
+        try:
+            for _ in range(5):
+                assert client.get("/api/v1/accounts").status_code == 200
+            assert client.get("/api/v1/accounts").headers.get("X-RateLimit-Tier") == "enterprise"
+        finally:
+            get_settings.cache_clear()
+            monkeypatch.setenv("API_RATE_LIMIT_ENABLED", "false")
+
+    def test_pro_tier_via_redis_override(self, monkeypatch: pytest.MonkeyPatch, fake_redis: object) -> None:
+        _enable_api_limits(monkeypatch, tier="free", per_minute=1)
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        monkeypatch.setenv("API_RATE_LIMIT_PRO_PER_MINUTE", "3")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        assert owner.id is not None
+        fake_redis.set(redis_key(owner.id, "api_tier"), "pro")
+        mock_service = MagicMock()
+        mock_service.get_records.return_value = pd.DataFrame([])
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_accounts_service] = lambda: mock_service
+            with TestClient(app) as client:
+                assert client.get("/api/v1/accounts").status_code == 200
+                assert client.get("/api/v1/accounts").status_code == 200
+                third = client.get("/api/v1/accounts")
+                assert third.status_code == 200
+                assert third.headers.get("X-RateLimit-Tier") == "pro"
+                blocked = client.get("/api/v1/accounts")
+                assert blocked.status_code == 429
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("API_RATE_LIMIT_ENABLED", "false")
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+
+    def test_disabled_skips_enforcement(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("API_RATE_LIMIT_ENABLED", "false")
+        monkeypatch.setenv("API_RATE_LIMIT_FREE_PER_MINUTE", "1")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+        client, _, _ = _accounts_client_with_owner()
+        for _ in range(3):
+            assert client.get("/api/v1/accounts").status_code == 200

--- a/modules/api/tests/test_api_rate_limit.py
+++ b/modules/api/tests/test_api_rate_limit.py
@@ -64,9 +64,63 @@ class TestApiTierHelpers:
         fake_redis.set(redis_key(owner.id, "api_tier"), "pro")
         assert resolve_api_tier(settings, owner.id, fake_redis) is ApiTier.PRO
 
+    def test_resolve_ignores_invalid_redis_tier(self, fake_redis: object) -> None:
+        settings = get_settings()
+        owner = make_user()
+        fake_redis.set(redis_key(owner.id, "api_tier"), "gold")
+        assert resolve_api_tier(settings, owner.id, fake_redis) == ApiTier(
+            settings.API_RATE_LIMIT_DEFAULT_TIER
+        )
+
+    def test_resolve_redis_error_falls_back(self) -> None:
+        settings = get_settings()
+        owner = make_user()
+        client = MagicMock()
+        from redis.exceptions import RedisError
+
+        client.get.side_effect = RedisError("boom")
+        assert resolve_api_tier(settings, owner.id, client) == ApiTier(settings.API_RATE_LIMIT_DEFAULT_TIER)
+
+    def test_resolve_invalid_default_tier_is_free(self) -> None:
+        settings = MagicMock()
+        settings.API_RATE_LIMIT_DEFAULT_TIER = "not-a-tier"
+        owner = make_user()
+        assert resolve_api_tier(settings, owner.id) is ApiTier.FREE
+
+
+class TestMergeLimitHeaders:
+    """Unit coverage for minute/day header selection."""
+
+    def test_merge_limit_header_branches(self) -> None:
+        from papita_txnsapi.core.rate_limit import RateLimitResult
+        from papita_txnsapi.dependencies.rate_limit import _client_ip, _merge_limit_headers
+
+        unlimited = RateLimitResult(allowed=True, limit=0, remaining=0, reset_at=1)
+        minute = RateLimitResult(allowed=True, limit=10, remaining=2, reset_at=10)
+        day = RateLimitResult(allowed=True, limit=100, remaining=90, reset_at=20)
+        assert _merge_limit_headers(unlimited, unlimited) == {}
+        assert _merge_limit_headers(unlimited, day)["X-RateLimit-Limit"] == "100"
+        assert _merge_limit_headers(minute, unlimited)["X-RateLimit-Limit"] == "10"
+        assert _merge_limit_headers(minute, day)["X-RateLimit-Remaining"] == "2"
+
+        request = MagicMock()
+        request.client = None
+        assert _client_ip(request) == "unknown"
+
 
 class TestTenantApiRateLimit:
     """HTTP tests for tenant-scoped API quotas on protected routers."""
+
+    def test_missing_owner_id_returns_401(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _enable_api_limits(monkeypatch, per_minute=10)
+        owner = make_user()
+        owner.id = None
+        client, _, _ = _accounts_client_with_owner(owner=owner)
+        try:
+            assert client.get("/api/v1/accounts").status_code == 401
+        finally:
+            get_settings.cache_clear()
+            monkeypatch.setenv("API_RATE_LIMIT_ENABLED", "false")
 
     def test_allows_under_limit_and_sets_headers(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _enable_api_limits(monkeypatch, per_minute=3)

--- a/modules/api/tests/test_auth_denylist.py
+++ b/modules/api/tests/test_auth_denylist.py
@@ -1,0 +1,90 @@
+"""Tests for Redis JWT denylist wiring on auth + logout (PPT-043 P2)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from auth_helpers import make_user
+from papita_txnsapi.config.settings import get_settings
+from papita_txnsapi.core.rate_limit import InMemoryRateLimiter
+from papita_txnsapi.core.security import AuthSecurityManager
+from papita_txnsapi.dependencies.services import get_users_service
+from papita_txnsapi.main import create_app
+
+
+class TestLogoutDenylist:
+    """Local logout + protected route rejection when Redis denylist is active."""
+
+    def test_local_logout_denylists_token(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        assert owner.id is not None
+        mock_users = MagicMock()
+        mock_users.get_owner.return_value = owner
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_users_service] = lambda: mock_users
+            settings = get_settings()
+            token = AuthSecurityManager(settings).generate_token(str(owner.id))
+
+            with TestClient(app) as client:
+                me_ok = client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+                logout = client.post(
+                    "/api/v1/auth/logout",
+                    json={"refresh_token": "unused-local", "access_token": token},
+                )
+                me_denied = client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+
+        assert me_ok.status_code == 200
+        assert logout.status_code == 204
+        assert me_denied.status_code == 401
+
+    def test_denylist_fail_closed_returns_503(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When Redis is required but the client is missing, protected routes 503."""
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        mock_users = MagicMock()
+        mock_users.get_owner.return_value = owner
+
+        with patch("papita_txnsapi.main.init_redis", return_value=None):
+            app = create_app()
+            app.state.redis = None
+            app.dependency_overrides[get_users_service] = lambda: mock_users
+            settings = get_settings()
+            token = AuthSecurityManager(settings).generate_token(str(owner.id))
+
+            with TestClient(app) as client:
+                response = client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+
+        assert response.status_code == 503
+        assert "revocation" in response.json()["detail"].lower()

--- a/modules/api/tests/test_cache_bypass_owner_none.py
+++ b/modules/api/tests/test_cache_bypass_owner_none.py
@@ -1,0 +1,151 @@
+"""Cover Redis cache BYPASS branches when ``owner.id`` is missing (Codecov patch)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from unittest.mock import MagicMock
+
+import pandas as pd
+from fastapi import Response
+
+from auth_helpers import make_user
+from papita_txnsapi.config.settings import get_settings
+from papita_txnsapi.dependencies.pagination import PaginationParams
+from papita_txnsapi.routers.v1 import accounts, categories, reports, transactions
+from papita_txnsapi.schemas.query_params import (
+    ReportCashFlowQuery,
+    ReportSpendingQuery,
+    ReportTrendsQuery,
+    TransactionListQuery,
+)
+from papita_txnsmodel.access.transactions.dto import TransactionsDTO
+from papita_txnsmodel.model.enums import TransactionKind, TransactionStatus
+
+
+def _owner_without_id():
+    owner = make_user()
+    owner.id = None
+    return owner
+
+
+class TestCacheBypassOwnerNone:
+    """``X-Cache: BYPASS`` when authenticated owner lacks a primary key."""
+
+    def test_list_accounts_bypass(self) -> None:
+        owner = _owner_without_id()
+        response = Response()
+        service = MagicMock()
+        service.get_records.return_value = pd.DataFrame([])
+        service.balances_service = None
+        accounts.list_accounts(
+            owner,
+            PaginationParams(skip=0, limit=20),
+            service,
+            get_settings(),
+            None,
+            response,
+        )
+        assert response.headers["X-Cache"] == "BYPASS"
+
+    def test_list_categories_bypass(self) -> None:
+        owner = _owner_without_id()
+        response = Response()
+        service = MagicMock()
+        service.get_records.return_value = pd.DataFrame([])
+        categories.list_categories(
+            owner,
+            PaginationParams(skip=0, limit=20),
+            service,
+            get_settings(),
+            None,
+            response,
+        )
+        assert response.headers["X-Cache"] == "BYPASS"
+
+    def test_list_transactions_bypass(self) -> None:
+        owner = _owner_without_id()
+        response = Response()
+        service = MagicMock()
+        service.list_transactions.return_value = (pd.DataFrame([]), 0)
+        transactions.list_transactions(
+            owner,
+            PaginationParams(skip=0, limit=20),
+            service,
+            TransactionListQuery(),
+            get_settings(),
+            None,
+            response,
+        )
+        assert response.headers["X-Cache"] == "BYPASS"
+
+    def test_get_transaction_bypass(self) -> None:
+        owner = _owner_without_id()
+        response = Response()
+        now = datetime.now(timezone.utc)
+        txn = TransactionsDTO(
+            id=uuid.uuid4(),
+            owner_id=uuid.uuid4(),
+            transaction_kind=TransactionKind.EXPENSE,
+            amount=1.0,
+            currency="USD",
+            transaction_ts=now,
+            from_account_id=uuid.uuid4(),
+            category_id=uuid.uuid4(),
+            status=TransactionStatus.COMPLETED,
+            description="x",
+            created_at=now,
+            updated_at=now,
+        )
+        service = MagicMock()
+        service.get.return_value = txn
+        transactions.get_transaction(
+            txn.id,
+            owner,
+            service,
+            get_settings(),
+            None,
+            response,
+        )
+        assert response.headers["X-Cache"] == "BYPASS"
+
+    def test_reports_bypass(self) -> None:
+        owner = _owner_without_id()
+        settings = get_settings()
+        spending_service = MagicMock()
+        spending_service.spending.return_value = {
+            "group_by": "category",
+            "expenses": [],
+            "expense_total": 0.0,
+            "income_total": 0.0,
+        }
+        cash_service = MagicMock()
+        cash_service.cash_flow.return_value = {
+            "inflows": 0.0,
+            "outflows": 0.0,
+            "net": 0.0,
+            "portfolio_total": 0.0,
+        }
+        trends_service = MagicMock()
+        trends_service.trends.return_value = {"period": "month", "series": []}
+
+        for fn, service, filters in (
+            (
+                reports.get_spending_report,
+                spending_service,
+                ReportSpendingQuery(start_date=date(2026, 1, 1), end_date=date(2026, 1, 31)),
+            ),
+            (
+                reports.get_cash_flow_report,
+                cash_service,
+                ReportCashFlowQuery(start_date=date(2026, 1, 1), end_date=date(2026, 1, 31)),
+            ),
+            (
+                reports.get_trends_report,
+                trends_service,
+                ReportTrendsQuery(months=3),
+            ),
+        ):
+            response = Response()
+            fn(owner, service, filters, settings, None, response)
+            assert response.headers["X-Cache"] == "BYPASS"

--- a/modules/api/tests/test_cache_edges.py
+++ b/modules/api/tests/test_cache_edges.py
@@ -1,0 +1,88 @@
+"""Edge / fail-open paths for Redis cache helpers (Codecov patch gaps)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import MagicMock
+
+from redis.exceptions import RedisError
+
+from papita_txnsapi.config.settings import get_settings
+from papita_txnsapi.core.cache import (
+    CacheNamespace,
+    bump_cache_versions,
+    cache_get_json,
+    cache_set_json,
+    get_cache_version,
+    get_versioned_cached_json,
+    set_versioned_cached_json,
+    ttl_for_namespace,
+)
+
+
+class TestCacheFailOpen:
+    """RedisError and invalid payload paths."""
+
+    def test_get_version_none_client(self) -> None:
+        assert get_cache_version(None, uuid.uuid4(), CacheNamespace.ACCOUNTS) == 0
+
+    def test_get_version_redis_error(self) -> None:
+        client = MagicMock()
+        client.get.side_effect = RedisError("boom")
+        assert get_cache_version(client, uuid.uuid4(), CacheNamespace.ACCOUNTS) == 0
+
+    def test_get_version_invalid_int(self, fake_redis: object) -> None:
+        owner_id = uuid.uuid4()
+        from papita_txnsapi.core.cache import version_key
+
+        fake_redis.set(version_key(owner_id, CacheNamespace.ACCOUNTS), "not-int")
+        assert get_cache_version(fake_redis, owner_id, CacheNamespace.ACCOUNTS) == 0
+
+    def test_bump_noop_and_error(self) -> None:
+        bump_cache_versions(None, uuid.uuid4(), CacheNamespace.ACCOUNTS)
+        bump_cache_versions(MagicMock(), None, CacheNamespace.ACCOUNTS)
+        bump_cache_versions(MagicMock(), uuid.uuid4())
+        client = MagicMock()
+        client.pipeline.side_effect = RedisError("boom")
+        bump_cache_versions(client, uuid.uuid4(), CacheNamespace.ACCOUNTS)
+
+    def test_cache_get_edges(self, fake_redis: object) -> None:
+        assert cache_get_json(None, "k") is None
+        client = MagicMock()
+        client.get.side_effect = RedisError("boom")
+        assert cache_get_json(client, "k") is None
+        fake_redis.set("bad-json", "{")
+        assert cache_get_json(fake_redis, "bad-json") is None
+        fake_redis.set("list-json", json.dumps([1]))
+        assert cache_get_json(fake_redis, "list-json") is None
+
+    def test_cache_set_edges(self) -> None:
+        assert cache_set_json(None, "k", {"a": 1}, ttl_seconds=60) is False
+        assert cache_set_json(MagicMock(), "k", {"a": 1}, ttl_seconds=0) is False
+        client = MagicMock()
+        client.setex.side_effect = RedisError("boom")
+        assert cache_set_json(client, "k", {"a": 1}, ttl_seconds=60) is False
+
+    def test_versioned_bypass_and_set_none(self) -> None:
+        owner_id = uuid.uuid4()
+        payload, status = get_versioned_cached_json(None, owner_id, CacheNamespace.ACCOUNTS, "r")
+        assert payload is None and status == "BYPASS"
+        assert (
+            set_versioned_cached_json(
+                None,
+                owner_id,
+                CacheNamespace.ACCOUNTS,
+                "r",
+                {},
+                value={"x": 1},
+                ttl_seconds=60,
+            )
+            is False
+        )
+
+    def test_ttl_defaults_without_settings(self) -> None:
+        assert ttl_for_namespace(None, "transactions") == 15
+        assert ttl_for_namespace(None, CacheNamespace.REPORTS) == 180
+        settings = get_settings()
+        assert ttl_for_namespace(settings, "accounts") == settings.REDIS_CACHE_TTL_ACCOUNTS_SECONDS

--- a/modules/api/tests/test_health.py
+++ b/modules/api/tests/test_health.py
@@ -102,6 +102,8 @@ class TestHealthEndpoints:
         assert payload["database_latency_ms"] == 2.5
         assert payload["auth"] == "skipped"
         assert payload["auth_detail"] == AuthProbeDetail.SKIPPED_LOCAL
+        assert payload["redis"] == "skipped"
+        assert payload["redis_detail"] == "redis disabled"
         assert "version" in payload
         assert "timestamp" in payload
 

--- a/modules/api/tests/test_idempotency_unit.py
+++ b/modules/api/tests/test_idempotency_unit.py
@@ -1,0 +1,117 @@
+"""Unit tests for Redis idempotency helpers (Codecov patch gaps)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import MagicMock
+
+from redis.exceptions import RedisError
+
+from papita_txnsapi.core.idempotency import (
+    _result_from_stored,
+    begin_idempotency,
+    clear_idempotency_pending,
+    complete_idempotency,
+)
+
+
+class TestResultFromStored:
+    """Edge cases for stored Redis payloads."""
+
+    def test_none_is_conflict(self) -> None:
+        assert _result_from_stored(None).state == "conflict"
+
+    def test_invalid_json_is_conflict(self) -> None:
+        assert _result_from_stored("not-json{").state == "conflict"
+
+    def test_non_dict_is_conflict(self) -> None:
+        assert _result_from_stored(json.dumps([1, 2])).state == "conflict"
+
+    def test_pending_is_conflict(self) -> None:
+        assert _result_from_stored(json.dumps({"status": "pending"})).state == "conflict"
+
+    def test_completed_without_dict_body_is_conflict(self) -> None:
+        assert _result_from_stored(json.dumps({"status": "completed", "body": "x"})).state == "conflict"
+
+    def test_completed_with_body_is_hit(self) -> None:
+        result = _result_from_stored(json.dumps({"status": "completed", "body": {"ok": True}}))
+        assert result.state == "hit"
+        assert result.payload == {"ok": True}
+
+
+class TestBeginIdempotency:
+    """Claim / race / fail-open paths."""
+
+    def test_bypass_when_client_or_key_missing(self) -> None:
+        owner_id = uuid.uuid4()
+        assert begin_idempotency(None, owner_id, scope="s", key="k", ttl_seconds=60).state == "bypass"
+        assert begin_idempotency(MagicMock(), owner_id, scope="s", key=None, ttl_seconds=60).state == "bypass"
+        assert begin_idempotency(MagicMock(), owner_id, scope="s", key="  ", ttl_seconds=60).state == "bypass"
+        assert begin_idempotency(MagicMock(), owner_id, scope="s", key="k", ttl_seconds=0).state == "bypass"
+
+    def test_race_lost_then_hit(self, fake_redis: object) -> None:
+        owner_id = uuid.uuid4()
+        client = MagicMock()
+        completed = json.dumps({"status": "completed", "body": {"id": "1"}})
+        client.get.side_effect = [None, completed]
+        client.set.return_value = False
+        result = begin_idempotency(client, owner_id, scope="s", key="race", ttl_seconds=60)
+        assert result.state == "hit"
+        assert result.payload == {"id": "1"}
+
+    def test_race_lost_then_key_vanished_is_miss(self) -> None:
+        owner_id = uuid.uuid4()
+        client = MagicMock()
+        client.get.side_effect = [None, None]
+        client.set.return_value = False
+        assert begin_idempotency(client, owner_id, scope="s", key="race2", ttl_seconds=60).state == "miss"
+
+    def test_redis_error_bypasses(self) -> None:
+        owner_id = uuid.uuid4()
+        client = MagicMock()
+        client.get.side_effect = RedisError("boom")
+        assert begin_idempotency(client, owner_id, scope="s", key="err", ttl_seconds=60).state == "bypass"
+
+
+class TestCompleteAndClear:
+    """complete_idempotency / clear_idempotency_pending edges."""
+
+    def test_complete_noop_guards(self) -> None:
+        owner_id = uuid.uuid4()
+        complete_idempotency(None, owner_id, scope="s", key="k", body={}, ttl_seconds=60)
+        complete_idempotency(MagicMock(), owner_id, scope="s", key=None, body={}, ttl_seconds=60)
+        complete_idempotency(MagicMock(), owner_id, scope="s", key="k", body={}, ttl_seconds=0)
+
+    def test_complete_swallows_redis_error(self) -> None:
+        owner_id = uuid.uuid4()
+        client = MagicMock()
+        client.setex.side_effect = RedisError("boom")
+        complete_idempotency(client, owner_id, scope="s", key="k", body={"a": 1}, ttl_seconds=60)
+
+    def test_clear_pending_deletes_lock(self, fake_redis: object) -> None:
+        owner_id = uuid.uuid4()
+        begun = begin_idempotency(fake_redis, owner_id, scope="s", key="clear-me", ttl_seconds=60)
+        assert begun.state == "miss"
+        clear_idempotency_pending(fake_redis, owner_id, scope="s", key="clear-me")
+        again = begin_idempotency(fake_redis, owner_id, scope="s", key="clear-me", ttl_seconds=60)
+        assert again.state == "miss"
+
+    def test_clear_noop_when_missing_or_completed(self, fake_redis: object) -> None:
+        owner_id = uuid.uuid4()
+        clear_idempotency_pending(None, owner_id, scope="s", key="k")
+        clear_idempotency_pending(fake_redis, owner_id, scope="s", key=None)
+        clear_idempotency_pending(fake_redis, owner_id, scope="s", key="absent")
+        begin_idempotency(fake_redis, owner_id, scope="s", key="done", ttl_seconds=60)
+        complete_idempotency(
+            fake_redis, owner_id, scope="s", key="done", body={"ok": True}, ttl_seconds=60
+        )
+        clear_idempotency_pending(fake_redis, owner_id, scope="s", key="done")
+        replay = begin_idempotency(fake_redis, owner_id, scope="s", key="done", ttl_seconds=60)
+        assert replay.state == "hit"
+
+    def test_clear_swallows_errors(self) -> None:
+        owner_id = uuid.uuid4()
+        client = MagicMock()
+        client.get.side_effect = RedisError("boom")
+        clear_idempotency_pending(client, owner_id, scope="s", key="k")

--- a/modules/api/tests/test_redis_cache.py
+++ b/modules/api/tests/test_redis_cache.py
@@ -1,0 +1,181 @@
+"""Tests for versioned Redis cache and write-path invalidation (PPT-043)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from auth_helpers import make_user
+from papita_txnsapi.config.settings import get_settings
+from papita_txnsapi.core.cache import (
+    CacheNamespace,
+    bump_cache_versions,
+    get_cache_version,
+    get_versioned_cached_json,
+    set_versioned_cached_json,
+)
+from papita_txnsapi.core.rate_limit import InMemoryRateLimiter
+from papita_txnsapi.dependencies.auth import get_current_owner
+from papita_txnsapi.dependencies.services import get_accounts_service, get_categories_service
+from papita_txnsapi.main import create_app
+from papita_txnsmodel.access.accounts.dto import AccountsDTO
+from papita_txnsmodel.access.categories.dto import CategoriesDTO
+from papita_txnsmodel.model.enums import AccountKind, CategoryKind, LedgerSide
+
+
+def _sample_account(owner_id: uuid.UUID) -> AccountsDTO:
+    now = datetime.now(timezone.utc)
+    return AccountsDTO(
+        id=uuid.uuid4(),
+        name="Main Checking",
+        description="Primary",
+        owner_id=owner_id,
+        account_kind=AccountKind.CHECKING,
+        ledger_side=LedgerSide.ASSET,
+        currency="USD",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _sample_category(owner_id: uuid.UUID) -> CategoriesDTO:
+    now = datetime.now(timezone.utc)
+    return CategoriesDTO(
+        id=uuid.uuid4(),
+        name="Groceries",
+        description="Food",
+        tags=["food"],
+        owner_id=owner_id,
+        category_kind=CategoryKind.EXPENSE,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestVersionedCacheHelpers:
+    """Namespace version counters invalidate prior hashed keys."""
+
+    def test_bump_invalidates_prior_entry(self, fake_redis: object) -> None:
+        owner_id = uuid.uuid4()
+        params = {"skip": 0, "limit": 20}
+        assert get_cache_version(fake_redis, owner_id, CacheNamespace.ACCOUNTS) == 0
+        set_versioned_cached_json(
+            fake_redis,
+            owner_id,
+            CacheNamespace.ACCOUNTS,
+            "accounts:list",
+            params,
+            value={"total": 1, "items": [], "skip": 0, "limit": 20},
+            ttl_seconds=60,
+        )
+        hit, status = get_versioned_cached_json(
+            fake_redis, owner_id, CacheNamespace.ACCOUNTS, "accounts:list", params
+        )
+        assert status == "HIT"
+        assert hit is not None
+
+        bump_cache_versions(fake_redis, owner_id, CacheNamespace.ACCOUNTS)
+        miss, status_after = get_versioned_cached_json(
+            fake_redis, owner_id, CacheNamespace.ACCOUNTS, "accounts:list", params
+        )
+        assert status_after == "MISS"
+        assert miss is None
+        assert get_cache_version(fake_redis, owner_id, CacheNamespace.ACCOUNTS) == 1
+
+
+class TestAccountsCacheInvalidation:
+    """Account mutations bump cache so the next list is a miss then rebuild."""
+
+    def test_create_account_busts_list_cache(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        account = _sample_account(owner.id)
+        mock_service = MagicMock()
+        mock_service.get_records.return_value = pd.DataFrame([account.model_dump(mode="python")])
+        mock_service.balances_service.get_balances.return_value = pd.DataFrame(
+            [{"account_id": account.id, "balance": 100.0, "currency": "USD", "owner_id": owner.id}]
+        )
+        mock_service.create_account.return_value = account
+        mock_service.get_with_extension.return_value = (account, None)
+        mock_service.get_balance.return_value = None
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_accounts_service] = lambda: mock_service
+            with TestClient(app) as client:
+                first = client.get("/api/v1/accounts")
+                second = client.get("/api/v1/accounts")
+                create = client.post(
+                    "/api/v1/accounts",
+                    json={
+                        "name": "Main Checking",
+                        "account_kind": "checking",
+                        "ledger_side": "asset",
+                        "currency": "USD",
+                        "banking_details": {"entity": "Example Bank"},
+                    },
+                )
+                third = client.get("/api/v1/accounts")
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.headers.get("X-Cache") in {"MISS", "BYPASS"}
+        assert second.headers.get("X-Cache") == "HIT"
+        assert create.status_code == 201
+        assert third.status_code == 200
+        assert third.headers.get("X-Cache") == "MISS"
+        assert mock_service.get_records.call_count == 2
+
+
+class TestCategoriesCache:
+    """Categories list uses Redis cache-aside."""
+
+    def test_list_categories_cache_hit(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        category = _sample_category(owner.id)
+        mock_service = MagicMock()
+        mock_service.get_records.return_value = pd.DataFrame([category.model_dump(mode="python")])
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_categories_service] = lambda: mock_service
+            with TestClient(app) as client:
+                first = client.get("/api/v1/categories")
+                second = client.get("/api/v1/categories")
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert second.headers.get("X-Cache") == "HIT"
+        assert mock_service.get_records.call_count == 1

--- a/modules/api/tests/test_redis_cache.py
+++ b/modules/api/tests/test_redis_cache.py
@@ -179,3 +179,33 @@ class TestCategoriesCache:
         assert second.status_code == 200
         assert second.headers.get("X-Cache") == "HIT"
         assert mock_service.get_records.call_count == 1
+
+    def test_list_categories_with_parent_filter(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        parent_id = uuid.uuid4()
+        child = _sample_category(owner.id)
+        child.parent_id = parent_id
+        mock_service = MagicMock()
+        mock_service.get_records.return_value = pd.DataFrame([child.model_dump(mode="python")])
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_categories_service] = lambda: mock_service
+            with TestClient(app) as client:
+                response = client.get("/api/v1/categories", params={"parent_id": str(parent_id)})
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert response.status_code == 200
+        assert response.json()["total"] == 1

--- a/modules/api/tests/test_redis_client.py
+++ b/modules/api/tests/test_redis_client.py
@@ -1,0 +1,108 @@
+"""Unit tests for Redis client lifecycle and probes (Codecov patch gaps)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from redis.exceptions import RedisError
+
+from papita_txnsapi.core.redis import (
+    RedisProbeDetail,
+    _safe_latency_ms,
+    close_redis,
+    get_redis_from_app,
+    init_redis,
+    ping_redis,
+)
+
+
+class TestSafeLatency:
+    """Finite latency clamping."""
+
+    def test_normal_and_clamped(self) -> None:
+        assert _safe_latency_ms(0.001) == 1.0
+        assert _safe_latency_ms(-1.0) == 0.0
+        assert _safe_latency_ms(float("nan")) == 0.0
+        assert _safe_latency_ms(100.0) == 60_000.0  # capped at _MAX_LATENCY_MS
+
+
+class TestInitAndClose:
+    """init_redis / close_redis branches."""
+
+    def test_disabled_returns_none(self) -> None:
+        settings = MagicMock(REDIS_ENABLED=False)
+        assert init_redis(settings) is None
+
+    def test_enabled_without_url_raises(self) -> None:
+        settings = MagicMock(REDIS_ENABLED=True, REDIS_URL="")
+        with pytest.raises(ValueError, match="REDIS_URL"):
+            init_redis(settings)
+
+    def test_enabled_pings_and_returns_client(self) -> None:
+        settings = MagicMock(REDIS_ENABLED=True, REDIS_URL="redis://localhost:6379/0", REDIS_MAX_CONNECTIONS=5)
+        fake_client = MagicMock()
+        with (
+            patch("papita_txnsapi.core.redis.ConnectionPool.from_url") as from_url,
+            patch("papita_txnsapi.core.redis.Redis", return_value=fake_client) as redis_cls,
+        ):
+            from_url.return_value = MagicMock()
+            client = init_redis(settings)
+        assert client is fake_client
+        fake_client.ping.assert_called_once()
+        redis_cls.assert_called_once()
+
+    def test_close_none_is_noop(self) -> None:
+        close_redis(None)
+
+    def test_close_disconnects_pool(self) -> None:
+        pool = MagicMock()
+        client = MagicMock()
+        client.connection_pool = pool
+        close_redis(client)
+        client.close.assert_called_once()
+        pool.disconnect.assert_called_once()
+
+    def test_close_swallows_errors(self) -> None:
+        client = MagicMock()
+        client.close.side_effect = RuntimeError("close failed")
+        close_redis(client)
+
+
+class TestPingRedis:
+    """ping_redis detail paths."""
+
+    def test_disabled_when_optional_and_no_client(self) -> None:
+        result = ping_redis(None, required=False)
+        assert result.connected is True
+        assert result.detail is RedisProbeDetail.DISABLED
+
+    def test_client_unavailable_when_required(self) -> None:
+        result = ping_redis(None, required=True)
+        assert result.connected is False
+        assert result.detail is RedisProbeDetail.CLIENT_UNAVAILABLE
+        assert result.required is True
+
+    def test_healthy_ping(self) -> None:
+        client = MagicMock()
+        with patch("papita_txnsapi.core.redis.time.perf_counter", side_effect=[1.0, 1.002]):
+            result = ping_redis(client, required=True)
+        assert result.connected is True
+        assert result.detail is RedisProbeDetail.HEALTHY
+        assert result.latency_ms == 2.0
+
+    def test_probe_failed_on_redis_error(self) -> None:
+        client = MagicMock()
+        client.ping.side_effect = RedisError("down")
+        result = ping_redis(client, required=True)
+        assert result.connected is False
+        assert result.detail is RedisProbeDetail.PROBE_FAILED
+
+
+class TestGetRedisFromApp:
+    """App state helper."""
+
+    def test_reads_app_state(self) -> None:
+        app = MagicMock()
+        app.state.redis = "client"
+        assert get_redis_from_app(app) == "client"

--- a/modules/api/tests/test_redis_health.py
+++ b/modules/api/tests/test_redis_health.py
@@ -100,3 +100,35 @@ class TestRedisHealth:
         assert payload["detail"] == RedisProbeDetail.HEALTHY
         assert "checked_at" in payload
         datetime.fromisoformat(payload["checked_at"].replace("Z", "+00:00"))
+
+    @patch("papita_txnsapi.routers.v1.health.probe_database", return_value=_connected_db())
+    @patch("papita_txnsapi.routers.v1.health.probe_supabase_auth", return_value=_auth_skipped())
+    @patch(
+        "papita_txnsapi.routers.v1.health.ping_redis",
+        return_value=RedisProbeResult(
+            connected=False,
+            latency_ms=None,
+            detail=RedisProbeDetail.PROBE_FAILED,
+            required=True,
+        ),
+    )
+    def test_composite_health_degraded_when_redis_down(
+        self,
+        _mock_redis: object,
+        _mock_auth: object,
+        _mock_db: object,
+        monkeypatch: object,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        from papita_txnsapi.config.settings import get_settings
+
+        get_settings.cache_clear()
+        with patch("papita_txnsapi.main.init_redis", return_value=MagicMock()):
+            with TestClient(create_app()) as client:
+                response = client.get("/api/v1/health")
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert response.status_code == 200
+        assert response.json()["status"] == "degraded"
+        assert response.json()["redis"] == "disconnected"

--- a/modules/api/tests/test_redis_health.py
+++ b/modules/api/tests/test_redis_health.py
@@ -1,0 +1,102 @@
+"""Tests for Redis health probes (PPT-043)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from papita_txnsapi.core.auth_health import AuthProbeDetail, AuthProbeResult
+from papita_txnsapi.core.db_health import DatabaseProbeDetail, DatabaseProbeResult
+from papita_txnsapi.core.redis import RedisProbeDetail, RedisProbeResult
+from papita_txnsapi.main import create_app
+
+
+def _connected_db() -> DatabaseProbeResult:
+    return DatabaseProbeResult(connected=True, latency_ms=1.0, detail=DatabaseProbeDetail.HEALTHY)
+
+
+def _auth_skipped() -> AuthProbeResult:
+    return AuthProbeResult(
+        reachable=True,
+        latency_ms=None,
+        detail=AuthProbeDetail.SKIPPED_LOCAL,
+        provider="local",
+    )
+
+
+class TestRedisHealth:
+    """Redis component of health / ready probes."""
+
+    def test_redis_health_skipped_when_disabled(self, client: TestClient) -> None:
+        response = client.get("/api/v1/health/redis")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["status"] == "healthy"
+        assert payload["reachable"] is True
+        assert payload["required"] is False
+        assert payload["detail"] == RedisProbeDetail.DISABLED
+
+    @patch("papita_txnsapi.routers.v1.health.probe_database", return_value=_connected_db())
+    @patch("papita_txnsapi.routers.v1.health.probe_supabase_auth", return_value=_auth_skipped())
+    @patch(
+        "papita_txnsapi.routers.v1.health.ping_redis",
+        return_value=RedisProbeResult(
+            connected=False,
+            latency_ms=None,
+            detail=RedisProbeDetail.PROBE_FAILED,
+            required=True,
+        ),
+    )
+    def test_ready_503_when_redis_required_and_down(
+        self,
+        _mock_redis: object,
+        _mock_auth: object,
+        _mock_db: object,
+        monkeypatch: object,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        from papita_txnsapi.config.settings import get_settings
+
+        get_settings.cache_clear()
+        with patch("papita_txnsapi.main.init_redis", return_value=MagicMock()):
+            with TestClient(create_app()) as client:
+                response = client.get("/api/v1/health/ready")
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert response.status_code == 503
+        assert response.json() == {"ready": False}
+
+    @patch(
+        "papita_txnsapi.routers.v1.health.ping_redis",
+        return_value=RedisProbeResult(
+            connected=True,
+            latency_ms=0.5,
+            detail=RedisProbeDetail.HEALTHY,
+            required=True,
+        ),
+    )
+    def test_redis_health_connected_when_enabled(
+        self,
+        _mock_redis: object,
+        monkeypatch: object,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        from papita_txnsapi.config.settings import get_settings
+
+        get_settings.cache_clear()
+        with patch("papita_txnsapi.main.init_redis", return_value=MagicMock()):
+            with TestClient(create_app()) as client:
+                response = client.get("/api/v1/health/redis")
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["status"] == "healthy"
+        assert payload["latency_ms"] == 0.5
+        assert payload["detail"] == RedisProbeDetail.HEALTHY
+        assert "checked_at" in payload
+        datetime.fromisoformat(payload["checked_at"].replace("Z", "+00:00"))

--- a/modules/api/tests/test_redis_keys.py
+++ b/modules/api/tests/test_redis_keys.py
@@ -46,3 +46,23 @@ class TestBrokerKeyPrefix:
         broker = RedisBroker(fake_redis, BrokerSettings(enabled=True))
         assert broker.enqueue("job-1") is True
         assert fake_redis.llen(redis_key("jobs")) == 1
+
+    def test_publish_prefixes_channel(self, fake_redis: object, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PAPITA_ENV", "local")
+        broker = RedisBroker(fake_redis, BrokerSettings(enabled=True))
+        assert broker.publish("invalidate", "accounts") is True
+        assert broker.publish("papita:local:channel:custom", "msg") is True
+
+    def test_disabled_and_redis_errors(self) -> None:
+        from unittest.mock import MagicMock
+
+        from redis.exceptions import RedisError
+
+        assert RedisBroker(None, BrokerSettings(enabled=True)).enqueue("x") is False
+        assert RedisBroker(MagicMock(), BrokerSettings(enabled=False)).publish("c", "m") is False
+        client = MagicMock()
+        client.lpush.side_effect = RedisError("boom")
+        client.publish.side_effect = RedisError("boom")
+        broker = RedisBroker(client, BrokerSettings(enabled=True))
+        assert broker.enqueue("x") is False
+        assert broker.publish("c", "m") is False

--- a/modules/api/tests/test_redis_keys.py
+++ b/modules/api/tests/test_redis_keys.py
@@ -1,0 +1,48 @@
+"""Tests for Redis key namespacing (PPT-043 hardening)."""
+
+from __future__ import annotations
+
+import pytest
+
+from papita_txnsapi.config.settings import get_settings
+from papita_txnsapi.core.broker import BrokerSettings, RedisBroker
+from papita_txnsapi.core.cache import CacheNamespace, ttl_for_namespace
+from papita_txnsapi.core.redis_keys import redis_key, redis_key_prefix
+
+
+class TestRedisKeys:
+    """``papita:{env}:…`` prefix helpers."""
+
+    def test_prefix_follows_papita_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PAPITA_ENV", "staging")
+        assert redis_key_prefix() == "papita:staging:"
+        assert redis_key("ratelimit", "auth-login:1.1.1.1").startswith("papita:staging:")
+
+    def test_explicit_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PAPITA_ENV", "local")
+        assert redis_key("a", "b", env="production") == "papita:production:a:b"
+
+    def test_local_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("PAPITA_ENV", raising=False)
+        assert redis_key_prefix() == "papita:local:"
+
+
+class TestPerRouteTtls:
+    """Per-namespace cache TTLs (not a single global default)."""
+
+    def test_namespace_defaults(self) -> None:
+        settings = get_settings()
+        assert ttl_for_namespace(settings, CacheNamespace.ACCOUNTS) == 60
+        assert ttl_for_namespace(settings, CacheNamespace.CATEGORIES) == 300
+        assert 120 <= ttl_for_namespace(settings, CacheNamespace.REPORTS) <= 300
+        assert ttl_for_namespace(settings, CacheNamespace.TRANSACTIONS) == 15
+
+
+class TestBrokerKeyPrefix:
+    """Broker scaffold uses env-prefixed keys."""
+
+    def test_enqueue_uses_papita_env_prefix(self, fake_redis: object, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PAPITA_ENV", "local")
+        broker = RedisBroker(fake_redis, BrokerSettings(enabled=True))
+        assert broker.enqueue("job-1") is True
+        assert fake_redis.llen(redis_key("jobs")) == 1

--- a/modules/api/tests/test_redis_rate_limit.py
+++ b/modules/api/tests/test_redis_rate_limit.py
@@ -1,0 +1,31 @@
+"""Tests for Redis distributed rate limiting (PPT-043)."""
+
+from __future__ import annotations
+
+from papita_txnsapi.core.rate_limit import RedisRateLimiter
+from papita_txnsapi.core.redis_keys import redis_key
+
+
+class TestRedisRateLimiter:
+    """Atomic Lua sliding-window limiter shared via FakeRedis."""
+
+    def test_shared_counter_across_limiter_instances(self, fake_redis: object) -> None:
+        limiter_a = RedisRateLimiter(fake_redis)
+        limiter_b = RedisRateLimiter(fake_redis)
+        key = "auth-login:127.0.0.1"
+
+        first = limiter_a.check(key, limit=2, window_seconds=60)
+        second = limiter_b.check(key, limit=2, window_seconds=60)
+        blocked = limiter_a.check(key, limit=2, window_seconds=60)
+
+        assert first.allowed is True
+        assert second.allowed is True
+        assert blocked.allowed is False
+        assert blocked.remaining == 0
+        assert blocked.limit == 2
+        assert fake_redis.exists(redis_key("ratelimit", key)) == 1
+
+    def test_non_positive_limit_always_allows(self, fake_redis: object) -> None:
+        limiter = RedisRateLimiter(fake_redis)
+        result = limiter.check("auth-login:1.1.1.1", limit=0, window_seconds=60)
+        assert result.allowed is True

--- a/modules/api/tests/test_redis_rate_limit.py
+++ b/modules/api/tests/test_redis_rate_limit.py
@@ -63,6 +63,7 @@ class TestRedisRateLimiter:
 
     def test_get_rate_limiter_for_request_uses_redis(self, fake_redis: object, monkeypatch) -> None:
         monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
         monkeypatch.setenv("REDIS_RATE_LIMIT_ENABLED", "true")
         get_settings.cache_clear()
         settings = get_settings()
@@ -76,6 +77,7 @@ class TestRedisRateLimiter:
 
     def test_get_rate_limiter_falls_back_when_client_not_redis(self, monkeypatch) -> None:
         monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
         monkeypatch.setenv("REDIS_RATE_LIMIT_ENABLED", "true")
         get_settings.cache_clear()
         settings = get_settings()

--- a/modules/api/tests/test_redis_rate_limit.py
+++ b/modules/api/tests/test_redis_rate_limit.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from papita_txnsapi.core.rate_limit import RedisRateLimiter
+from unittest.mock import MagicMock
+
+from redis.exceptions import RedisError
+
+from papita_txnsapi.config.settings import get_settings
+from papita_txnsapi.core.rate_limit import (
+    InMemoryRateLimiter,
+    RedisRateLimiter,
+    get_rate_limiter_for_request,
+)
 from papita_txnsapi.core.redis_keys import redis_key
 
 
@@ -29,3 +38,51 @@ class TestRedisRateLimiter:
         limiter = RedisRateLimiter(fake_redis)
         result = limiter.check("auth-login:1.1.1.1", limit=0, window_seconds=60)
         assert result.allowed is True
+
+    def test_fail_open_on_redis_error(self) -> None:
+        client = MagicMock()
+        client.register_script.return_value = MagicMock(side_effect=RedisError("connection lost"))
+        limiter = RedisRateLimiter(client)
+        result = limiter.check("api:owner:min", limit=10, window_seconds=60)
+        assert result.allowed is True
+        assert result.remaining == 10
+
+    def test_evalsha_noscript_falls_back_to_eval(self) -> None:
+        client = MagicMock()
+        script = MagicMock(side_effect=RedisError("NOSCRIPT No matching script"))
+        client.register_script.return_value = script
+        client.eval.return_value = [1, 1, 1.0]
+        limiter = RedisRateLimiter(client)
+        result = limiter.check("api:owner:min", limit=5, window_seconds=60)
+        assert result.allowed is True
+        client.eval.assert_called_once()
+
+    def test_inmemory_non_positive_limit(self) -> None:
+        result = InMemoryRateLimiter().check("k", limit=0, window_seconds=60)
+        assert result.allowed is True
+
+    def test_get_rate_limiter_for_request_uses_redis(self, fake_redis: object, monkeypatch) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_RATE_LIMIT_ENABLED", "true")
+        get_settings.cache_clear()
+        settings = get_settings()
+        request = MagicMock()
+        request.app.state.redis = fake_redis
+        limiter = get_rate_limiter_for_request(request, settings)
+        assert isinstance(limiter, RedisRateLimiter)
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        monkeypatch.setenv("REDIS_RATE_LIMIT_ENABLED", "false")
+
+    def test_get_rate_limiter_falls_back_when_client_not_redis(self, monkeypatch) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_RATE_LIMIT_ENABLED", "true")
+        get_settings.cache_clear()
+        settings = get_settings()
+        request = MagicMock()
+        request.app.state.redis = object()  # not a Redis instance
+        limiter = get_rate_limiter_for_request(request, settings)
+        assert isinstance(limiter, InMemoryRateLimiter)
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        monkeypatch.setenv("REDIS_RATE_LIMIT_ENABLED", "false")

--- a/modules/api/tests/test_reports_redis.py
+++ b/modules/api/tests/test_reports_redis.py
@@ -1,0 +1,97 @@
+"""Report route Redis cache-aside coverage (Codecov patch gaps)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from auth_helpers import make_user
+from papita_txnsapi.config.settings import get_settings
+from papita_txnsapi.core.rate_limit import InMemoryRateLimiter
+from papita_txnsapi.dependencies.auth import get_current_owner
+from papita_txnsapi.dependencies.services import get_report_service
+from papita_txnsapi.main import create_app
+
+_SPENDING_PARAMS = {"start_date": "2026-02-01", "end_date": "2026-02-28"}
+
+
+class TestReportsCache:
+    """Cache HIT/MISS headers on report GETs when Redis is enabled."""
+
+    def test_spending_cache_hit(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        mock_service = MagicMock()
+        mock_service.spending.return_value = {
+            "group_by": "category",
+            "expenses": [],
+            "expense_total": 0.0,
+            "income_total": 0.0,
+        }
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_report_service] = lambda: mock_service
+            with TestClient(app) as client:
+                first = client.get("/api/v1/reports/spending", params=_SPENDING_PARAMS)
+                second = client.get("/api/v1/reports/spending", params=_SPENDING_PARAMS)
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert second.headers.get("X-Cache") == "HIT"
+        assert mock_service.spending.call_count == 1
+
+    def test_cash_flow_and_trends_cache_hit(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        mock_service = MagicMock()
+        mock_service.cash_flow.return_value = {
+            "inflows": 10.0,
+            "outflows": 5.0,
+            "net": 5.0,
+            "portfolio_total": 100.0,
+        }
+        mock_service.trends.return_value = {
+            "period": "month",
+            "series": [],
+        }
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_report_service] = lambda: mock_service
+            with TestClient(app) as client:
+                cf1 = client.get("/api/v1/reports/cash-flow", params=_SPENDING_PARAMS)
+                cf2 = client.get("/api/v1/reports/cash-flow", params=_SPENDING_PARAMS)
+                tr1 = client.get("/api/v1/reports/trends", params={"months": 3})
+                tr2 = client.get("/api/v1/reports/trends", params={"months": 3})
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert cf1.status_code == 200 and cf2.headers.get("X-Cache") == "HIT"
+        assert tr1.status_code == 200 and tr2.headers.get("X-Cache") == "HIT"
+        assert mock_service.cash_flow.call_count == 1
+        assert mock_service.trends.call_count == 1

--- a/modules/api/tests/test_session_store.py
+++ b/modules/api/tests/test_session_store.py
@@ -1,0 +1,49 @@
+"""Tests for Redis session store denylist (PPT-043)."""
+
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import MagicMock
+
+import pytest
+from redis.exceptions import RedisError
+
+from papita_txnsapi.core.redis_keys import redis_key
+from papita_txnsapi.core.session_store import SessionStore, SessionStoreUnavailableError
+
+
+class TestSessionStore:
+    """JWT denylist SET with TTL and fail-closed policy."""
+
+    def test_revoke_and_check(self, fake_redis: object) -> None:
+        store = SessionStore(fake_redis, default_ttl_seconds=3600)
+        token = "eyJhbGciOiJIUzI1NiJ9.example"
+        assert store.is_revoked(token) is False
+        assert store.revoke(token) is True
+        assert store.is_revoked(token) is True
+        digest = hashlib.sha256(token.encode()).hexdigest()
+        assert fake_redis.exists(redis_key("jwt", "denylist", digest)) == 1
+
+    def test_unavailable_without_client_fail_open(self) -> None:
+        store = SessionStore(None, default_ttl_seconds=60, fail_closed=False)
+        assert store.available is False
+        assert store.revoke("token") is False
+        assert store.is_revoked("token") is False
+
+    def test_fail_closed_without_client(self) -> None:
+        store = SessionStore(None, default_ttl_seconds=60, fail_closed=True)
+        with pytest.raises(SessionStoreUnavailableError):
+            store.is_revoked("token")
+
+    def test_fail_closed_on_redis_error(self) -> None:
+        client = MagicMock()
+        client.exists.side_effect = RedisError("boom")
+        store = SessionStore(client, default_ttl_seconds=60, fail_closed=True)
+        with pytest.raises(SessionStoreUnavailableError):
+            store.is_revoked("token")
+
+    def test_fail_open_on_redis_error(self) -> None:
+        client = MagicMock()
+        client.exists.side_effect = RedisError("boom")
+        store = SessionStore(client, default_ttl_seconds=60, fail_closed=False)
+        assert store.is_revoked("token") is False

--- a/modules/api/tests/test_session_store.py
+++ b/modules/api/tests/test_session_store.py
@@ -47,3 +47,17 @@ class TestSessionStore:
         client.exists.side_effect = RedisError("boom")
         store = SessionStore(client, default_ttl_seconds=60, fail_closed=False)
         assert store.is_revoked("token") is False
+
+    def test_revoke_empty_token_and_redis_error(self) -> None:
+        store = SessionStore(MagicMock(), default_ttl_seconds=60)
+        assert store.revoke("") is False
+        client = MagicMock()
+        client.setex.side_effect = RedisError("boom")
+        assert SessionStore(client, default_ttl_seconds=60).revoke("token") is False
+
+    def test_is_revoked_empty_token(self) -> None:
+        assert SessionStore(MagicMock(), default_ttl_seconds=60).is_revoked("") is False
+
+    def test_fail_closed_property(self) -> None:
+        store = SessionStore(None, default_ttl_seconds=60, fail_closed=True)
+        assert store.fail_closed is True

--- a/modules/api/tests/test_settings_engine.py
+++ b/modules/api/tests/test_settings_engine.py
@@ -97,3 +97,26 @@ class TestSettingsEstablish:
         with pytest.warns(UserWarning, match="DATABASE_URL is None"):
             Settings(JWT_SECRET_KEY=_JWT, DATABASE_URL=None)
         mock_establish.assert_called_once_with(connection=None)
+
+    @patch("papita_txnsapi.config.settings.SQLDatabaseConnector.establish")
+    @patch("papita_txnsapi.config.settings.configure_logger")
+    def test_redis_enabled_requires_url(self, _mock_logger: MagicMock, mock_establish: MagicMock) -> None:
+        mock_establish.return_value = SQLDatabaseConnector
+        get_settings.cache_clear()
+        with pytest.raises(ValueError, match="REDIS_URL is required"):
+            Settings(JWT_SECRET_KEY=_JWT, DATABASE_URL=None, REDIS_ENABLED=True, REDIS_URL="")
+
+    @patch("papita_txnsapi.config.settings.SQLDatabaseConnector.establish")
+    @patch("papita_txnsapi.config.settings.configure_logger")
+    def test_redis_enabled_with_url_ok(self, _mock_logger: MagicMock, mock_establish: MagicMock) -> None:
+        mock_establish.return_value = SQLDatabaseConnector
+        get_settings.cache_clear()
+        with pytest.warns(UserWarning, match="DATABASE_URL is None"):
+            settings = Settings(
+                JWT_SECRET_KEY=_JWT,
+                DATABASE_URL=None,
+                REDIS_ENABLED=True,
+                REDIS_URL="redis://localhost:6379/0",
+            )
+        assert settings.REDIS_ENABLED is True
+        assert settings.REDIS_URL == "redis://localhost:6379/0"

--- a/modules/api/tests/test_transactions_redis.py
+++ b/modules/api/tests/test_transactions_redis.py
@@ -163,3 +163,290 @@ class TestTransactionIdempotency:
         assert replay.state == "hit"
         assert replay.payload is not None
         assert replay.payload["amount"] == 1.0
+
+    def test_create_without_owner_id_returns_401(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        owner.id = None
+        expense = _sample_expense(uuid.uuid4())
+        mock_service = MagicMock()
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_transactions_service] = lambda: mock_service
+            with TestClient(app) as client:
+                response = client.post("/api/v1/transactions", json=_create_body(expense))
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert response.status_code == 401
+
+    def test_create_conflict_returns_409(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        expense = _sample_expense(owner.id)
+        mock_service = MagicMock()
+        mock_service.create.return_value = expense
+        begin_idempotency(
+            fake_redis, owner.id, scope="transactions:create", key="pending-key", ttl_seconds=60
+        )
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_transactions_service] = lambda: mock_service
+            with TestClient(app) as client:
+                blocked = client.post(
+                    "/api/v1/transactions",
+                    json=_create_body(expense),
+                    headers={"Idempotency-Key": "pending-key"},
+                )
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert blocked.status_code == 409
+        assert mock_service.create.call_count == 0
+
+    def test_create_failure_clears_pending(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        expense = _sample_expense(owner.id)
+        mock_service = MagicMock()
+        mock_service.create.side_effect = RuntimeError("db down")
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_transactions_service] = lambda: mock_service
+            headers = {"Idempotency-Key": "fail-then-retry"}
+            with TestClient(app, raise_server_exceptions=False) as client:
+                first = client.post("/api/v1/transactions", json=_create_body(expense), headers=headers)
+            mock_service.create.side_effect = None
+            mock_service.create.return_value = expense
+            with TestClient(app) as client:
+                second = client.post("/api/v1/transactions", json=_create_body(expense), headers=headers)
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert first.status_code == 500
+        assert second.status_code == 201
+        assert mock_service.create.call_count == 2
+
+    def test_detail_cache_hit(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        expense = _sample_expense(owner.id)
+        mock_service = MagicMock()
+        mock_service.get.return_value = expense
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_transactions_service] = lambda: mock_service
+            with TestClient(app) as client:
+                first = client.get(f"/api/v1/transactions/{expense.id}")
+                second = client.get(f"/api/v1/transactions/{expense.id}")
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert second.headers.get("X-Cache") == "HIT"
+        assert mock_service.get.call_count == 1
+
+    def test_bulk_create_idempotent_replay(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        expense = _sample_expense(owner.id)
+        mock_service = MagicMock()
+        mock_service.create.return_value = expense
+        body = {"transactions": [_create_body(expense)]}
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_transactions_service] = lambda: mock_service
+            headers = {"Idempotency-Key": "bulk-1"}
+            with TestClient(app) as client:
+                first = client.post("/api/v1/transactions/bulk", json=body, headers=headers)
+                second = client.post("/api/v1/transactions/bulk", json=body, headers=headers)
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert first.status_code == 201
+        assert second.status_code == 201
+        assert first.json()["created"] == second.json()["created"] == 1
+        assert mock_service.create.call_count == 1
+
+    def test_bulk_conflict_returns_409(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        expense = _sample_expense(owner.id)
+        begin_idempotency(
+            fake_redis, owner.id, scope="transactions:bulk", key="bulk-pending", ttl_seconds=60
+        )
+        mock_service = MagicMock()
+        body = {"transactions": [_create_body(expense)]}
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_transactions_service] = lambda: mock_service
+            with TestClient(app) as client:
+                blocked = client.post(
+                    "/api/v1/transactions/bulk",
+                    json=body,
+                    headers={"Idempotency-Key": "bulk-pending"},
+                )
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert blocked.status_code == 409
+        assert mock_service.create.call_count == 0
+
+    def test_bulk_unexpected_error_clears_pending(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        expense = _sample_expense(owner.id)
+        mock_service = MagicMock()
+        # Raise outside ValueError/TypeError so the outer except clears the lock.
+        mock_service.create.side_effect = RuntimeError("boom")
+        body = {"transactions": [_create_body(expense)]}
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_transactions_service] = lambda: mock_service
+            headers = {"Idempotency-Key": "bulk-fail"}
+            with TestClient(app, raise_server_exceptions=False) as client:
+                first = client.post("/api/v1/transactions/bulk", json=body, headers=headers)
+            mock_service.create.side_effect = None
+            mock_service.create.return_value = expense
+            with TestClient(app) as client:
+                second = client.post("/api/v1/transactions/bulk", json=body, headers=headers)
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert first.status_code == 500
+        assert second.status_code == 201
+
+    def test_detail_not_found(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        mock_service = MagicMock()
+        mock_service.get.return_value = None
+        missing_id = uuid.uuid4()
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_transactions_service] = lambda: mock_service
+            with TestClient(app) as client:
+                response = client.get(f"/api/v1/transactions/{missing_id}")
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert response.status_code == 404
+
+    def test_bulk_partial_failure_counts_failed(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        expense = _sample_expense(owner.id)
+        mock_service = MagicMock()
+        mock_service.create.side_effect = [expense, ValueError("bad row")]
+        body = {"transactions": [_create_body(expense), _create_body(expense)]}
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_transactions_service] = lambda: mock_service
+            with TestClient(app) as client:
+                response = client.post("/api/v1/transactions/bulk", json=body)
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+        assert response.status_code == 201
+        assert response.json()["created"] == 1
+        assert response.json()["failed"] == 1

--- a/modules/api/tests/test_transactions_redis.py
+++ b/modules/api/tests/test_transactions_redis.py
@@ -1,0 +1,165 @@
+"""Tests for transaction Redis cache and Idempotency-Key (PPT-043)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from auth_helpers import make_user
+from papita_txnsapi.config.settings import get_settings
+from papita_txnsapi.core.idempotency import begin_idempotency, complete_idempotency
+from papita_txnsapi.core.rate_limit import InMemoryRateLimiter
+from papita_txnsapi.dependencies.auth import get_current_owner
+from papita_txnsapi.dependencies.services import get_transactions_service
+from papita_txnsapi.main import create_app
+from papita_txnsmodel.access.transactions.dto import TransactionsDTO
+from papita_txnsmodel.model.enums import TransactionKind, TransactionStatus
+
+
+def _sample_expense(owner_id: uuid.UUID) -> TransactionsDTO:
+    now = datetime.now(timezone.utc)
+    return TransactionsDTO(
+        id=uuid.uuid4(),
+        owner_id=owner_id,
+        transaction_kind=TransactionKind.EXPENSE,
+        amount=45.5,
+        currency="USD",
+        transaction_ts=now,
+        from_account_id=uuid.uuid4(),
+        category_id=uuid.uuid4(),
+        status=TransactionStatus.COMPLETED,
+        description="Lunch",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _create_body(expense: TransactionsDTO) -> dict:
+    return {
+        "transaction_type": "expense",
+        "amount": expense.amount,
+        "currency": expense.currency,
+        "transaction_date": expense.transaction_ts.date().isoformat(),
+        "account_id": str(expense.from_account_id),
+        "category_id": str(expense.category_id),
+        "description": expense.description,
+    }
+
+
+class TestTransactionListCache:
+    """Short-TTL cache-aside on GET /transactions."""
+
+    def test_list_cache_hit_and_create_invalidates(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        expense = _sample_expense(owner.id)
+        mock_service = MagicMock()
+        mock_service.list_transactions.return_value = (
+            pd.DataFrame([expense.model_dump(mode="python")]),
+            1,
+        )
+        mock_service.create.return_value = expense
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_transactions_service] = lambda: mock_service
+            with TestClient(app) as client:
+                first = client.get("/api/v1/transactions")
+                second = client.get("/api/v1/transactions")
+                created = client.post("/api/v1/transactions", json=_create_body(expense))
+                third = client.get("/api/v1/transactions")
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert second.headers.get("X-Cache") == "HIT"
+        assert created.status_code == 201
+        assert third.status_code == 200
+        assert third.headers.get("X-Cache") == "MISS"
+        assert mock_service.list_transactions.call_count == 2
+
+
+class TestTransactionIdempotency:
+    """Idempotency-Key replay for POST /transactions."""
+
+    def test_create_replay_skips_second_service_call(
+        self,
+        fake_redis: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("REDIS_ENABLED", "true")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        get_settings.cache_clear()
+        InMemoryRateLimiter().reset()
+
+        owner = make_user()
+        expense = _sample_expense(owner.id)
+        mock_service = MagicMock()
+        mock_service.create.return_value = expense
+
+        with patch("papita_txnsapi.main.init_redis", return_value=fake_redis):
+            app = create_app()
+            app.state.redis = fake_redis
+            app.dependency_overrides[get_current_owner] = lambda: owner
+            app.dependency_overrides[get_transactions_service] = lambda: mock_service
+            headers = {"Idempotency-Key": "txn-create-1"}
+            with TestClient(app) as client:
+                first = client.post("/api/v1/transactions", json=_create_body(expense), headers=headers)
+                second = client.post("/api/v1/transactions", json=_create_body(expense), headers=headers)
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("REDIS_ENABLED", "false")
+
+        assert first.status_code == 201
+        assert second.status_code == 201
+        assert first.json()["id"] == second.json()["id"]
+        assert mock_service.create.call_count == 1
+
+    def test_begin_conflict_when_pending(self, fake_redis: object) -> None:
+        owner_id = uuid.uuid4()
+        first = begin_idempotency(
+            fake_redis, owner_id, scope="transactions:create", key="k1", ttl_seconds=60
+        )
+        second = begin_idempotency(
+            fake_redis, owner_id, scope="transactions:create", key="k1", ttl_seconds=60
+        )
+        assert first.state == "miss"
+        assert second.state == "conflict"
+
+    def test_begin_hit_after_complete(self, fake_redis: object) -> None:
+        owner_id = uuid.uuid4()
+        begun = begin_idempotency(
+            fake_redis, owner_id, scope="transactions:create", key="k2", ttl_seconds=60
+        )
+        assert begun.state == "miss"
+        complete_idempotency(
+            fake_redis,
+            owner_id,
+            scope="transactions:create",
+            key="k2",
+            body={"id": str(uuid.uuid4()), "amount": 1.0},
+            ttl_seconds=60,
+        )
+        replay = begin_idempotency(
+            fake_redis, owner_id, scope="transactions:create", key="k2", ttl_seconds=60
+        )
+        assert replay.state == "hit"
+        assert replay.payload is not None
+        assert replay.payload["amount"] == 1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ types-toml = "^0.10.8.20240310"
 types-requests = "^2.32.4.20250913"
 types-pytz = "^2025.2.0.20250809"
 flake8-pyproject = "^1.2.4"
+fakeredis = { version = "^2.26.0", extras = ["lua"] }
 
 [build-system]
 requires = ["poetry>=1.1.13"]


### PR DESCRIPTION
## Summary

Delivers **PPT-043 / #83**: optional Redis for `papita_txnsapi` so cache-aside GETs, distributed rate limits, JWT denylist, and idempotent transaction creates work across replicas. Postgres stays source of truth; with `REDIS_ENABLED=false` the API keeps in-memory rate limits and skips cache/denylist. Also includes B0 Compose Redis, smoke/ops docs, Free/Pro/Enterprise API quotas, and a mixed-in **PPT-045 / #93** uvicorn packaging brief plus auth/schema docstring polish.

## Out of scope / Highlights

**Out of scope**

- Full background worker fleet / real queue consumers (`core/broker.py` is scaffold only)
- Live pub/sub product features
- PPT-045 uvicorn process packaging implementation (issue/brief only — #93)
- Managed B1 Redis provider provisioning (runbook placeholders only)

**Highlights**

- Versioned tenant cache (`papita:{PAPITA_ENV}:…`) with per-route TTLs and `X-Cache`
- Atomic Lua sliding-window rate limits; tenant Free/Pro/Enterprise quotas + `X-RateLimit-*`
- Logout JWT denylist fail-closed when Redis is required (503 if unavailable)
- `Idempotency-Key` on `POST /transactions` (+ bulk)

## Changes

**API core**

- Pool lifecycle, keys, cache-aside, session denylist, idempotency, tier helpers, broker scaffold
- Atomic Redis rate limiter (auth + tenant API); in-memory fallback when Redis off
- Settings: `REDIS_*`, per-namespace cache TTLs, idempotency TTL, `API_RATE_LIMIT_*`

**API surface**

- Cache + invalidation on accounts / categories / reports / transactions GETs
- Tenant rate limits on ledger/report routers; middleware stamps rate-limit headers
- Auth logout → denylist; denylist check on `get_current_owner`
- `/health/redis` and ready includes Redis when enabled
- Idempotency on transaction create/bulk

**Ops / compose**

- Redis 7 service + `docker/redis/redis.conf`; Compose wires API `REDIS_URL`
- `make redis-up` / `stack-up` / `redis-smoke`; `deploy/redis_smoke.sh`; ops checklist

**Docs / env / strata**

- `environments/*/.env.example`, `environments/README.md`, `modules/api/README.md`
- PPT-045 brief + issues README map; strata architecture/project_state notes
- Auth/schema docstring polish; interrogate badge refresh

**Tests / deps**

- fakeredis[lua] + redis client; Redis/cache/denylist/tier/idempotency/health coverage
- Conftest disables Redis / API rate limits by default

<details>
<summary>File changes (~56 files)</summary>
