### PR TITLE
docs: add create-issue skill for templated GitHub issues

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -231,7 +231,7 @@ Before opening or marking ready for review (commands in [`.github/CI.md`](../.gi
 7. Keep scope focused — avoid drive-by refactors
 8. Omit regenerated artifacts (`docs/coverage.xml`, badge SVGs) unless CI requires them
 9. Fill [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) for the PR body (skill: `.cursor/skills/pr-description/`)
-10. New GitHub issues: use [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE/) (epic / program / child / bug) per [github_issue_conventions](rules/gen-custom/github_issue_conventions.mdc)
+10. New GitHub issues: use [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE/) (epic / program / child / bug) per [github_issue_conventions](rules/gen-custom/github_issue_conventions.mdc); agent skill: [`.cursor/skills/create-issue/`](skills/create-issue/) (`/create-issue`)
 
 Do not create git commits unless the user explicitly asks.
 

--- a/.cursor/rules/gen-custom/github_issue_conventions.mdc
+++ b/.cursor/rules/gen-custom/github_issue_conventions.mdc
@@ -77,6 +77,8 @@ GitHub issue chooser templates live under [`.github/ISSUE_TEMPLATE/`](../../.git
 
 Prefer those files when creating or editing issues via `gh issue create` / `gh issue edit`. Do not invent alternate section orders.
 
+**Agent automation:** [`.cursor/skills/create-issue/`](../skills/create-issue/) (`/create-issue`) asks type → fields → optional context, fills the matching template, then creates the issue on origin with `gh`.
+
 ### Program issue skeleton (summary)
 
 ```markdown

--- a/.cursor/skills/create-issue/SKILL.md
+++ b/.cursor/skills/create-issue/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: create-issue
+description: >
+  Creates GitHub issues on origin from repo ISSUE_TEMPLATE files (epic, program
+  issue, child under epic, bug). Interactive: asks issue type, required fields,
+  and optional additional context, then runs gh issue create. Use when the user
+  asks to create/file/open a GitHub issue, epic, child issue, bug ticket, or
+  /create-issue in this repository.
+disable-model-invocation: true
+---
+
+# Create GitHub issue (project)
+
+Open a **real issue on `origin`** (`Elmorralito/save-ma-money`) by filling a
+repo template under [`.github/ISSUE_TEMPLATE/`](../../../.github/ISSUE_TEMPLATE/).
+
+This skill lives at `.cursor/skills/create-issue/` (repo-only).
+
+**Never** put secrets, tokens, passwords, private keys, or credentialed URLs in
+titles, bodies, or labels. Name env _variables_ only.
+
+## Templates (SSOT)
+
+| Type               | Ask the user as | File                                                                         |
+| ------------------ | --------------- | ---------------------------------------------------------------------------- |
+| Epic               | `epic`          | [`01-epic.md`](../../../.github/ISSUE_TEMPLATE/01-epic.md)                   |
+| Program issue      | `program`       | [`02-program-issue.md`](../../../.github/ISSUE_TEMPLATE/02-program-issue.md) |
+| Child (under epic) | `child`         | [`03-child-issue.md`](../../../.github/ISSUE_TEMPLATE/03-child-issue.md)     |
+| Bug                | `bug`           | [`04-bug-report.md`](../../../.github/ISSUE_TEMPLATE/04-bug-report.md)       |
+
+Title notation: `.cursor/rules/gen-custom/github_issue_conventions.mdc` →
+`{semantic}/PPT-{NNN}: [{domain}] {Sentence case}` (epics: `[EPIC][{domain}]`).
+
+Shape references and field notes: [reference.md](reference.md).
+
+## Workflow
+
+Copy and complete:
+
+```
+Create-issue progress:
+- [ ] 1. Issue type (epic | program | child | bug)
+- [ ] 2. Required fields for that type
+- [ ] 3. Optional additional context
+- [ ] 4. Draft body from template + user answers
+- [ ] 5. Preview title + body; user confirms
+- [ ] 6. gh issue create on origin; return URL
+```
+
+### Step 1 — Ask type
+
+If the user did not already specify, ask:
+
+> Which issue type?
+>
+> 1. **epic** — multi-issue program epic
+> 2. **program** — standalone / post-MVP PPT issue
+> 3. **child** — sub-issue under an epic
+> 4. **bug** — something broken
+
+Do not invent a type. Stop if unclear.
+
+### Step 2 — Required fields
+
+Load the matching template file (read full file). Ask only what is still missing.
+Strip YAML frontmatter for the body; use frontmatter `labels` as defaults.
+
+**All types**
+
+| Field        | Notes                                                                         |
+| ------------ | ----------------------------------------------------------------------------- |
+| `semantic`   | `feat` \| `fix` \| `ops` \| `ci` \| `docs` \| `test` \| `chore` \| `refactor` |
+| `PPT-NNN`    | e.g. `PPT-046` — must match intended program id / label                       |
+| `domain`     | `api` \| `model` \| `infra` \| … (epic title uses `[EPIC][domain]`)           |
+| `title_text` | Sentence case short title (no semantic/PPT prefix)                            |
+
+**epic** — also: step/phase name; parent program (default `#28` PPT-031); summary; out of scope (can be short); blocked-by if known.
+
+**program** — also: parent program (default `#28`); parent epic if any (often `#42`); step; summary; depends/blocks (may be “none”); platform rule note; at least one acceptance criterion.
+
+**child** — also: **parent epic** (required, e.g. `#42`); program (default `#28`); step number; goal; depends on; blocks (siblings); acceptance criteria.
+
+**bug** — also: summary; reproduce steps; expected; actual; environment row(s); acceptance (“bug no longer reproduces”).
+
+### Step 3 — Optional additional context
+
+Ask:
+
+> Any **additional context** to fold into the issue? (optional — design links, code paths, constraints, “already done / gaps”. Press skip for none.)
+
+Merge into the best sections (`Summary` / `Goal`, `Current state`, `Tasks`, `References`). Do not dump unstructured blobs above the template headings.
+
+### Step 4 — Draft
+
+1. Start from the template **body** (everything after the second `---`).
+2. Replace `PPT-{NNN}`, placeholders, and HTML `<!-- ... -->` guidance comments with real content (delete leftover guidance comments).
+3. Keep required headings from the template — do not invent a parallel outline.
+4. Build title:
+
+   - epic: `{semantic}/PPT-{NNN}: [EPIC][{domain}] {title_text}`
+   - other: `{semantic}/PPT-{NNN}: [{domain}] {title_text}`
+   - bug without PPT only if user insists: `fix: [{domain}] {title_text}` (prefer PPT when it maps to a track)
+
+5. Labels: template defaults + `PPT-{NNN}` when that label exists on the repo. Check with
+   `gh label list --limit 200`. Create missing `PPT-{NNN}` only if the user asks.
+
+### Step 5 — Confirm
+
+Show:
+
+- **Type**, **Title**, **Labels**
+- Full **body** (or collapsed preview if long)
+
+Ask: create on origin now? **Yes / edit / cancel**.
+
+### Step 6 — Create on origin
+
+```bash
+# Write body to a temp file (no secrets). Example:
+BODY_FILE="$(mktemp)"
+# ... write drafted markdown to $BODY_FILE ...
+
+gh issue create \
+  --repo Elmorralito/save-ma-money \
+  --title "{TITLE}" \
+  --body-file "$BODY_FILE" \
+  --label "{labels comma-separated as separate --label flags}"
+
+rm -f "$BODY_FILE"
+```
+
+Prefer `--repo Elmorralito/save-ma-money` (or the current `gh` remote) so the issue lands on **origin**, not a fork.
+
+Return the issue **URL** and number. Do not close or edit other issues unless asked.
+
+## Rules
+
+- Interactive first: type → fields → optional context → confirm → create.
+- Template structure is SSOT; fill it, don’t replace it.
+- Never invent green CI, fake issue numbers, or PPT ids the user didn’t approve.
+- Never paste secrets.
+- If `gh` auth fails, stop and report — do not pretend the issue was filed.
+- Optional: offer a matching brief under `docs/issues/` only when the user asks.
+
+## Additional resources
+
+- [reference.md](reference.md) — field checklist by type + example titles
+- Conventions: `.cursor/rules/gen-custom/github_issue_conventions.mdc`
+- Briefs index: `docs/issues/README.md`

--- a/.cursor/skills/create-issue/SKILL.md
+++ b/.cursor/skills/create-issue/SKILL.md
@@ -43,8 +43,9 @@ Create-issue progress:
 - [ ] 2. Required fields for that type
 - [ ] 3. Optional additional context
 - [ ] 4. Draft body from template + user answers
-- [ ] 5. Preview title + body; user confirms
-- [ ] 6. gh issue create on origin; return URL
+- [ ] 5. gh auth — login if necessary
+- [ ] 6. Preview title + body; user confirms
+- [ ] 7. gh issue create on origin; return URL
 ```
 
 ### Step 1 — Ask type
@@ -102,9 +103,31 @@ Merge into the best sections (`Summary` / `Goal`, `Current state`, `Tasks`, `Ref
    - bug without PPT only if user insists: `fix: [{domain}] {title_text}` (prefer PPT when it maps to a track)
 
 5. Labels: template defaults + `PPT-{NNN}` when that label exists on the repo. Check with
-   `gh label list --limit 200`. Create missing `PPT-{NNN}` only if the user asks.
+   `gh label list --limit 200` **after** auth (step 5). Create missing `PPT-{NNN}` only if the user asks.
+   If labels were not checked yet, do that check in step 5 once `gh` is authenticated.
 
-### Step 5 — Confirm
+### Step 5 — `gh` auth (login if necessary)
+
+Before preview/create, ensure GitHub CLI can reach origin:
+
+```bash
+gh auth status
+```
+
+- **Logged in** (token valid for `github.com` / the repo host) → continue to step 6.
+- **Not logged in**, expired, or missing `repo` / issue scopes → tell the user and run interactive login:
+
+```bash
+gh auth login
+```
+
+Prefer GitHub.com + HTTPS (or the host this repo’s `gh` remote uses, e.g. if `gh` is configured for a GHES / alias host). Do **not** paste tokens into chat or the issue body.
+
+Re-run `gh auth status` until it succeeds. If the user declines login, **stop** — do not pretend the issue was filed.
+
+Optional after auth: `gh label list --repo Elmorralito/save-ma-money --limit 200` to finalize labels for the draft.
+
+### Step 6 — Confirm
 
 Show:
 
@@ -113,7 +136,7 @@ Show:
 
 Ask: create on origin now? **Yes / edit / cancel**.
 
-### Step 6 — Create on origin
+### Step 7 — Create on origin
 
 ```bash
 # Write body to a temp file (no secrets). Example:
@@ -135,11 +158,11 @@ Return the issue **URL** and number. Do not close or edit other issues unless as
 
 ## Rules
 
-- Interactive first: type → fields → optional context → confirm → create.
+- Interactive first: type → fields → optional context → draft → **gh auth** → confirm → create.
 - Template structure is SSOT; fill it, don’t replace it.
 - Never invent green CI, fake issue numbers, or PPT ids the user didn’t approve.
-- Never paste secrets.
-- If `gh` auth fails, stop and report — do not pretend the issue was filed.
+- Never paste secrets or `gh` tokens.
+- If `gh` auth fails or the user skips login, stop and report — do not pretend the issue was filed.
 - Optional: offer a matching brief under `docs/issues/` only when the user asks.
 
 ## Additional resources

--- a/.cursor/skills/create-issue/reference.md
+++ b/.cursor/skills/create-issue/reference.md
@@ -49,6 +49,10 @@ Typical sets (adjust to what `gh label list` shows):
 ## `gh` tips
 
 ```bash
+# Auth (skill step 5 — required before create if not already logged in)
+gh auth status
+gh auth login   # only when status fails / scopes missing
+
 # Dry-run style: print then create
 gh issue create --repo Elmorralito/save-ma-money --title "…" --body-file /tmp/body.md --label enhancement --label PPT-045
 

--- a/.cursor/skills/create-issue/reference.md
+++ b/.cursor/skills/create-issue/reference.md
@@ -1,0 +1,59 @@
+# create-issue — reference
+
+## Template map
+
+| Type    | Path                                         | GitHub chooser name      |
+| ------- | -------------------------------------------- | ------------------------ |
+| epic    | `.github/ISSUE_TEMPLATE/01-epic.md`          | Epic (PPT program)       |
+| program | `.github/ISSUE_TEMPLATE/02-program-issue.md` | Program issue (PPT)      |
+| child   | `.github/ISSUE_TEMPLATE/03-child-issue.md`   | Child issue (under epic) |
+| bug     | `.github/ISSUE_TEMPLATE/04-bug-report.md`    | Bug report               |
+
+## Shape references (human-written exemplars)
+
+| Type    | Examples                                                                                                                                                                                                         |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Epic    | [#42](https://github.com/Elmorralito/save-ma-money/issues/42) (PPT-032)                                                                                                                                          |
+| Program | [#52](https://github.com/Elmorralito/save-ma-money/issues/52), [#89](https://github.com/Elmorralito/save-ma-money/issues/89), [#93](https://github.com/Elmorralito/save-ma-money/issues/93)                      |
+| Child   | PPT-032 children [#43](https://github.com/Elmorralito/save-ma-money/issues/43)–[#50](https://github.com/Elmorralito/save-ma-money/issues/50); e.g. [#45](https://github.com/Elmorralito/save-ma-money/issues/45) |
+
+## Example titles
+
+```text
+feat/PPT-032: [EPIC][api] FastAPI MVP on v3 model + Supabase Auth
+ops/PPT-045: [api] Standardize uvicorn process packaging for host and Compose
+fix/PPT-044: [api] Post-MVP API security and operational hardening
+feat/PPT-034: [api] FastAPI app scaffold, middleware, and health probes
+fix/PPT-046: [infra] Badge workflow loops on docs-only pushes
+```
+
+## Default parents
+
+| Field                   | Default (confirm with user)                           |
+| ----------------------- | ----------------------------------------------------- |
+| Parent program          | `#28` (PPT-031)                                       |
+| Parent epic (API track) | `#42` (PPT-032) when relevant                         |
+| Child without epic      | Reject — ask for epic number or switch to **program** |
+
+## Labels
+
+Typical sets (adjust to what `gh label list` shows):
+
+| Type    | Suggest                                                        |
+| ------- | -------------------------------------------------------------- |
+| epic    | `enhancement`, `PPT-{NNN}`, domain (`API`, …)                  |
+| program | `enhancement` or `CI/CD` / `documentation` as apt, `PPT-{NNN}` |
+| child   | `enhancement`, `PPT-{NNN}`, domain                             |
+| bug     | `bug`, `PPT-{NNN}` if mapped                                   |
+
+## `gh` tips
+
+```bash
+# Dry-run style: print then create
+gh issue create --repo Elmorralito/save-ma-money --title "…" --body-file /tmp/body.md --label enhancement --label PPT-045
+
+# List PPT labels
+gh label list --repo Elmorralito/save-ma-money --limit 200 | rg 'PPT-'
+```
+
+Multiple labels: repeat `--label` (do not pass one comma-separated string unless your `gh` version accepts it).


### PR DESCRIPTION
**Branch:** `docs/create-issue-skill` · **Base:** `main` · **1 commit** · **4 files**

## Summary

Adds a project Cursor skill `/create-issue` that interactively asks for issue type (epic / program / child / bug), required fields, and optional additional context, then fills the matching `.github/ISSUE_TEMPLATE` and creates the issue on origin with `gh`.

## Out of scope / Highlights

**Out of scope**

- Auto-filing issues without confirmation
- Syncing or rewriting existing GitHub issues
- Creating `docs/issues/` briefs unless separately requested

**Highlights**

- Uses templates from [#100](https://github.com/Elmorralito/save-ma-money/pull/100) as SSOT
- Explicit confirm step before `gh issue create`

## Changes

**Agent tooling**

- `.cursor/skills/create-issue/SKILL.md` — type → fields → optional context → preview → create
- `.cursor/skills/create-issue/reference.md` — exemplars (#42 / #52 / #89 / #93 / children)
- Wire AGENTS + github_issue_conventions to the skill

## File changes

<details>
<summary>File changes (~4 files)</summary>

```
.cursor/skills/create-issue/SKILL.md
.cursor/skills/create-issue/reference.md
.cursor/AGENTS.md
.cursor/rules/gen-custom/github_issue_conventions.mdc
```

</details>

## Commits

- `c3e5902` docs: add create-issue skill for templated GitHub issues

## Checks, tests, and validation already done

- pre-commit on commit — pass
- End-to-end `/create-issue` against origin — not run in this PR

## QA / test plan

- [ ] Attach `/create-issue` and create a dry-run draft (cancel before `gh`)
- [ ] Optional: file a throwaway bug then close it

## Risks

> [!CAUTION]
>
> ### Risks
>
> - Skill can create real issues on origin after confirmation — misuse creates noise tickets.

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - `disable-model-invocation: true` — invoke explicitly (`/create-issue` or ask to create an issue).
> - PPT labels are applied only when they already exist unless the user asks to create them.

## References

- Templates: `.github/ISSUE_TEMPLATE/`
- Related: [#100](https://github.com/Elmorralito/save-ma-money/pull/100)

Made with [Cursor](https://cursor.com)