### PR TITLE
feat/PPT-048: [web] OpenAPI types + thin API client (no domain logic)

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -74,6 +74,8 @@ Domain entities in the model layer include **accounts**, **transactions**, **cat
 
 **Web OpenAPI types (PPT-065):** strategy **B** — committed `modules/web/openapi/openapi.json` + `openapi-typescript` → `modules/web/src/types/api.d.ts`. After API/model OpenAPI-affecting changes run `make web-openapi`. CI: `web-ci.yml` (`check-types`) + `openapi-contract.yml` (artifact vs offline `app.openapi()`; paths include API src + model `model/`/`access/`). Exporter normalizes `info.version`. See `modules/web/README.md`.
 
+**Web thin API client (PPT-048):** `modules/web/src/api/` — `apiFetch` (`credentials: 'include'`, no Bearer), `queryKeys` / `queryOptions`, `PapitaApiError` + discovery headers, health/meta probes only. Domain logic stays in Python.
+
 ---
 
 ## Layered architecture (model package)

--- a/modules/web/README.md
+++ b/modules/web/README.md
@@ -65,7 +65,24 @@ make sync-openapi-live   # needs make api-up with DEBUG or DOCS_ENABLED=true
 
 If live fetch returns 404, enable docs on the running API or use `make sync-openapi` instead.
 
-Thin schema aliases live in `src/types/domain.ts`. HTTP client / TanStack Query wiring is [#114](https://github.com/Elmorralito/save-ma-money/issues/114).
+Thin schema aliases live in `src/types/domain.ts`.
+
+## Thin HTTP client + TanStack Query (PPT-048 / #114)
+
+Presentation-only client under `src/api/`. **No** `papita_txnsmodel` business logic in TypeScript — typed HTTP + Query wiring only.
+
+| Piece            | Location                                       | Notes                                                                        |
+| ---------------- | ---------------------------------------------- | ---------------------------------------------------------------------------- |
+| `apiFetch`       | `src/api/http.ts`                              | `credentials: 'include'`; `AbortSignal`; no `Authorization` header           |
+| Base URL         | `src/api/config.ts`                            | Default same-origin (`""`) → Vite `/api` proxy; optional `VITE_API_BASE_URL` |
+| Errors           | `src/api/errors.ts`                            | `PapitaApiError` maps `X-Papita-Error-Code` + discovery headers              |
+| Contract helpers | `src/api/contract.ts`                          | `bulkMaxTransactions` / `reportWindowMaxDays` from body (prefer) or headers  |
+| Probes           | `src/api/meta.ts`, `health.ts`                 | Unauthenticated health + `GET /api/v1/meta/client-contract`                  |
+| Query            | `queryKeys.ts`, `queries.ts`, `queryClient.ts` | `queryOptions()`; `staleTime` 60s; **no 4xx retries**                        |
+
+**Credentials policy:** always send cookies (`credentials: 'include'`) so PPT-049 BFF HttpOnly sessions work without client changes. Do **not** store JWTs in `localStorage` / JS-readable storage or attach Bearer tokens from the SPA (PDF Axios interceptor pattern is superseded).
+
+**Local smoke:** `make api-up` then `make web-dev` — the App scaffold shows health status + bulk/report limits from the contract probe.
 
 ## Vite `/api` proxy
 

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -20,6 +20,7 @@
     "check-types": "node ./scripts/check-types.mjs"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/modules/web/src/App.test.tsx
+++ b/modules/web/src/App.test.tsx
@@ -1,11 +1,71 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import App from "@/App";
+import { QueryTestProvider } from "@/test/queryWrapper";
+
+vi.mock("@/api/health", () => ({
+  getHealth: vi.fn(async () => ({
+    status: "healthy",
+    version: "0.0.0-test",
+    timestamp: "2026-07-29T00:00:00Z",
+    database: "connected",
+    auth: "skipped",
+    auth_detail: "auth provider is local — supabase probe skipped",
+    redis: "skipped",
+    redis_detail: "redis disabled",
+  })),
+  getHealthLive: vi.fn(async () => ({ status: "ok" })),
+}));
+
+vi.mock("@/api/meta", () => ({
+  getClientContract: vi.fn(async () => ({
+    contract: {
+      breaking_changes: "ppt-044",
+      api_version: "0.0.0-test",
+      secure_defaults: {
+        reports_foreign_account_status: 404,
+        cash_flow_refresh_balances_default: false,
+        bulk_max_transactions: 100,
+        report_window_max_days: 366,
+        docs_require_debug_or_docs_enabled: true,
+        cors_wildcard_forbidden_when_not_debug: true,
+      },
+      effective: {
+        reports_foreign_account_status: 404,
+        cash_flow_refresh_balances_default: false,
+        bulk_max_transactions: 100,
+        report_window_max_days: 366,
+        docs_enabled: true,
+      },
+      compat: { active: [], sunset: null, flags: {} },
+      error_codes: {},
+      migration: {
+        probe: "GET /api/v1/meta/client-contract",
+        prefer_headers: [],
+        client_checklist: [],
+      },
+    },
+    discovery: {
+      breakingChanges: "ppt-044",
+      bulkMax: 100,
+      reportWindowMaxDays: 366,
+      cashFlowRefreshDefault: false,
+      reportsForeignAccountStatus: 404,
+      errorCode: null,
+      compatActive: [],
+    },
+  })),
+}));
 
 describe("App", () => {
-  it("renders the scaffold heading", () => {
-    render(<App />);
+  it("renders the scaffold heading and contract probe section", () => {
+    render(
+      <QueryTestProvider>
+        <App />
+      </QueryTestProvider>,
+    );
     expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "API probe status" })).toBeInTheDocument();
   });
 });

