### PR TITLE
fix(ci): unblock model 1.0.0 publish (Poetry CLI + API pin)

### DIFF
--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -22,3 +22,5 @@ project**. Papita API verifies JWTs + links `users` by `sub` — it is not the I
 
 - Do not commit `environments/**/.env`
 - PSR writes modules/model/CHANGELOG.md only (not root CHANGELOG.md)
+
+- Prettier-format modules/model/CHANGELOG.md from PSR 1.0.0

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -10,13 +10,14 @@ project**. Papita API verifies JWTs + links `users` by `sub` — it is not the I
 
 ### Last completed (this session)
 
-- PPT-024 / #11 PR #104 babysit: `__meta__` unit tests for Codecov patch coverage
-  (importlib.metadata + pyproject fallback paths)
+- PPT-024 first release: PSR created `model-v1.0.0` + GH release; publish failed
+  because `bin/package.sh` used `python -m poetry` (CLI-only Poetry in CI)
 
 ### Next action
 
-- Land PR #104 when CI green; configure Trusted Publishers; first live publish
-- Do not commit `environments/**/.env`
+- Land package.sh Poetry CLI fix; re-dispatch Publish model package → PyPI
+- Ensure PyPI/TestPyPI Trusted Publishers + `pypi`/`testpypi` environments
+- Note: GITHUB_TOKEN tag pushes do not cascade to publish-model.yml
 
 ### Uncommitted / staging notes
 

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -10,13 +10,12 @@ project**. Papita API verifies JWTs + links `users` by `sub` — it is not the I
 
 ### Last completed (this session)
 
-- PPT-024 first release: PSR created `model-v1.0.0` + GH release; publish failed
-  because `bin/package.sh` used `python -m poetry` (CLI-only Poetry in CI)
+- PPT-024: PSR tagged `model-v1.0.0`; publish blocked by Poetry CLI + API pin `<1.0`
 
 ### Next action
 
-- Land package.sh Poetry CLI fix; re-dispatch Publish model package → PyPI
-- Ensure PyPI/TestPyPI Trusted Publishers + `pypi`/`testpypi` environments
+- Land package.sh Poetry CLI fix + API model dep `>=1.0.0,<2.0`
+- Re-dispatch Publish model package → PyPI (Trusted Publishers)
 - Note: GITHUB_TOKEN tag pushes do not cascade to publish-model.yml
 
 ### Uncommitted / staging notes

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -55,6 +55,21 @@ _modules_to_build() {
     printf '%s\n' "${LIBS_INPUT_PATH}/${MOD}"
 }
 
+# Prefer the Poetry CLI (snok/install-poetry, official installer). Fall back to
+# `python -m poetry` for envs where Poetry is installed as a module only.
+_run_poetry() {
+    if command -v poetry >/dev/null 2>&1; then
+        poetry "$@"
+        return $?
+    fi
+    if python -m poetry --version >/dev/null 2>&1; then
+        python -m poetry "$@"
+        return $?
+    fi
+    log "ERROR" "Poetry not found (need poetry on PATH or python -m poetry)."
+    return 1
+}
+
 package() {
     log "INFO" "Starting package process using Poetry (MOD=${MOD})..."
 
@@ -78,7 +93,7 @@ package() {
         }
         __package_name="$(basename "${lib}")"
         log "INFO" "Building sdist + wheel for ${__package_name}..."
-        if ! python -m poetry build -o "${LIBS_OUTPUT_PATH}" -v; then
+        if ! _run_poetry build -o "${LIBS_OUTPUT_PATH}" -v; then
             log "ERROR" "Failed to package ${__package_name}."
             failed=1
             continue

--- a/modules/api/pyproject.toml
+++ b/modules/api/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 dependencies = [
     "python-dateutil (>=2.9.0.post0)",
-    "papita-transactions-model (>=0.1.0,<1.0)",
+    "papita-transactions-model (>=1.0.0,<2.0)",
     "fastapi (>=0.139.2,<0.140.0)",
     "starlette (>=1.3.1,<2.0.0)",
     "pydantic-settings (>=2.14.2,<3.0.0)",

--- a/modules/model/CHANGELOG.md
+++ b/modules/model/CHANGELOG.md
@@ -405,7 +405,7 @@ This file is **not** the monorepo issue tracker changelog. Root
   ([#53](https://github.com/Elmorralito/save-ma-money/pull/53),
   [`3ffeb19`](https://github.com/Elmorralito/save-ma-money/commit/3ffeb19f85adb58008fe1dc399830d87c43940d9))
 
-- Cover __meta__ version resolution for Codecov patch
+- Cover **meta** version resolution for Codecov patch
   ([#104](https://github.com/Elmorralito/save-ma-money/pull/104),
   [`c0c3f0d`](https://github.com/Elmorralito/save-ma-money/commit/c0c3f0d95e65fc0db74a2385c49d47b3dc0bcaf8))
 


### PR DESCRIPTION
## Summary
- Prefer Poetry CLI in `bin/package.sh` (fixes publish-model build).
- Widen API dependency to `papita-transactions-model (>=1.0.0,<2.0)` after PSR tagged `model-v1.0.0`.

## Test plan
- [ ] CI green on this PR
- [ ] Re-dispatch Publish model package → PyPI for 1.0.0