### PR TITLE
style(model): prettier-format CHANGELOG for QC gate

### DIFF
--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -23,3 +23,5 @@ project**. Papita API verifies JWTs + links `users` by `sub` — it is not the I
 
 - Do not commit `environments/**/.env`
 - PSR → `modules/model/CHANGELOG.md` only; root CHANGELOG = auto-updates.yml
+
+- Prettier-format modules/model/CHANGELOG.md (unblocks Dependabot QC)

--- a/modules/model/CHANGELOG.md
+++ b/modules/model/CHANGELOG.md
@@ -32,7 +32,6 @@ This file is **not** the monorepo issue tracker changelog. Root
   ([#105](https://github.com/Elmorralito/save-ma-money/pull/105),
   [`9e60ffe`](https://github.com/Elmorralito/save-ma-money/commit/9e60ffe8f15f3d2ded702993e115814d4d65995c))
 
-
 ## v1.0.0 (2026-07-24)
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary
One-line prettier fix on `modules/model/CHANGELOG.md` so `quality-control` (`pre-commit --all-files`) stops failing on Dependabot PRs that do not touch this file.

## Test plan
- [x] `pre-commit run prettier --files modules/model/CHANGELOG.md`
- [ ] QC green after merge; re-run Dependabot PR checks


Made with [Cursor](https://cursor.com)