--- a/modules/web/src/App.tsx
+++ b/modules/web/src/App.tsx
@@ -1,18 +1,54 @@
-import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  bulkMaxTransactions,
+  clientContractQueryOptions,
+  healthQueryOptions,
+  reportWindowMaxDays,
+} from "@/api";
 
 import "./App.css";
 
 function App() {
-  const [count, setCount] = useState(0);
   const title = import.meta.env.VITE_APP_TITLE ?? "Papita";
+  const healthQuery = useQuery(healthQueryOptions());
+  const contractQuery = useQuery(clientContractQueryOptions());
+
+  const bulkMax = bulkMaxTransactions(contractQuery.data);
+  const windowMax = reportWindowMaxDays(contractQuery.data);
 
   return (
     <main className="app">
       <h1>{title}</h1>
-      <p>Web scaffold (PPT-047). Domain features land in later epic children.</p>
-      <button type="button" onClick={() => setCount((value) => value + 1)}>
-        Count is {count}
-      </button>
+      <p>
+        Thin API client wiring (PPT-048). Domain features land in later epic children; auth cookies
+        land in PPT-049.
+      </p>
+      <section aria-label="API probe status">
+        <h2>Contract probes</h2>
+        <ul>
+          <li>
+            Health:{" "}
+            {healthQuery.isPending
+              ? "loading…"
+              : healthQuery.isError
+                ? "unavailable (start API with make api-up)"
+                : (healthQuery.data?.status ?? "unknown")}
+          </li>
+          <li>
+            Bulk max:{" "}
+            {contractQuery.isPending ? "loading…" : contractQuery.isError ? "—" : (bulkMax ?? "—")}
+          </li>
+          <li>
+            Report window max days:{" "}
+            {contractQuery.isPending
+              ? "loading…"
+              : contractQuery.isError
+                ? "—"
+                : (windowMax ?? "—")}
+          </li>
+        </ul>
+      </section>
     </main>
   );
 }

--- a/modules/web/src/api/config.ts
+++ b/modules/web/src/api/config.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolve the API base URL for browser calls.
+ *
+ * Empty / unset uses same-origin paths so the Vite `/api` proxy (dev) or
+ * nginx `/api` reverse proxy (prod) handles routing. Set `VITE_API_BASE_URL`
+ * only when calling the API cross-origin (then CORS `ALLOWED_ORIGINS` must
+ * include the web origin).
+ */
+export function resolveApiBaseUrl(): string {
+  const configured = import.meta.env.VITE_API_BASE_URL?.trim();
+  if (configured === undefined || configured === "") {
+    return "";
+  }
+  return configured.replace(/\/+$/, "");
+}
+
+/** Join base URL with an absolute API path (must start with `/`). */
+export function buildApiUrl(path: string): string {
+  if (!path.startsWith("/")) {
+    throw new Error(`API path must be absolute (got ${path})`);
+  }
+  return `${resolveApiBaseUrl()}${path}`;
+}

--- a/modules/web/src/api/contract.test.ts
+++ b/modules/web/src/api/contract.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bulkMaxTransactions,
+  reportWindowMaxDays,
+  reportsForeignAccountStatus,
+} from "@/api/contract";
+import type { DiscoveryHeaders } from "@/api/headers";
+import type { ClientContract } from "@/types/domain";
+
+const sampleContract = {
+  breaking_changes: "ppt-044",
+  api_version: "1.0.0",
+  secure_defaults: {
+    reports_foreign_account_status: 404,
+    cash_flow_refresh_balances_default: false,
+    bulk_max_transactions: 100,
+    report_window_max_days: 366,
+    docs_require_debug_or_docs_enabled: true,
+    cors_wildcard_forbidden_when_not_debug: true,
+  },
+  effective: {
+    reports_foreign_account_status: 404,
+    cash_flow_refresh_balances_default: false,
+    bulk_max_transactions: 50,
+    report_window_max_days: 90,
+    docs_enabled: true,
+  },
+  compat: { active: [], sunset: null, flags: {} },
+  error_codes: {},
+  migration: {
+    probe: "GET /api/v1/meta/client-contract",
+    prefer_headers: [],
+    client_checklist: [],
+  },
+} satisfies ClientContract;
+
+const sampleDiscovery: DiscoveryHeaders = {
+  breakingChanges: "ppt-044",
+  bulkMax: 25,
+  reportWindowMaxDays: 30,
+  cashFlowRefreshDefault: false,
+  reportsForeignAccountStatus: 400,
+  errorCode: null,
+  compatActive: [],
+};
+
+describe("contract helpers", () => {
+  it("prefers effective body values over discovery headers", () => {
+    expect(bulkMaxTransactions(sampleContract, sampleDiscovery)).toBe(50);
+    expect(reportWindowMaxDays(sampleContract, sampleDiscovery)).toBe(90);
+    expect(reportsForeignAccountStatus(sampleContract, sampleDiscovery)).toBe(404);
+  });
+
+  it("falls back to discovery headers when body is absent", () => {
+    expect(bulkMaxTransactions(null, sampleDiscovery)).toBe(25);
+    expect(reportWindowMaxDays(undefined, sampleDiscovery)).toBe(30);
+    expect(reportsForeignAccountStatus(null, sampleDiscovery)).toBe(400);
+  });
+
+  it("returns null when neither body nor headers provide a value", () => {
+    expect(bulkMaxTransactions(null, null)).toBeNull();
+    expect(reportWindowMaxDays(null, null)).toBeNull();
+  });
+});

