### PR TITLE
docs(ci): refresh model README install path and harden PR/publish CI

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -46,6 +46,7 @@ flowchart TB
         TR[Trivy Security Scan]
         BS[Bash Security]
         ST[Strata Check]
+        SYN[Branch sync with main]
     end
 
     subgraph main [Merge to main]
@@ -60,8 +61,9 @@ flowchart TB
     TR --> |CVE + misconfig SARIF| Pass6[Gate]
     BS --> |ShellCheck security + Semgrep| Pass7[Gate]
     ST --> |.strata/ layout + pairing| Pass8[Gate]
+    SYN --> |not behind origin/main| Pass9[Gate]
 
-    Pass1 & Pass2 & Pass3 & Pass4 & Pass5 & Pass6 & Pass7 & Pass8 --> Merge[Merge]
+    Pass1 & Pass2 & Pass3 & Pass4 & Pass5 & Pass6 & Pass7 & Pass8 & Pass9 --> Merge[Merge]
     Merge --> AU
     AU --> |CHANGELOG + badges| Push[Push to main]
 ```
@@ -76,23 +78,23 @@ flowchart TB
 
 Use this matrix to predict required checks before opening a PR.
 
-| Change type                                 | Quality Control | Gitleaks | Supply Chain | Migration | CodeQL | Trivy | Bash Sec | Strata |
-| :------------------------------------------ | :-------------: | :------: | :----------: | :-------: | :----: | :---: | :------: | :----: |
-| `docs/**` only                              |        —        |    ✓     |      —       |     —     |   —    |   —   |    —     |   —    |
-| `modules/**` code                           |        ✓        |    ✓     |     —\*      |    —\*    |   ✓†   |  —\*  |    —     |   ✓    |
-| `pyproject.toml` / module deps              |        ✓        |    ✓     |      ✓       |     —     |   ✓†   |   ✓   |    —     |   ✓‡   |
-| Model / Alembic / `docker/database/**`      |        ✓        |    ✓     |     —\*      |     ✓     |   ✓†   |  —\*  |    —     |   ✓    |
-| `bin/**` or `.github/scripts/**`            |        ✓        |    ✓     |     —\*      |    —\*    |   —    |   —   |    ✓     |  —\*   |
-| `.strata/**` only (no `modules/` or `bin/`) |        ✓        |    ✓     |      —       |     —     |   —    |   —   |    —     |   —§   |
-| `.github/workflows/**`                      |        ✓        |    ✓     |      ✓       |    —\*    |  —\*   |  —\*  |   —\*    |  —\*   |
-| `.cursor/mcp.json`                          |        ✓        |    ✓     |      —       |     —     |   —    |   —   |    —     |   —    |
+| Change type                                 | Quality Control | Gitleaks | Supply Chain | Migration | CodeQL | Trivy | Bash Sec | Strata | Branch sync |
+| :------------------------------------------ | :-------------: | :------: | :----------: | :-------: | :----: | :---: | :------: | :----: | :---------: |
+| `docs/**` only                              |        —        |    ✓     |      —       |     —     |   —    |   —   |    —     |   —    |      ✓      |
+| `modules/**` code                           |        ✓        |    ✓     |     —\*      |    —\*    |   ✓†   |  —\*  |    —     |   ✓    |      ✓      |
+| `pyproject.toml` / module deps              |        ✓        |    ✓     |      ✓       |     —     |   ✓†   |   ✓   |    —     |   ✓‡   |      ✓      |
+| Model / Alembic / `docker/database/**`      |        ✓        |    ✓     |     —\*      |     ✓     |   ✓†   |  —\*  |    —     |   ✓    |      ✓      |
+| `bin/**` or `.github/scripts/**`            |        ✓        |    ✓     |     —\*      |    —\*    |   —    |   —   |    ✓     |  —\*   |      ✓      |
+| `.strata/**` only (no `modules/` or `bin/`) |        ✓        |    ✓     |      —       |     —     |   —    |   —   |    —     |   —§   |      ✓      |
+| `.github/workflows/**`                      |        ✓        |    ✓     |      ✓       |    —\*    |  —\*   |  —\*  |   —\*    |  —\*   |      ✓      |
+| `.cursor/mcp.json`                          |        ✓        |    ✓     |      —       |     —     |   —    |   —   |    —     |   —    |      ✓      |
 
 \* Runs only when matching [path filters](#workflow-overview) apply.
 † CodeQL runs on PRs **targeting `main`** only.
 ‡ Strata Check runs when root `pyproject.toml` changes (listed in its path filter).
 § Strata Check path filters do **not** include `.strata/**` — layout validation for memory-only edits is enforced locally via pre-commit, not this workflow.
 
-**Always on PRs:** Secret Scan (Gitleaks) — no path filter, full history.
+**Always on PRs:** Secret Scan (Gitleaks) — no path filter, full history · Branch sync with main — fail if the PR head is behind `origin/main`.
 
 ---
 
@@ -108,6 +110,7 @@ Use this matrix to predict required checks before opening a PR.
 | Trivy Security Scan  | [`workflows/trivy.yml`](./workflows/trivy.yml)                           | PR + push (manifest/docker paths); Mon 07:00 UTC           | Filesystem CVE + IaC misconfig (SARIF)                              |
 | Bash Security        | [`workflows/bash-security.yml`](./workflows/bash-security.yml)           | **PR only** (shell/script paths)                           | ShellCheck security codes + Semgrep bash rules                      |
 | Strata Check         | [`workflows/strata-check.yml`](./workflows/strata-check.yml)             | PR + push to `main` (code/bin paths)                       | `.strata/` layout + strict code/memory pairing                      |
+| Branch sync          | [`workflows/branch-sync.yml`](./workflows/branch-sync.yml)               | **All PRs**; `workflow_dispatch`                           | Fail if branch is behind `origin/main` (needs merge/rebase)         |
 | Auto Updates         | [`workflows/auto-updates.yml`](./workflows/auto-updates.yml)             | Push or merged PR to `main`                                | Regenerate [`CHANGELOG.md`](../CHANGELOG.md) and badges             |
 | CI Adoption Badge    | [`workflows/ci-badge.yml`](./workflows/ci-badge.yml)                     | PR + push to `main`; Mon 06:00 UTC; `workflow_dispatch`    | Score CI maturity and update README adoption badge                  |
 | Release model (PSR)  | [`workflows/release-model.yml`](./workflows/release-model.yml)           | Push `main` (model paths); `workflow_dispatch`             | python-semantic-release → `model-v*` + `modules/model/CHANGELOG.md` |
@@ -128,6 +131,10 @@ pre-commit run --all-files
 
 # Supply chain (deps or workflow script changes)
 /bin/bash .github/scripts/supply_chain_check.sh
+
+# Branch not behind main (same gate as branch-sync.yml)
+git fetch origin main
+/bin/bash .github/scripts/branch_sync_check.sh
 
 # Strata layout + strict pairing (PR range vs main)
 STRATA_STRICT_MODULES=1 STRATA_BASE_REF=origin/main /bin/bash .github/scripts/strata_check.sh
@@ -161,6 +168,17 @@ pre-commit install   # optional but recommended for commit-time hooks
 ---
 
 ## Workflows in detail
+
+### Branch sync with main
+
+|               |                                                                                     |
+| :------------ | :---------------------------------------------------------------------------------- |
+| **Trigger**   | All pull requests; optional `workflow_dispatch`                                     |
+| **Script**    | [`scripts/branch_sync_check.sh`](./scripts/branch_sync_check.sh)                    |
+| **Pass when** | PR head is **not behind** `origin/main` (ahead-only feature commits are fine)       |
+| **Fail when** | `git rev-list --count HEAD..origin/main` &gt; 0 — merge or rebase `main`, then push |
+
+Checks out the PR head SHA (not the temporary merge commit) so the behind-count matches what you see locally.
 
 ### Release model (python-semantic-release, PPT-024)
 
@@ -613,6 +631,7 @@ Missing file → skip with success (project may not use MCP).
 
 | Script                                                             | Invoked by               | Description                                                              |
 | :----------------------------------------------------------------- | :----------------------- | :----------------------------------------------------------------------- |
+| [`branch_sync_check.sh`](./scripts/branch_sync_check.sh)           | Branch sync with main    | Fail if `HEAD` is behind `BASE_REF` (default `origin/main`)              |
 | [`migration_check.sh`](./scripts/migration_check.sh)               | Migration Check          | Alembic upgrade → downgrade → upgrade → `check`; requires `DB_URL`       |
 | [`supply_chain_check.sh`](./scripts/supply_chain_check.sh)         | Supply Chain Check       | Poetry metadata, semver check, pip upgrade, pip-audit                    |
 | [`check_module_versions.py`](./scripts/check_module_versions.py)   | Supply Chain Check       | Validates `[project].version` semver in each `modules/*/pyproject.toml`  |
@@ -652,6 +671,7 @@ pre-commit run --all-files
 
 - Never commit `.env`, credentials, or real secrets
 - Pair `modules/**` / `bin/**` edits with `.strata/` (or adapter) updates
+- Keep the branch current with `main` (`git fetch origin && git merge origin/main` — Branch sync CI gate)
 - Keep PR scope focused
 - Use the PR body template: [`.github/PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md)
 - New issues: use [`.github/ISSUE_TEMPLATE/`](./ISSUE_TEMPLATE/) (epic / program / child / bug)
@@ -661,6 +681,22 @@ Full agent-oriented checklist: [`.agents/AGENTS.md` — PR checklist](../.agents
 ---
 
 ## Troubleshooting
+
+### Branch sync failed: behind `origin/main`
+
+```
+Branch is N commit(s) behind origin/main
+```
+
+Your PR head is missing commits that landed on `main`. Update and push:
+
+```bash
+git fetch origin
+git merge origin/main   # or: git rebase origin/main
+git push
+```
+
+Local preview: `/bin/bash .github/scripts/branch_sync_check.sh`
 
 ### Strata Check / `strata-validate` failed: code without memory update
 
@@ -757,8 +793,10 @@ Each scheduled workflow also supports **`workflow_dispatch`** from the Actions t
 | Python                    | 3.12                                              |
 | Poetry                    | 2.1.3 (`snok/install-poetry@v1`)                  |
 | PostgreSQL (migration CI) | `postgres:15-alpine`                              |
-| checkout                  | `actions/checkout@v5`                             |
-| setup-python              | `actions/setup-python@v5`                         |
+| checkout                  | `actions/checkout@v7`                             |
+| setup-python              | `actions/setup-python@v7`                         |
+| upload-artifact           | `actions/upload-artifact@v6` (Node.js 24)         |
+| download-artifact         | `actions/download-artifact@v7` (Node.js 24)       |
 | pre-commit action         | `pre-commit/action@v3.0.0`                        |
 | Codecov                   | `codecov/codecov-action@v4`                       |
 | Gitleaks                  | `gitleaks/gitleaks-action@e0c47f4…` (v3)          |

--- a/.github/scripts/branch_sync_check.sh
+++ b/.github/scripts/branch_sync_check.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Fail when HEAD is behind the sync base (default: origin/main).
+# Ahead-of-base feature commits are expected and do not fail the check.
+#
+# Usage:
+#   /bin/bash .github/scripts/branch_sync_check.sh
+#   BASE_REF=origin/main /bin/bash .github/scripts/branch_sync_check.sh
+# shellcheck disable=SC1090,SC1091
+
+set -euo pipefail
+
+PROJECT_PATH="$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"
+# shellcheck source=../../bin/utils.sh
+source "${PROJECT_PATH}/bin/utils.sh"
+
+BASE_REF="${BASE_REF:-origin/main}"
+HEAD_REF="${HEAD_REF:-HEAD}"
+
+if ! git rev-parse --verify "${BASE_REF}" >/dev/null 2>&1; then
+    log "ERROR" "Base ref not found: ${BASE_REF} (fetch main first: git fetch origin main)"
+    exit 1
+fi
+
+if ! git rev-parse --verify "${HEAD_REF}" >/dev/null 2>&1; then
+    log "ERROR" "Head ref not found: ${HEAD_REF}"
+    exit 1
+fi
+
+behind="$(git rev-list --count "${HEAD_REF}..${BASE_REF}")"
+ahead="$(git rev-list --count "${BASE_REF}..${HEAD_REF}")"
+merge_base="$(git merge-base "${HEAD_REF}" "${BASE_REF}")"
+
+log "INFO" "sync check: head=${HEAD_REF} base=${BASE_REF}"
+log "INFO" "merge-base=${merge_base}"
+log "INFO" "behind=${behind} ahead=${ahead}"
+
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    {
+        echo "## Branch sync with main"
+        echo ""
+        echo "| | |"
+        echo "| :--- | :--- |"
+        echo "| Head | \`${HEAD_REF}\` |"
+        echo "| Base | \`${BASE_REF}\` |"
+        echo "| Merge-base | \`${merge_base}\` |"
+        echo "| Behind base | ${behind} |"
+        echo "| Ahead of base | ${ahead} |"
+    } >>"${GITHUB_STEP_SUMMARY:-/dev/null}"
+fi
+
+if [[ "${behind}" -gt 0 ]]; then
+    log "ERROR" "Branch is ${behind} commit(s) behind ${BASE_REF}."
+    log "ERROR" "Merge or rebase main, then push — e.g. git fetch origin && git merge origin/main"
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        echo "::error::Branch is ${behind} commit(s) behind ${BASE_REF}. Merge or rebase main before merging this PR."
+    fi
+    exit 1
+fi
+
+log "INFO" "Branch is not behind ${BASE_REF} (in sync for merge purposes)."
+exit 0

--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -1,0 +1,52 @@
+---
+# Fail when a PR (or dispatched) branch is behind main and needs merge/rebase.
+# Being ahead of main is normal for feature work and does not fail.
+
+name: Branch sync with main
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "Base ref to compare against (default origin/main)"
+        type: string
+        required: false
+        default: "origin/main"
+
+concurrency:
+  group: branch-sync-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  branch-sync:
+    name: Not behind main
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout PR head (full history)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout current ref (full history)
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main for comparison
+        run: git fetch --no-tags origin main:refs/remotes/origin/main
+
+      - name: Check branch is not behind main
+        env:
+          BASE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.base_ref || 'origin/main' }}
+          HEAD_REF: HEAD
+        run: /bin/bash .github/scripts/branch_sync_check.sh

--- a/.github/workflows/publish-model.yml
+++ b/.github/workflows/publish-model.yml
@@ -80,8 +80,9 @@ jobs:
           /tmp/model-wheel-smoke/bin/pip install "${WHEEL}"
           /tmp/model-wheel-smoke/bin/python -c "import papita_txnsmodel; from papita_txnsmodel import __version__; print('ok', __version__)"
 
+      # Node.js 24 runtime (v4 was Node 20 and triggered deprecation warnings).
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: model-dist
           path: dist/*
@@ -97,7 +98,7 @@ jobs:
       contents: read
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: model-dist
           path: dist
@@ -122,7 +123,7 @@ jobs:
       contents: read
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: model-dist
           path: dist

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -10,17 +10,16 @@ project**. Papita API verifies JWTs + links `users` by `sub` — it is not the I
 
 ### Last completed (this session)
 
-- PPT-024: PSR tagged `model-v1.0.0`; publish blocked by Poetry CLI + API pin `<1.0`
+- PPT-024: model **1.0.1** on PyPI/TestPyPI; model README install/release refresh
+- Added `branch-sync.yml` + `branch_sync_check.sh` (fail PRs behind `origin/main`)
+- publish-model: bump artifact actions to Node.js 24 (`upload@v6`, `download@v7`)
 
 ### Next action
 
-- Land package.sh Poetry CLI fix + API model dep `>=1.0.0,<2.0`
-- Re-dispatch Publish model package → PyPI (Trusted Publishers)
-- Note: GITHUB_TOKEN tag pushes do not cascade to publish-model.yml
+- Prefer dispatch publish when GITHUB_TOKEN tags do not cascade
+- Avoid `[skip ci]` inside squash-merge bodies (skips release-model.yml)
 
 ### Uncommitted / staging notes
 
 - Do not commit `environments/**/.env`
-- PSR writes modules/model/CHANGELOG.md only (not root CHANGELOG.md)
-
-- Prettier-format modules/model/CHANGELOG.md from PSR 1.0.0
+- PSR → `modules/model/CHANGELOG.md` only; root CHANGELOG = auto-updates.yml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # save-ma-money
 
 ![Python](https://img.shields.io/badge/python-3.12+-blue.svg)
-[![CI Adoption](https://img.shields.io/badge/CI%20Adoption-Advanced%20%7C%20Score%3A%2082-brightgreen?style=flat&logo=githubactions&logoColor=white)](https://github.com/Elmorralito/save-ma-money/actions)
+[![CI Adoption](https://img.shields.io/badge/CI%20Adoption-Advanced%20%7C%20Score%3A%2083-brightgreen?style=flat&logo=githubactions&logoColor=white)](https://github.com/Elmorralito/save-ma-money/actions)
 ![interrogate score](./docs/interrogate_badge.svg)
 [![coverage score](./docs/coverage-badge.svg)](https://app.codecov.io/github/Elmorralito/save-ma-money)
 ![pre-commit.ci status](https://results.pre-commit.ci/badge/github/pre-commit/pre-commit/main.svg)

--- a/modules/model/README.md
+++ b/modules/model/README.md
@@ -1,6 +1,16 @@
 # Papita Transactions Data Model
 
-Welcome to the **backbone of financial data integrity** for the **save-ma-money** monorepo. The `papita-txnsmodel` package (`papita-transactions-model`) is the **system of record**: SQLModel schemas, Alembic migrations, repositories, services, and ingestion handlers. The sibling [`papita-txnsapi`](../api/README.md) package will expose HTTP routes that call these services — business rules live here, not in FastAPI routers.
+Welcome to the **backbone of financial data integrity** for the **save-ma-money** monorepo. The importable package is **`papita_txnsmodel`** (PyPI: [`papita-transactions-model`](https://pypi.org/project/papita-transactions-model/)). It is the **system of record**: SQLModel schemas, Alembic migrations, repositories, services, and ingestion handlers. The sibling [`papita-txnsapi`](../api/README.md) exposes HTTP routes that call these services — business rules live here, not in FastAPI routers.
+
+|                     |                                                                                                |
+| :------------------ | :--------------------------------------------------------------------------------------------- |
+| **PyPI**            | [`papita-transactions-model`](https://pypi.org/project/papita-transactions-model/)             |
+| **Import**          | `import papita_txnsmodel`                                                                      |
+| **Current version** | See [`pyproject.toml`](./pyproject.toml) / [`CHANGELOG.md`](./CHANGELOG.md) (package releases) |
+| **Python**          | `>=3.10,<3.15`                                                                                 |
+| **Issue**           | [PPT-024 / #11](https://github.com/Elmorralito/save-ma-money/issues/11)                        |
+
+**Contents:** [Overview](#overview) · [From v0 to v3](#from-v0-to-v3) · [Tenancy](#tenancy-and-security) · [Layers](#architectural-layers) · [Balance reports](#balance-reports-and-materialized-views) · [Database](#database-integration) · [Usage](#usage-examples) · [Install](#install) · [Layout](#package-layout) · [Migrations](#database-migrations) · [Testing](#testing) · [Related docs](#related-documentation)
 
 ![PostgreSQL ER diagram — papita_transactions v3 core + balance read models](../../docs/postgres_papita_transactions_v4.png)
 
@@ -10,7 +20,7 @@ Entity-relationship diagram for schema `papita_transactions`: **v3 core tables**
 
 Personal and small-business finance rarely starts in one clean database. Data arrives as bank CSVs, card portal exports, broker statements, spreadsheets, and manual corrections — each with its own column names, sign conventions, and category vocabulary. Without a shared domain layer, every import script re-implements validation, tenancy, and balance logic differently, and an API built on top inherits those inconsistencies.
 
-`papita-txnsmodel` solves that by treating finance as **structured, tenant-scoped domain data** in PostgreSQL (schema `papita_transactions`). Every path — bulk CSV ingest via handlers, direct service calls in notebooks, or future REST endpoints — flows through the same DTO validation, repository upserts, and service rules.
+`papita_txnsmodel` solves that by treating finance as **structured, tenant-scoped domain data** in PostgreSQL (schema `papita_transactions`). Every path — bulk CSV ingest via handlers, direct service calls in notebooks, or REST endpoints in `papita-txnsapi` — flows through the same DTO validation, repository upserts, and service rules.
 
 ### The problem space
 
@@ -330,59 +340,130 @@ txns.upsert_records(
 
 ## Install
 
-**PyPI name:** `papita-transactions-model` · **Import:** `papita_txnsmodel`
+**PyPI name:** [`papita-transactions-model`](https://pypi.org/project/papita-transactions-model/) · **Import:** `papita_txnsmodel` · **Requires:** Python `>=3.10,<3.15`
 
-| Mode                      | Command                                                                                                             |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Published (when released) | `pip install papita-transactions-model`                                                                             |
-| Poetry                    | `poetry add papita-transactions-model`                                                                              |
-| Monorepo path (this repo) | Root `pyproject.toml` path dep — `poetry install` from repo root                                                    |
-| TestPyPI                  | `pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ papita-transactions-model` |
+The published wheel is the **importable library**. Alembic migrations stay in this git checkout (`modules/model/alembic/`) and are applied with [`bin/alembic.sh`](../../bin/alembic.sh) (or Docker) from the monorepo — they are not a separate installable console script in the wheel.
 
-Alembic migrations remain in the **git checkout** (`modules/model/alembic/`); the published wheel is the importable library. Run migrations via [`bin/alembic.sh`](../../bin/alembic.sh) from this repository (or Docker).
+### Quick start (PyPI)
+
+```bash
+# Latest release from PyPI
+pip install papita-transactions-model
+
+# Pin a release (recommended for apps; versions on PyPI / CHANGELOG.md)
+pip install "papita-transactions-model==1.0.1"
+
+# Poetry (external project)
+poetry add papita-transactions-model
+# or compatible range used by papita-transactions-api:
+poetry add "papita-transactions-model>=1.0.0,<2.0"
+```
+
+Verify the install:
+
+```bash
+python -c "import papita_txnsmodel; from papita_txnsmodel import __version__; print(__version__)"
+```
+
+Installed wheels resolve `__version__` via `importlib.metadata` for distribution `papita-transactions-model`. Source checkouts fall back to reading this module’s [`pyproject.toml`](./pyproject.toml).
+
+### Install modes
+
+| Mode                     | When to use                              | Command                                                              |
+| :----------------------- | :--------------------------------------- | :------------------------------------------------------------------- |
+| **PyPI (production)**    | Apps, CI consumers, external projects    | `pip install papita-transactions-model`                              |
+| **Pinned PyPI**          | Reproducible deploys                     | `pip install "papita-transactions-model==<version>"`                 |
+| **Poetry (external)**    | Poetry-managed apps outside this repo    | `poetry add papita-transactions-model`                               |
+| **Monorepo (develop)**   | Contributors working in `save-ma-money`  | From repo root: `poetry install` (path dep in root `pyproject.toml`) |
+| **Editable module only** | Local hack on model in isolation         | `pip install -e modules/model` (from repo root)                      |
+| **TestPyPI**             | Pre-release smoke against the test index | See [TestPyPI](#testpypi)                                            |
+
+**API module note:** `papita-transactions-api` depends on `papita-transactions-model (>=1.0.0,<2.0)`. Keep that range in sync when cutting model majors.
+
+### TestPyPI
+
+```bash
+pip install \
+  -i https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  papita-transactions-model
+```
+
+`--extra-index-url` pulls runtime dependencies from real PyPI when they are not mirrored on TestPyPI.
+
+### After install — database
+
+1. Provide a PostgreSQL URL (`postgresql+psycopg2://…`).
+2. From a **clone of this repository**, run migrations (wheel alone does not ship runnable Alembic env wiring for ops):
+
+```bash
+/bin/bash ./bin/alembic.sh upgrade --docker-local --docker-rm
+# or:
+/bin/bash ./bin/alembic.sh upgrade --url "postgresql+psycopg2://user:pass@host:5432/db"
+```
+
+3. Establish the connector in application code (see [Database integration](#database-integration)).
+
+Environment templates: [`.env.example`](../../.env.example) · Compose: [`docker/database/docker-compose.yml`](../../docker/database/docker-compose.yml).
 
 ### Build / version / publish (PPT-024)
 
-**Automatic versioning** uses [python-semantic-release](https://python-semantic-release.readthedocs.io/) on `main` ([`release-model.yml`](../../.github/workflows/release-model.yml)):
+Packaging and release automation for **this module only** ([#11](https://github.com/Elmorralito/save-ma-money/issues/11)):
 
-- Updates **`modules/model/CHANGELOG.md` only** (never root [`CHANGELOG.md`](../../CHANGELOG.md) — that file is owned by [`auto-updates.yml`](../../.github/workflows/auto-updates.yml))
-- Bumps `pyproject.toml` and tags `model-v{version}`
-- PyPI upload: [`publish-model.yml`](../../.github/workflows/publish-model.yml) on those tags
+| Concern                                          | Owner                                                                                                                                         |
+| :----------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
+| Version bump + `model-v*` tag + GH release notes | [`release-model.yml`](../../.github/workflows/release-model.yml) ([python-semantic-release](https://python-semantic-release.readthedocs.io/)) |
+| Package release notes                            | [`modules/model/CHANGELOG.md`](./CHANGELOG.md) **only**                                                                                       |
+| Monorepo issue tracker changelog                 | Root [`CHANGELOG.md`](../../CHANGELOG.md) via [`auto-updates.yml`](../../.github/workflows/auto-updates.yml) — **never** written by PSR       |
+| sdist / wheel → TestPyPI / PyPI                  | [`publish-model.yml`](../../.github/workflows/publish-model.yml) (OIDC [Trusted Publishers](https://docs.pypi.org/trusted-publishers/))       |
 
-Use Conventional Commits with a **model** scope so bumps are detected:
+**Commit style for bumps** — Conventional Commits with model scope (or path-filtered changes under `modules/model/`). Title style `feat/PPT-024: …` alone does **not** drive a version bump:
 
 ```text
 feat(model): add report window helper
 fix(model): correct soft-delete filter
 ```
 
-```bash
-# Manual bump (escape hatch; prefer semantic-release on main)
-./bin/version.sh --mod model --version 0.1.14 --skip-install
+**Avoid `[skip ci]` in squash-merge bodies** — GitHub skips all `push` workflows for that commit (including `release-model.yml`). Prefer a clean squash title/body, or put skip tokens only on standalone non-release commits.
 
-# Build sdist + wheel into dist/ (model only)
+#### Local build
+
+```bash
+# From repository root — model-only sdist + wheel → dist/
 ./bin/package.sh --mod model
 # or: make package-model
 
+# Manual version bump (escape hatch; prefer PSR on main)
+./bin/version.sh --mod model --version 1.0.2 --skip-install
+
 # Local smoke
-python -m venv /tmp/model-smoke && /tmp/model-smoke/bin/pip install dist/papita_transactions_model-*.whl
+python -m venv /tmp/model-smoke
+/tmp/model-smoke/bin/pip install dist/papita_transactions_model-*.whl
 /tmp/model-smoke/bin/python -c "import papita_txnsmodel; print(papita_txnsmodel.__version__)"
 ```
 
-| Trigger                                                       | Target                                                 |
-| ------------------------------------------------------------- | ------------------------------------------------------ |
-| Merge conventional `*(model):` / model-path commits to `main` | `release-model.yml` → tag `model-v*` + model CHANGELOG |
-| Tag `model-vX.Y.Z`                                            | PyPI via `publish-model.yml`                           |
-| Actions → **Publish model package** → `target=testpypi`       | TestPyPI (OIDC)                                        |
+`bin/package.sh` prefers the `poetry` CLI on `PATH` (as in CI via `snok/install-poetry`), with a `python -m poetry` fallback.
 
-Configure [Trusted Publishers](https://docs.pypi.org/trusted-publishers/) for this repo, `publish-model.yml`, and Environments `testpypi` / `pypi`. Do **not** commit API tokens.
+#### Release triggers
+
+| Trigger                                                                                        | Result                                                                                             |
+| :--------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------- |
+| Push/merge to `main` touching `modules/model/**` (or `workflow_dispatch` on **Release model**) | PSR bumps version, updates `modules/model/CHANGELOG.md`, tags `model-v*`, creates a GitHub Release |
+| Tag `model-vX.Y.Z` (when the push is not from `GITHUB_TOKEN`)                                  | `publish-model.yml` → **PyPI**                                                                     |
+| Actions → **Publish model package** → `target=testpypi`                                        | **TestPyPI** (OIDC, environment `testpypi`)                                                        |
+| Actions → **Publish model package** → `target=pypi` + `confirm_pypi=publish`                   | **PyPI** (OIDC, environment `pypi`) — use when tag pushes did not cascade                          |
+
+**Operator note:** Trusted Publishers are configured on PyPI/TestPyPI for workflow `publish-model.yml` and GitHub Environments `pypi` / `testpypi`. Do **not** commit API tokens. Tags created by `GITHUB_TOKEN` inside Actions often **do not** start other workflows — if a tag exists but PyPI was not updated, re-dispatch **Publish model package** manually (see [CI.md](../../.github/CI.md#publish-model-package-ppt-024)).
 
 ## Package layout
 
 ```
 modules/model/
+├── pyproject.toml              # Package metadata + [tool.semantic_release]
+├── CHANGELOG.md                # Package releases (PSR; not root CHANGELOG.md)
 ├── alembic/                    # Migrations (alembic.ini at module root)
 ├── src/papita_txnsmodel/
+│   ├── __meta__.py             # Version (importlib.metadata or pyproject)
 │   ├── model/                  # SQLModel tables
 │   ├── access/                 # DTOs + repositories per domain
 │   ├── services/               # Business logic
@@ -416,13 +497,14 @@ Environment templates: [`.env.example`](../../.env.example) · Docker Compose: [
 
 ## Testing
 
-**351** tests — layered coverage across access, database, services, handlers, and views.
+**406** tests (collected) — layered coverage across access, database, services, handlers, views, and package metadata.
 
-| Suite            | Location                                     | Requirements                                                 |
-| :--------------- | :------------------------------------------- | :----------------------------------------------------------- |
-| Unit (default)   | `tests/tests_papita_txnsmodel/`              | Mocked DB; no `DATABASE_URL` needed                          |
-| Integration      | `tests/.../integration/`                     | `DATABASE_URL` must be PostgreSQL; 4 tests skipped otherwise |
-| PPT-041 services | `tests/.../services/test_ppt041_services.py` | Account orchestration, transfers, reports, category guards   |
+| Suite            | Location                                     | Requirements                                                    |
+| :--------------- | :------------------------------------------- | :-------------------------------------------------------------- |
+| Unit (default)   | `tests/tests_papita_txnsmodel/`              | Mocked DB; no `DATABASE_URL` needed                             |
+| Integration      | `tests/.../integration/`                     | `DATABASE_URL` must be PostgreSQL; live tests skipped otherwise |
+| PPT-041 services | `tests/.../services/test_ppt041_services.py` | Account orchestration, transfers, reports, category guards      |
+| Package meta     | `tests/.../test_meta.py`                     | `__version__` via importlib.metadata / pyproject fallback       |
 
 ```bash
 # Standard gate (from repo root)
@@ -438,6 +520,9 @@ DATABASE_URL="postgresql+psycopg2://user:pass@localhost:5435/papita" \
 
 | Document                                                                                                                                                             | Description                                                                                       |
 | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------ |
+| [`CHANGELOG.md`](./CHANGELOG.md)                                                                                                                                     | **Package** release notes (python-semantic-release)                                               |
+| [PyPI — papita-transactions-model](https://pypi.org/project/papita-transactions-model/)                                                                              | Published distributions                                                                           |
+| [`.github/CI.md` — Publish model](../../.github/CI.md#publish-model-package-ppt-024)                                                                                 | Release + OIDC publish workflows (PPT-024)                                                        |
 | [`docs/design/README.md`](../../docs/design/README.md)                                                                                                               | PPT-031 design program index                                                                      |
 | [`docs/design/ARCHITECTURE.md#part-ii--target-schema-v1v3-ppt-031-a2a4-32`](../../docs/design/ARCHITECTURE.md#part-ii--target-schema-v1v3-ppt-031-a2a4-32)           | v3 frozen schema, constraints, G1 checklist                                                       |
 | [`docs/design/ARCHITECTURE.md#part-i--v0-data-model-audit-ppt-031-a1-30`](../../docs/design/ARCHITECTURE.md#part-i--v0-data-model-audit-ppt-031-a1-30)               | v0 inventory, 3NF analysis, NF register                                                           |
@@ -446,8 +531,8 @@ DATABASE_URL="postgresql+psycopg2://user:pass@localhost:5435/papita" \
 | [`docs/design/ARCHITECTURE.md#part-vii--migration-runbook-ppt-031-d-34`](../../docs/design/ARCHITECTURE.md#part-vii--migration-runbook-ppt-031-d-34)                 | B0/B1 validation, rollback, FR-14                                                                 |
 | [`docs/issues/README.md#part-ii--ppt-031-c-supabase--fastapi-decision-31`](../../docs/issues/README.md#part-ii--ppt-031-c-supabase--fastapi-decision-31)             | B0/B1 platform; B2/B3 deferred                                                                    |
 | [`docs/design/ARCHITECTURE.md#part-iii--post-mvp-v4-extensions-ppt-031-track-a`](../../docs/design/ARCHITECTURE.md#part-iii--post-mvp-v4-extensions-ppt-031-track-a) | Budgets, splits, recurrence (post-MVP)                                                            |
-| [`modules/api/README.md`](../api/README.md)                                                                                                                          | FastAPI scaffold and target REST contract                                                         |
+| [`modules/api/README.md`](../api/README.md)                                                                                                                          | FastAPI REST surface over this model                                                              |
 | [`README.md`](../../README.md)                                                                                                                                       | Monorepo overview and quick start                                                                 |
-| [`CHANGELOG.md`](../../CHANGELOG.md)                                                                                                                                 | Issue and release tracker                                                                         |
+| [`CHANGELOG.md`](../../CHANGELOG.md)                                                                                                                                 | Monorepo **issue** tracker (auto-updates; not package releases)                                   |
 
-Package version: [`pyproject.toml`](./pyproject.toml) (`papita-transactions-model`).
+Package metadata: [`pyproject.toml`](./pyproject.toml) (`papita-transactions-model`).


### PR DESCRIPTION
**Branch:** `docs/updating-readme-model-package` · **Base:** `main` · **1 commit** · **6 files**

## Summary

After the first live publish of `papita-transactions-model` (1.0.1 on PyPI/TestPyPI), this updates the model package README with real install/release instructions and hardens CI around PR freshness and Node.js 24 artifact actions. Operators and consumers get a clear path from `pip install` through Trusted Publisher publish, and PRs that lag `main` fail a dedicated sync check.

## Out of scope / Highlights

**Out of scope**

- Re-publishing or re-tagging the model package
- Changing PSR / release-model versioning rules
- Making Branch sync a required status check in branch protection (repo settings)

**Highlights**

- Model README documents PyPI install, TestPyPI, monorepo path deps, and the GITHUB_TOKEN tag-cascade caveat
- New always-on PR gate: fail when the head is behind `origin/main`
- Clears Node.js 20 deprecation warnings from [publish-model run #30290382262](https://github.com/Elmorralito/save-ma-money/actions/runs/30290382262)

## Changes

**Docs (model)**

- Expand `modules/model/README.md` Install section: PyPI / pin / Poetry / editable / TestPyPI, version verify, migrations stay in-repo
- Document release ownership (PSR → `modules/model/CHANGELOG.md` only; root CHANGELOG = auto-updates)
- Note API dep range `papita-transactions-model (>=1.0.0,<2.0)` and `[skip ci]` squash-merge pitfall
- Refresh package layout, test count (406), and related links (PyPI, CI.md)

**CI / ops**

- Add `branch-sync.yml` + `branch_sync_check.sh`: PRs fail if behind `origin/main` (ahead-only is OK)
- Document the gate in `.github/CI.md` (matrix, local run, troubleshooting)
- Bump `publish-model.yml` to `actions/upload-artifact@v6` and `actions/download-artifact@v7` (Node.js 24 runtimes)
- Align CI.md toolchain pins for checkout/setup-python `@v7` and artifact actions

**Strata**

- Update `.strata/memory/project_state.md` for the above

## File changes

<details>
<summary>File changes (6 files)</summary>

```
 .github/CI.md                        |  66 +++++++++++----
 .github/scripts/branch_sync_check.sh |  61 ++++++++++++++
 .github/workflows/branch-sync.yml    |  52 ++++++++++++
 .github/workflows/publish-model.yml  |   7 +-
 .strata/memory/project_state.md      |  13 ++-
 modules/model/README.md              | 155 +++++++++++++++++++++++++++--------
 6 files changed, 295 insertions(+), 59 deletions(-)
```

</details>

## Commits

- `bc294f0` docs(ci): refresh model README install path and harden PR/publish CI

## Checks, tests, and validation already done

- Local pre-commit on commit (shellcheck, actionlint, yamllint, prettier, markdownlint, strata) — pass
- Local `branch_sync_check.sh` vs `origin/main` — pass (behind=0)
- GitHub Actions on this PR — not yet observed at description time

## QA / test plan

- [ ] Confirm CI green on this PR (including new **Branch sync with main** / Not behind main)
- [ ] Skim model README Install + Build/version/publish sections for accuracy against live PyPI 1.0.1
- [ ] Optional: dispatch **Publish model package** (testpypi) after merge and confirm Node.js 20 artifact warnings are gone
- [ ] Optional: open a throwaway PR from a stale branch and confirm Branch sync fails until rebased/merged with main

## Risks

> [!CAUTION]
>
> ### Risks
>
> - **Branch sync is a new failing check** on all PRs once this lands — contributors with stale branches must merge/rebase `main` before the gate passes (enable as required in branch protection if desired)
> - Mixed PR concerns (docs + CI) — reviewers should skim both areas

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - Tag pushes created by `GITHUB_TOKEN` inside Actions still may not cascade into `publish-model.yml`; manual dispatch remains the escape hatch (documented in the model README)
> - Artifact action majors jump `v4` → `v6`/`v7` (Node 24); behavior for this workflow’s zip path should be unchanged, but first post-merge publish is the real confirmation

## References

- Related context: [PPT-024 / #11](https://github.com/Elmorralito/save-ma-money/issues/11) (prior model packaging work; this PR does not close it)
- [Publish model package run (Node 20 warnings)](https://github.com/Elmorralito/save-ma-money/actions/runs/30290382262)
- [PyPI — papita-transactions-model](https://pypi.org/project/papita-transactions-model/)
- [`.github/CI.md`](https://github.com/Elmorralito/save-ma-money/blob/main/.github/CI.md)