--- a/modules/web/src/api/contract.ts
+++ b/modules/web/src/api/contract.ts
@@ -1,0 +1,38 @@
+import type { DiscoveryHeaders } from "@/api/headers";
+import type { ClientContract } from "@/types/domain";
+
+/** Bulk create cap from contract JSON body (preferred) or discovery headers. */
+export function bulkMaxTransactions(
+  contract: ClientContract | null | undefined,
+  discovery?: DiscoveryHeaders | null,
+): number | null {
+  const fromBody = contract?.effective?.bulk_max_transactions;
+  if (typeof fromBody === "number" && Number.isFinite(fromBody)) {
+    return fromBody;
+  }
+  return discovery?.bulkMax ?? null;
+}
+
+/** Report window max days from contract JSON body or discovery headers. */
+export function reportWindowMaxDays(
+  contract: ClientContract | null | undefined,
+  discovery?: DiscoveryHeaders | null,
+): number | null {
+  const fromBody = contract?.effective?.report_window_max_days;
+  if (typeof fromBody === "number" && Number.isFinite(fromBody)) {
+    return fromBody;
+  }
+  return discovery?.reportWindowMaxDays ?? null;
+}
+
+/** Foreign report `account_id` HTTP status (404 secure default; 400 when compat). */
+export function reportsForeignAccountStatus(
+  contract: ClientContract | null | undefined,
+  discovery?: DiscoveryHeaders | null,
+): number | null {
+  const fromBody = contract?.effective?.reports_foreign_account_status;
+  if (typeof fromBody === "number" && Number.isFinite(fromBody)) {
+    return fromBody;
+  }
+  return discovery?.reportsForeignAccountStatus ?? null;
+}

--- a/modules/web/src/api/errors.test.ts
+++ b/modules/web/src/api/errors.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isClientHttpError,
+  isPapitaApiError,
+  PapitaApiError,
+  papitaApiErrorFromResponse,
+} from "@/api/errors";
+import { HEADER_BULK_MAX, HEADER_ERROR_CODE } from "@/api/headers";
+
+describe("PapitaApiError", () => {
+  it("exposes status, code, and discovery headers", () => {
+    const error = new PapitaApiError({
+      message: "too many",
+      status: 400,
+      code: "bulk_too_large",
+      discovery: {
+        breakingChanges: "ppt-044",
+        bulkMax: 100,
+        reportWindowMaxDays: 366,
+        cashFlowRefreshDefault: false,
+        reportsForeignAccountStatus: 404,
+        errorCode: "bulk_too_large",
+        compatActive: [],
+      },
+    });
+
+    expect(isPapitaApiError(error)).toBe(true);
+    expect(isClientHttpError(error)).toBe(true);
+    expect(error.code).toBe("bulk_too_large");
+    expect(error.discovery.bulkMax).toBe(100);
+  });
+
+  it("does not treat 5xx as client HTTP errors", () => {
+    const error = new PapitaApiError({
+      message: "boom",
+      status: 500,
+      discovery: {
+        breakingChanges: null,
+        bulkMax: null,
+        reportWindowMaxDays: null,
+        cashFlowRefreshDefault: null,
+        reportsForeignAccountStatus: null,
+        errorCode: null,
+        compatActive: [],
+      },
+    });
+    expect(isClientHttpError(error)).toBe(false);
+  });
+
+  it("maps X-Papita-Error-Code from a failed Response", async () => {
+    const response = new Response(JSON.stringify({ detail: "Bulk create exceeds max" }), {
+      status: 400,
+      headers: {
+        "content-type": "application/json",
+        [HEADER_ERROR_CODE]: "bulk_too_large",
+        [HEADER_BULK_MAX]: "100",
+      },
+    });
+
+    const error = await papitaApiErrorFromResponse(response);
+    expect(error.message).toBe("Bulk create exceeds max");
+    expect(error.code).toBe("bulk_too_large");
+    expect(error.discovery.bulkMax).toBe(100);
+  });
+});

--- a/modules/web/src/api/errors.ts
+++ b/modules/web/src/api/errors.ts
@@ -1,0 +1,80 @@
+import { parseDiscoveryHeaders, type DiscoveryHeaders } from "@/api/headers";
+
+/** Structured client error for papita_txnsapi responses (no domain rules). */
+export class PapitaApiError extends Error {
+  readonly status: number;
+  readonly code: string | null;
+  readonly discovery: DiscoveryHeaders;
+  readonly body: unknown;
+
+  constructor(options: {
+    message: string;
+    status: number;
+    code?: string | null;
+    discovery: DiscoveryHeaders;
+    body?: unknown;
+  }) {
+    super(options.message);
+    this.name = "PapitaApiError";
+    this.status = options.status;
+    this.code = options.code ?? options.discovery.errorCode;
+    this.discovery = options.discovery;
+    this.body = options.body;
+  }
+}
+
+/** True when `error` is a {@link PapitaApiError}. */
+export function isPapitaApiError(error: unknown): error is PapitaApiError {
+  return error instanceof PapitaApiError;
+}
+
+/** HTTP status is a client error (do not retry in TanStack Query). */
+export function isClientHttpError(error: unknown): boolean {
+  return isPapitaApiError(error) && error.status >= 400 && error.status < 500;
+}
+
+function extractErrorMessage(body: unknown, fallback: string): string {
+  if (typeof body === "string" && body.trim() !== "") {
+    return body;
+  }
+  if (body !== null && typeof body === "object") {
+    const record = body as Record<string, unknown>;
+    const detail = record["detail"];
+    if (typeof detail === "string" && detail.trim() !== "") {
+      return detail;
+    }
+    if (Array.isArray(detail) && detail.length > 0) {
+      return "Request validation failed";
+    }
+    const message = record["message"];
+    if (typeof message === "string" && message.trim() !== "") {
+      return message;
+    }
+  }
+  return fallback;
+}
+
+/** Build a {@link PapitaApiError} from a failed Fetch response. */
+export async function papitaApiErrorFromResponse(response: Response): Promise<PapitaApiError> {
+  const discovery = parseDiscoveryHeaders(response.headers);
+  let body: unknown;
+  const contentType = response.headers.get("content-type") ?? "";
+  try {
+    if (contentType.includes("application/json")) {
+      body = await response.json();
+    } else {
+      const text = await response.text();
+      body = text === "" ? undefined : text;
+    }
+  } catch {
+    body = undefined;
+  }
+
+  return new PapitaApiError({
+    message: extractErrorMessage(body, `HTTP ${String(response.status)}`),
+    status: response.status,
+    code: discovery.errorCode,
+    discovery,
+    body,
+  });
+}

--- a/modules/web/src/api/headers.ts
+++ b/modules/web/src/api/headers.ts
@@ -1,0 +1,70 @@
+/**
+ * PPT-044 discovery / error header names (mirror papita_txnsapi.core.client_contract).
+ */
+
+export const HEADER_BREAKING_CHANGES = "X-Papita-Breaking-Changes";
+export const HEADER_BULK_MAX = "X-Papita-Bulk-Max";
+export const HEADER_REPORT_WINDOW_MAX_DAYS = "X-Papita-Report-Window-Max-Days";
+export const HEADER_REFRESH_BALANCES_DEFAULT = "X-Papita-Cash-Flow-Refresh-Default";
+export const HEADER_REPORTS_FOREIGN_ACCOUNT_STATUS = "X-Papita-Reports-Foreign-Account-Status";
+export const HEADER_ERROR_CODE = "X-Papita-Error-Code";
+export const HEADER_COMPAT_ACTIVE = "X-Papita-Compat-Active";
+
+/** Parsed discovery headers from an `/api/v1` response. */
+export type DiscoveryHeaders = {
+  breakingChanges: string | null;
+  bulkMax: number | null;
+  reportWindowMaxDays: number | null;
+  cashFlowRefreshDefault: boolean | null;
+  reportsForeignAccountStatus: number | null;
+  errorCode: string | null;
+  compatActive: string[];
+};
+
+function headerGet(headers: Headers, name: string): string | null {
+  return headers.get(name);
+}
+
+function parseIntHeader(value: string | null): number | null {
+  if (value === null || value.trim() === "") {
+    return null;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseBoolHeader(value: string | null): boolean | null {
+  if (value === null) {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true") {
+    return true;
+  }
+  if (normalized === "false") {
+    return false;
+  }
+  return null;
+}
+
+/** Extract PPT-044 discovery headers from a Fetch `Headers` object. */
+export function parseDiscoveryHeaders(headers: Headers): DiscoveryHeaders {
+  const compatRaw = headerGet(headers, HEADER_COMPAT_ACTIVE);
+  return {
+    breakingChanges: headerGet(headers, HEADER_BREAKING_CHANGES),
+    bulkMax: parseIntHeader(headerGet(headers, HEADER_BULK_MAX)),
+    reportWindowMaxDays: parseIntHeader(headerGet(headers, HEADER_REPORT_WINDOW_MAX_DAYS)),
+    cashFlowRefreshDefault: parseBoolHeader(headerGet(headers, HEADER_REFRESH_BALANCES_DEFAULT)),
+    reportsForeignAccountStatus: parseIntHeader(
+      headerGet(headers, HEADER_REPORTS_FOREIGN_ACCOUNT_STATUS),
+    ),
+    errorCode: headerGet(headers, HEADER_ERROR_CODE),
+    compatActive:
+      compatRaw === null || compatRaw.trim() === ""
+        ? []
+        : compatRaw
+            .split(",")
+            .map((part) => part.trim())
+            .filter((part) => part.length > 0),
+  };
+}

--- a/modules/web/src/api/health.ts
+++ b/modules/web/src/api/health.ts
@@ -1,0 +1,17 @@
+import { apiFetch } from "@/api/http";
+import type { HealthResponse } from "@/types/domain";
+
+const HEALTH_PATH = "/api/v1/health";
+const HEALTH_LIVE_PATH = "/api/v1/health/live";
+
+/** Aggregate health probe (`GET /api/v1/health`). */
+export async function getHealth(signal?: AbortSignal): Promise<HealthResponse> {
+  const result = await apiFetch<HealthResponse>(HEALTH_PATH, { signal });
+  return result.data;
+}
+
+/** Liveness probe (`GET /api/v1/health/live`) — no dependency checks. */
+export async function getHealthLive(signal?: AbortSignal): Promise<unknown> {
+  const result = await apiFetch<unknown>(HEALTH_LIVE_PATH, { signal });
+  return result.data;
+}

--- a/modules/web/src/api/http.test.ts
+++ b/modules/web/src/api/http.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PapitaApiError } from "@/api/errors";
+import { HEADER_ERROR_CODE } from "@/api/headers";
+import { apiFetch } from "@/api/http";
+
+describe("apiFetch", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("sends credentials include and forwards AbortSignal", async () => {
+    const signal = new AbortController().signal;
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json({ status: "healthy" }, { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await apiFetch<{ status: string }>("/api/v1/health", { signal });
+
+    expect(result.data.status).toBe("healthy");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/health",
+      expect.objectContaining({
+        credentials: "include",
+        signal,
+        method: "GET",
+      }),
+    );
+  });
+
+  it("throws PapitaApiError with error code on non-OK responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () =>
+        Response.json(
+          { detail: "nope" },
+          {
+            status: 404,
+            headers: { [HEADER_ERROR_CODE]: "report_account_not_found" },
+          },
+        ),
+      ),
+    );
+
+    await expect(apiFetch("/api/v1/meta/client-contract")).rejects.toBeInstanceOf(PapitaApiError);
+
+    try {
+      await apiFetch("/api/v1/meta/client-contract");
+      expect.fail("expected apiFetch to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PapitaApiError);
+      if (error instanceof PapitaApiError) {
+        expect(error.status).toBe(404);
+        expect(error.code).toBe("report_account_not_found");
+      }
+    }
+  });
+});

--- a/modules/web/src/api/http.ts
+++ b/modules/web/src/api/http.ts
@@ -1,0 +1,61 @@
+import { buildApiUrl } from "@/api/config";
+import { papitaApiErrorFromResponse } from "@/api/errors";
+import { parseDiscoveryHeaders, type DiscoveryHeaders } from "@/api/headers";
+
+export type ApiFetchOptions = {
+  method?: string;
+  signal?: AbortSignal;
+  headers?: HeadersInit;
+  body?: BodyInit | null;
+  /** Override default JSON Accept header. */
+  accept?: string;
+};
+
+export type ApiFetchResult<T> = {
+  data: T;
+  response: Response;
+  discovery: DiscoveryHeaders;
+};
+
+/**
+ * Thin Fetch wrapper for papita_txnsapi / BFF.
+ *
+ * - Uses same-origin `/api/...` by default (Vite proxy / nginx).
+ * - Always sends `credentials: 'include'` for future BFF cookie sessions (#115).
+ * - Does **not** attach `Authorization` — JWTs stay server-side after BFF lands.
+ */
+export async function apiFetch<T>(
+  path: string,
+  options: ApiFetchOptions = {},
+): Promise<ApiFetchResult<T>> {
+  const headers = new Headers(options.headers);
+  if (!headers.has("Accept")) {
+    headers.set("Accept", options.accept ?? "application/json");
+  }
+
+  const response = await fetch(buildApiUrl(path), {
+    method: options.method ?? "GET",
+    signal: options.signal,
+    credentials: "include",
+    headers,
+    body: options.body,
+  });
+
+  if (!response.ok) {
+    throw await papitaApiErrorFromResponse(response);
+  }
+
+  const discovery = parseDiscoveryHeaders(response.headers);
+  const contentType = response.headers.get("content-type") ?? "";
+  if (response.status === 204 || contentType === "") {
+    return { data: undefined as T, response, discovery };
+  }
+
+  if (contentType.includes("application/json")) {
+    const data = (await response.json()) as T;
+    return { data, response, discovery };
+  }
+
+  const text = (await response.text()) as T;
+  return { data: text, response, discovery };
+}

--- a/modules/web/src/api/index.ts
+++ b/modules/web/src/api/index.ts
@@ -1,0 +1,24 @@
+export {
+  bulkMaxTransactions,
+  reportWindowMaxDays,
+  reportsForeignAccountStatus,
+} from "@/api/contract";
+export { buildApiUrl, resolveApiBaseUrl } from "@/api/config";
+export { isClientHttpError, isPapitaApiError, PapitaApiError } from "@/api/errors";
+export {
+  HEADER_BULK_MAX,
+  HEADER_ERROR_CODE,
+  HEADER_REPORT_WINDOW_MAX_DAYS,
+  parseDiscoveryHeaders,
+  type DiscoveryHeaders,
+} from "@/api/headers";
+export { apiFetch, type ApiFetchOptions, type ApiFetchResult } from "@/api/http";
+export { getHealth, getHealthLive } from "@/api/health";
+export { getClientContract } from "@/api/meta";
+export {
+  clientContractQueryOptions,
+  healthLiveQueryOptions,
+  healthQueryOptions,
+} from "@/api/queries";
+export { createAppQueryClient } from "@/api/queryClient";
+export { queryKeys } from "@/api/queryKeys";

--- a/modules/web/src/api/meta.ts
+++ b/modules/web/src/api/meta.ts
@@ -1,0 +1,14 @@
+import type { DiscoveryHeaders } from "@/api/headers";
+import { apiFetch } from "@/api/http";
+import type { ClientContract } from "@/types/domain";
+
+const CLIENT_CONTRACT_PATH = "/api/v1/meta/client-contract";
+
+/** Probe `GET /api/v1/meta/client-contract` (unauthenticated PPT-044 discovery). */
+export async function getClientContract(signal?: AbortSignal): Promise<{
+  contract: ClientContract;
+  discovery: DiscoveryHeaders;
+}> {
+  const result = await apiFetch<ClientContract>(CLIENT_CONTRACT_PATH, { signal });
+  return { contract: result.data, discovery: result.discovery };
+}

--- a/modules/web/src/api/queries.ts
+++ b/modules/web/src/api/queries.ts
@@ -1,0 +1,29 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { getHealth, getHealthLive } from "@/api/health";
+import { getClientContract } from "@/api/meta";
+import { queryKeys } from "@/api/queryKeys";
+
+/** Shared query definition for PPT-044 client-contract discovery. */
+export function clientContractQueryOptions() {
+  return queryOptions({
+    queryKey: queryKeys.meta.clientContract(),
+    queryFn: ({ signal }) => getClientContract(signal).then((result) => result.contract),
+  });
+}
+
+/** Shared query definition for aggregate API health. */
+export function healthQueryOptions() {
+  return queryOptions({
+    queryKey: queryKeys.health.root(),
+    queryFn: ({ signal }) => getHealth(signal),
+  });
+}
+
+/** Shared query definition for liveness (no DB/Auth/Redis). */
+export function healthLiveQueryOptions() {
+  return queryOptions({
+    queryKey: queryKeys.health.live(),
+    queryFn: ({ signal }) => getHealthLive(signal),
+  });
+}

--- a/modules/web/src/api/queryClient.test.ts
+++ b/modules/web/src/api/queryClient.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { PapitaApiError } from "@/api/errors";
+import { createAppQueryClient } from "@/api/queryClient";
+
+describe("createAppQueryClient", () => {
+  it("does not retry 4xx PapitaApiError", () => {
+    const client = createAppQueryClient();
+    const retry = client.getDefaultOptions().queries?.retry;
+    expect(typeof retry).toBe("function");
+    if (typeof retry !== "function") {
+      return;
+    }
+
+    const clientError = new PapitaApiError({
+      message: "bad",
+      status: 400,
+      discovery: {
+        breakingChanges: null,
+        bulkMax: null,
+        reportWindowMaxDays: null,
+        cashFlowRefreshDefault: null,
+        reportsForeignAccountStatus: null,
+        errorCode: null,
+        compatActive: [],
+      },
+    });
+
+    expect(retry(0, clientError)).toBe(false);
+    expect(retry(0, new Error("network"))).toBe(true);
+    expect(retry(2, new Error("network"))).toBe(false);
+  });
+});

--- a/modules/web/src/api/queryClient.ts
+++ b/modules/web/src/api/queryClient.ts
@@ -1,0 +1,21 @@
+import { QueryClient } from "@tanstack/react-query";
+
+import { isClientHttpError } from "@/api/errors";
+
+/** Shared QueryClient defaults for the SPA (PPT-048). */
+export function createAppQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60_000,
+        retry: (failureCount, error) => {
+          if (isClientHttpError(error)) {
+            return false;
+          }
+          return failureCount < 2;
+        },
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+}

--- a/modules/web/src/api/queryKeys.test.ts
+++ b/modules/web/src/api/queryKeys.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { queryKeys } from "@/api/queryKeys";
+
+describe("queryKeys", () => {
+  it("keeps hierarchical prefixes stable", () => {
+    expect(queryKeys.all).toEqual(["papita"]);
+    expect(queryKeys.meta.all).toEqual(["papita", "meta"]);
+    expect(queryKeys.health.all).toEqual(["papita", "health"]);
+  });
+
+  it("builds distinct leaf keys for meta and health probes", () => {
+    expect(queryKeys.meta.clientContract()).toEqual(["papita", "meta", "client-contract"]);
+    expect(queryKeys.health.root()).toEqual(["papita", "health", "root"]);
+    expect(queryKeys.health.live()).toEqual(["papita", "health", "live"]);
+    expect(queryKeys.meta.clientContract()).not.toEqual(queryKeys.health.root());
+  });
+});

--- a/modules/web/src/api/queryKeys.ts
+++ b/modules/web/src/api/queryKeys.ts
@@ -1,0 +1,18 @@
+/**
+ * Hierarchical TanStack Query key factory (PPT-048).
+ *
+ * Keep keys stable and serializable. Feature screens (#117+) extend this factory —
+ * do not invent ad-hoc string keys in components.
+ */
+export const queryKeys = {
+  all: ["papita"] as const,
+  meta: {
+    all: ["papita", "meta"] as const,
+    clientContract: () => ["papita", "meta", "client-contract"] as const,
+  },
+  health: {
+    all: ["papita", "health"] as const,
+    root: () => ["papita", "health", "root"] as const,
+    live: () => ["papita", "health", "live"] as const,
+  },
+} as const;

--- a/modules/web/src/main.tsx
+++ b/modules/web/src/main.tsx
@@ -1,6 +1,8 @@
+import { QueryClientProvider } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
+import { createAppQueryClient } from "@/api/queryClient";
 import App from "@/App";
 import "./index.css";
 
@@ -9,8 +11,12 @@ if (rootElement === null) {
   throw new Error("Root element #root not found");
 }
 
+const queryClient = createAppQueryClient();
+
 createRoot(rootElement).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/modules/web/src/test/createTestQueryClient.ts
+++ b/modules/web/src/test/createTestQueryClient.ts
@@ -1,0 +1,14 @@
+import { QueryClient } from "@tanstack/react-query";
+
+/** Test helper: fresh QueryClient (no retries, no shared cache). */
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: 0,
+        gcTime: 0,
+      },
+    },
+  });
+}

--- a/modules/web/src/test/queryWrapper.tsx
+++ b/modules/web/src/test/queryWrapper.tsx
@@ -1,0 +1,14 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement, ReactNode } from "react";
+
+import { createTestQueryClient } from "@/test/createTestQueryClient";
+
+export function QueryTestProvider({
+  children,
+  client = createTestQueryClient(),
+}: {
+  children: ReactNode;
+  client?: ReturnType<typeof createTestQueryClient>;
+}): ReactElement {
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/modules/web/src/types/domain.ts
+++ b/modules/web/src/types/domain.ts
@@ -8,3 +8,46 @@ import type { components } from "./api";
 
 /** OpenAPI ``components.schemas`` map from the committed artifact. */
 export type ApiSchemas = components["schemas"];
+
+export type HealthResponse = ApiSchemas["HealthResponse"];
+export type AuthHealthResponse = ApiSchemas["AuthHealthResponse"];
+export type DatabaseHealthResponse = ApiSchemas["DatabaseHealthResponse"];
+export type RedisHealthResponse = ApiSchemas["RedisHealthResponse"];
+
+/**
+ * Shape of ``GET /api/v1/meta/client-contract``.
+ *
+ * OpenAPI types the 200 body as a free-form object; this interface mirrors the
+ * JSON from ``papita_txnsapi.core.client_contract.build_client_contract`` without
+ * reimplementing limit enforcement in TypeScript.
+ */
+export type ClientContract = {
+  breaking_changes: string;
+  api_version: string;
+  secure_defaults: {
+    reports_foreign_account_status: number;
+    cash_flow_refresh_balances_default: boolean;
+    bulk_max_transactions: number;
+    report_window_max_days: number;
+    docs_require_debug_or_docs_enabled: boolean;
+    cors_wildcard_forbidden_when_not_debug: boolean;
+  };
+  effective: {
+    reports_foreign_account_status: number;
+    cash_flow_refresh_balances_default: boolean;
+    bulk_max_transactions: number;
+    report_window_max_days: number;
+    docs_enabled: boolean;
+  };
+  compat: {
+    active: string[];
+    sunset: string | null;
+    flags: Record<string, { enabled: boolean; effect: string }>;
+  };
+  error_codes: Record<string, string>;
+  migration: {
+    probe: string;
+    prefer_headers: string[];
+    client_checklist: string[];
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   modules/web:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5
+        version: 5.101.4(react@19.2.8)
       react:
         specifier: ^19.2.7
         version: 19.2.8
@@ -421,6 +424,14 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@tanstack/query-core@5.101.4':
+    resolution: {integrity: sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==}
+
+  '@tanstack/react-query@5.101.4':
+    resolution: {integrity: sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1768,6 +1779,13 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
+
+  '@tanstack/query-core@5.101.4': {}
+
+  '@tanstack/react-query@5.101.4(react@19.2.8)':
+    dependencies:
+      '@tanstack/query-core': 5.101.4
+      react: 19.2.8
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
**Branch:** `feat/PPT-048` · **Base:** `main` · **1 commit** · **26 files**

**Suggested title:** `feat/PPT-048: [web] OpenAPI types + thin API client (no domain logic)`

## Summary

Closes the remaining PPT-048 / #114 work after strategy-B typegen landed in #130: a thin `fetch` client and TanStack Query wiring so the SPA can call `papita_txnsapi` with typed probes and cookie-ready credentials — without porting model business logic to TypeScript.

## Out of scope / Highlights

**Out of scope**

- BFF cookie session / Bearer-from-JS auth ([#115](https://github.com/Elmorralito/save-ma-money/issues/115))
- Feature screens (accounts/txns/reports — #117+)
- Zod/RHF forms ([#120](https://github.com/Elmorralito/save-ma-money/issues/120))
- Re-deciding OpenAPI typegen CI (locked **B** in [#130](https://github.com/Elmorralito/save-ma-money/issues/130))

**Highlights**

- `credentials: 'include'` from day one so PPT-049 BFF cookies are drop-in
- `queryOptions` for health + client-contract; smart retry skips 4xx
- App scaffold shows live probe status when API is up

## Changes

**Web client (`modules/web/src/api/`)**

- `apiFetch` with `AbortSignal`, same-origin base URL / optional `VITE_API_BASE_URL`, no `Authorization` header
- `PapitaApiError` + discovery header parsing (`X-Papita-Error-Code`, bulk/report limits)
- Contract helpers prefer JSON body from `GET /api/v1/meta/client-contract`, fall back to headers
- Health + meta read helpers only (prove wiring)
- Shared `QueryClient` (`staleTime` 60s; no 4xx retries) + `queryKeys` / `queryOptions`

**App / types / docs**

- `QueryClientProvider` in `main.tsx`; minimal App probe UI
- `domain.ts` health aliases + `ClientContract` shape (OpenAPI body is free-form)
- README credentials policy; `.cursor/AGENTS.md` pointer

**Tests / deps**

- Unit tests for queryKeys, errors, http, contract, queryClient; App test with Query provider
- Add `@tanstack/react-query` v5

## File changes

<details>
<summary>File changes (26 files)</summary>

```
 .cursor/AGENTS.md                             |  2 +
 modules/web/README.md                         | 19 ++++++-
 modules/web/package.json                      |  1 +
 modules/web/src/App.test.tsx                  | 66 +++++++++++++++++++++-
 modules/web/src/App.tsx                       | 48 ++++++++++++++--
 modules/web/src/api/*                         | thin client + unit tests
 modules/web/src/main.tsx                      |  8 ++-
 modules/web/src/test/createTestQueryClient.ts | 14 +++++
 modules/web/src/test/queryWrapper.tsx         | 14 +++++
 modules/web/src/types/domain.ts               | 43 ++++++++++++++
 pnpm-lock.yaml                                | 18 ++++++
 26 files changed, 859 insertions(+), 11 deletions(-)
```

</details>

## Commits

- `8dd6353` feat/PPT-048: [web] Add thin OpenAPI HTTP client and TanStack Query wiring

## Checks, tests, and validation already done

- `pnpm web:lint` — pass
- `pnpm web:test` — pass (12 tests)
- `pnpm web:build` — pass
- `pnpm web:check-types` — pass (OpenAPI types in sync)
- GitHub Actions on this PR — not observed yet

## QA / test plan

- [ ] Web CI green on this PR (`web-ci.yml`: check-types, lint, test, build)
- [ ] Optional local smoke: `make api-up` + `make web-dev` → App shows health + bulk/report limits
- [ ] Confirm no Bearer / JWT storage added in review

## Risks

> [!CAUTION]
>
> ### Risks
>
> - App now issues unauthenticated `/api/v1/health` and `/meta/client-contract` requests on load; without `make api-up` the UI shows unavailable/— (expected for scaffold)
> - Cookie `credentials: 'include'` is ready for #115 but session endpoints do not exist yet — no auth behavior change until BFF lands

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - `ClientContract` is a hand-mirrored interface because OpenAPI types the endpoint body as a free-form object
> - Feature domains should extend `queryKeys` / add helpers under `src/api/` — do not invent ad-hoc keys in screens

## References

- Closes [#114](https://github.com/Elmorralito/save-ma-money/issues/114) (PPT-048)
- Parent epic: [#112](https://github.com/Elmorralito/save-ma-money/issues/112) (PPT-046)
- Depends on / builds on: [#113](https://github.com/Elmorralito/save-ma-money/issues/113), [#130](https://github.com/Elmorralito/save-ma-money/issues/130)
- Unblocks: [#115](https://github.com/Elmorralito/save-ma-money/issues/115), [#129](https://github.com/Elmorralito/save-ma-money/issues/129), feature screens #117+
- Docs: `modules/web/README.md`, `modules/api/README.md`


Made with [Cursor](https://cursor.com)