### PR TITLE
feat/PPT-049: [web] BFF HttpOnly cookie session with Supabase IdP

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -76,6 +76,8 @@ Domain entities in the model layer include **accounts**, **transactions**, **cat
 
 **Web thin API client (PPT-048):** `modules/web/src/api/` — `apiFetch` (`credentials: 'include'`, no Bearer), `queryKeys` / `queryOptions`, `PapitaApiError` + discovery headers, health/meta probes only. Domain logic stays in Python.
 
+**Web BFF cookie auth (PPT-049):** API `/api/v1/bff/auth/*` + `BffSessionStore` (Redis or memory; **not** JWT denylist). Cookie `papita_sid` (HttpOnly); CSRF `X-Papita-CSRF`. SPA login/register + `RequireAuth`; `get_current_owner` accepts Bearer **or** BFF cookie. `make auth-smoke` (Bearer) still valid alongside BFF.
+
 ---
 
 ## Layered architecture (model package)

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -12,7 +12,8 @@ project**. Papita API verifies JWTs + links `users` by `sub` — it is not the I
 
 - **PPT-049 / #115 / PR #141:** BFF HttpOnly `papita_sid` session in API + web auth UI;
   babysit: CI TestClient `AUTH_COOKIE_SECURE=false`, session-id rotate on refresh,
-  log digests, `.trivyignore` for stale GHSA on patched `react-router@7.18.2`
+  log digests, `.trivyignore` for stale GHSA on patched `react-router@7.18.2`;
+  expanded mocked-Supabase BFF + store tests for `codecov/patch`
 - **PPT-047 / #113:** Scaffolded `modules/web` (`@papita/web`) — Vite + React 19 + TS strict,
   pnpm workspace (`pnpm-workspace.yaml`, committed `pnpm-lock.yaml`), ESLint 9 + Prettier +
   Vitest smoke, Vite `/api` → `:8000` proxy, Makefile `web-*`, path-filtered `web-ci.yml`,

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -10,6 +10,9 @@ project**. Papita API verifies JWTs + links `users` by `sub` — it is not the I
 
 ### Last completed (this session)
 
+- **PPT-049 / #115 / PR #141:** BFF HttpOnly `papita_sid` session in API + web auth UI;
+  babysit: CI TestClient `AUTH_COOKIE_SECURE=false`, session-id rotate on refresh,
+  log digests, `.trivyignore` for stale GHSA on patched `react-router@7.18.2`
 - **PPT-047 / #113:** Scaffolded `modules/web` (`@papita/web`) — Vite + React 19 + TS strict,
   pnpm workspace (`pnpm-workspace.yaml`, committed `pnpm-lock.yaml`), ESLint 9 + Prettier +
   Vitest smoke, Vite `/api` → `:8000` proxy, Makefile `web-*`, path-filtered `web-ci.yml`,
@@ -25,9 +28,9 @@ project**. Papita API verifies JWTs + links `users` by `sub` — it is not the I
 
 ### Next action
 
-- Merge npm-web Dependabot #136 after CI green
-- PPT-048 OpenAPI client (#114) on top of locked typegen; and/or PPT-051 design shell (#116)
-- Docs indexes for web (root README / `docs/issues`) → PPT-058 / #123
+- Land PR #141 (PPT-049) after quality-control + Trivy FS green
+- PPT-068 email verification (#139); PPT-069 non-goals guardrail (#140)
+- PPT-051 design shell (#116) when auth BFF is merged
 
 ### Uncommitted / staging notes
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,5 @@
+# react-router@7.18.2 is the patched 7.x line for GHSA-qwww-vcr4-c8h2
+# (upstream: >=7.18.2 and >=8.3.0). Trivy's DB still lists only 8.3.0 as fixed;
+# react-router-dom has no 8.x release yet. This SPA does not use unstable RSC APIs.
+# https://github.com/remix-run/react-router/security/advisories/GHSA-qwww-vcr4-c8h2
+GHSA-qwww-vcr4-c8h2

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -108,6 +108,9 @@ services:
     environment:
       # App settings (compose --env-file environments/<env>/.env supplies these)
       PAPITA_ENV: "${PAPITA_ENV:-local}"
+      # DEBUG defaults true for B0 local Compose; when false, ALLOWED_HOSTS is required.
+      DEBUG: "${DEBUG:-true}"
+      DOCS_ENABLED: "${DOCS_ENABLED:-true}"
       AUTH_PROVIDER: "${AUTH_PROVIDER:-local}"
       SUPABASE_URL: "${SUPABASE_URL:-}"
       SUPABASE_ANON_KEY: "${SUPABASE_ANON_KEY:-}"
@@ -116,11 +119,14 @@ services:
       SUPABASE_OAUTH_REDIRECT_TO: "${SUPABASE_OAUTH_REDIRECT_TO:-}"
       AUTH_RATE_LIMIT_ENABLED: "${AUTH_RATE_LIMIT_ENABLED:-true}"
       AUTH_OAUTH_RATE_LIMIT_PER_MINUTE: "${AUTH_OAUTH_RATE_LIMIT_PER_MINUTE:-20}"
+      AUTH_COOKIE_SECURE: "${AUTH_COOKIE_SECURE:-false}"
       JWT_SECRET_KEY: "${JWT_SECRET_KEY:-replace-with-long-random-secret-min-32-chars}"
       # Tenant DB stays on Compose Postgres (Auth users live in Supabase Auth, not this DB)
       DATABASE_URL: "postgresql+psycopg2://${DB_USER:-admin}:${DB_PASSWORD:-admin}@postgres-db:${DB_PORT:-5435}/${DB_NAME:-papita}"
       LOG_LEVEL: "${LOG_LEVEL:-INFO}"
-      ALLOWED_ORIGINS: '${ALLOWED_ORIGINS:-["*"]}'
+      ALLOWED_ORIGINS: '${ALLOWED_ORIGINS:-["http://localhost:3000","http://127.0.0.1:3000","http://localhost:5173","http://127.0.0.1:5173"]}'
+      # Required when DEBUG=false (TrustedHost). Harmless when DEBUG=true.
+      ALLOWED_HOSTS: '${ALLOWED_HOSTS:-["localhost","127.0.0.1","api","testserver"]}'
       DATABASE_POOL_SIZE: "${DATABASE_POOL_SIZE:-5}"
       # In-compose Redis DNS (do not reuse host REDIS_URL=localhost from .env)
       REDIS_URL: "redis://redis:6379/0"

--- a/docs/interrogate_badge.svg
+++ b/docs/interrogate_badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="20" role="img" aria-label="interrogate: 98.0%">
-    <title>interrogate: 98.0%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="20" role="img" aria-label="interrogate: 98.1%">
+    <title>interrogate: 98.1%</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -15,8 +15,8 @@
     <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
         <text aria-hidden="true" x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" fill="#fff" textLength="610">interrogate</text>
-        <text aria-hidden="true" x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">98.0%</text>
-        <text x="1160" y="140" transform="scale(.1)" fill="#fff" textLength="370" data-interrogate="result">98.0%</text>
+        <text aria-hidden="true" x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">98.1%</text>
+        <text x="1160" y="140" transform="scale(.1)" fill="#fff" textLength="370" data-interrogate="result">98.1%</text>
     </g>
     <g id="logo-shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -43,6 +43,7 @@ The API manages personal finance data aligned to the **v3 PostgreSQL schema** (`
 | `/reports/*` (except budget-performance) | `ReportService` aggregations over ledger + categories                                                                                                                      | Yes |
 | `/budgets/*`                             | Deferred — v4.1 ([`ARCHITECTURE.md#part-iii--post-mvp-v4-extensions-ppt-031-track-a`](../../docs/design/ARCHITECTURE.md#part-iii--post-mvp-v4-extensions-ppt-031-track-a)) | 501 |
 | `/auth/refresh`, `/auth/logout`          | **Supabase:** implemented (session rotate / sign-out + optional Redis denylist). **Local HS256:** 501                                                                      | —   |
+| `/bff/auth/*`                            | PPT-049 browser BFF: HttpOnly `papita_sid` session cookie; JWTs server-side; CSRF `X-Papita-CSRF`. Coexists with Bearer `/auth/*` (`make auth-smoke`)                      | Yes |
 | `/transactions/{id}/split`               | Deferred — v4 `transaction_splits`                                                                                                                                         | 501 |
 
 **Enum convention:** API JSON uses lowercase slugs (`expense`, `checking`); PostgreSQL stores uppercase enums (`EXPENSE`, `CHECKING`).

--- a/modules/api/src/papita_txnsapi/config/settings.py
+++ b/modules/api/src/papita_txnsapi/config/settings.py
@@ -190,6 +190,8 @@ class Settings(BaseSettings):
     AUTH_OAUTH_RATE_LIMIT_PER_MINUTE: int = 20
     # When None, OAuth PKCE cookies use Secure when DEBUG is false.
     AUTH_COOKIE_SECURE: bool | None = None
+    # BFF HttpOnly session cookie lifetime (PPT-049). Memory store when Redis off.
+    BFF_SESSION_MAX_AGE_SECONDS: int = Field(default=604_800, ge=60, le=31_536_000)
 
     # Health / ops probes (PPT-044)
     HEALTH_RATE_LIMIT_ENABLED: bool = True

--- a/modules/api/src/papita_txnsapi/core/bff_session.py
+++ b/modules/api/src/papita_txnsapi/core/bff_session.py
@@ -1,0 +1,236 @@
+"""BFF browser session binding store (PPT-049).
+
+Maps an opaque session id (HttpOnly cookie) to server-side access/refresh tokens.
+This is **not** the JWT denylist (:class:`~papita_txnsapi.core.session_store.SessionStore`).
+
+When Redis is unavailable/disabled, an in-memory map is used (B0/dev only — not
+shared across uvicorn workers).
+
+Key exports:
+    BFF_SESSION_COOKIE: Cookie name for the opaque session id.
+    BFF_CSRF_HEADER: Required header on cookie-authenticated mutations.
+    BffSessionRecord: Stored binding (tokens + CSRF + access expiry).
+    BffSessionStore: Redis or memory session map.
+    clear_memory_bff_sessions: Test helper to reset the process-local map.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from redis import Redis
+from redis.exceptions import RedisError
+
+from papita_txnsapi.core.redis_keys import redis_key
+
+logger = logging.getLogger(__name__)
+
+BFF_SESSION_COOKIE = "papita_sid"
+BFF_CSRF_HEADER = "X-Papita-CSRF"
+BFF_COOKIE_PATH = "/api"
+# Default cookie lifetime (refresh can extend the binding while the cookie lives).
+DEFAULT_BFF_SESSION_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+
+_memory_lock = threading.RLock()
+_memory_sessions: dict[str, str] = {}
+
+
+def clear_memory_bff_sessions() -> None:
+    """Clear the process-local BFF session map (tests / worker restart)."""
+    with _memory_lock:
+        _memory_sessions.clear()
+
+
+def new_session_id() -> str:
+    """Return a high-entropy opaque session identifier."""
+    return secrets.token_urlsafe(32)
+
+
+def new_csrf_token() -> str:
+    """Return a high-entropy CSRF token for the double-submit header."""
+    return secrets.token_urlsafe(32)
+
+
+@dataclass(slots=True)
+class BffSessionRecord:
+    """Server-side binding for one browser BFF session.
+
+    Attributes:
+        access_token: Bearer JWT attached in-process for protected v1 routes.
+        refresh_token: Optional Supabase refresh token (``None`` for local HS256).
+        csrf_token: Value the SPA must send as ``X-Papita-CSRF`` on mutations.
+        access_expires_at: Unix timestamp when the access token should be treated expired.
+        owner_id: Optional tenant user id string for diagnostics (not authorization).
+    """
+
+    access_token: str
+    refresh_token: str | None
+    csrf_token: str
+    access_expires_at: float
+    owner_id: str | None = None
+
+    def to_json(self) -> str:
+        """Serialize the record for Redis / memory storage."""
+        return json.dumps(asdict(self), separators=(",", ":"))
+
+    @classmethod
+    def from_json(cls, raw: str) -> BffSessionRecord:
+        """Deserialize a record from storage JSON.
+
+        Args:
+            raw: JSON object previously produced by :meth:`to_json`.
+
+        Returns:
+            Parsed session record.
+
+        Raises:
+            ValueError: When the payload is malformed.
+        """
+        try:
+            data: dict[str, Any] = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError("invalid BFF session payload") from exc
+        try:
+            return cls(
+                access_token=str(data["access_token"]),
+                refresh_token=data.get("refresh_token"),
+                csrf_token=str(data["csrf_token"]),
+                access_expires_at=float(data["access_expires_at"]),
+                owner_id=data.get("owner_id"),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError("invalid BFF session payload") from exc
+
+    def access_expired(self, *, skew_seconds: float = 30.0) -> bool:
+        """Return whether the access token should be refreshed.
+
+        Args:
+            skew_seconds: Refresh slightly before absolute expiry.
+        """
+        return time.time() >= (self.access_expires_at - skew_seconds)
+
+
+class BffSessionStore:
+    """Session-id → token binding store (Redis when available, else memory).
+
+    Args:
+        client: Optional Redis client. When ``None``, uses process memory.
+        default_ttl_seconds: TTL applied to new/updated session keys.
+    """
+
+    def __init__(self, client: Redis | None, *, default_ttl_seconds: int) -> None:
+        self._client = client
+        self._default_ttl_seconds = max(60, default_ttl_seconds)
+
+    @property
+    def backend(self) -> str:
+        """``redis`` or ``memory``."""
+        return "redis" if self._client is not None else "memory"
+
+    def create(
+        self,
+        *,
+        access_token: str,
+        refresh_token: str | None,
+        expires_in: int,
+        owner_id: str | None = None,
+        ttl_seconds: int | None = None,
+    ) -> tuple[str, BffSessionRecord]:
+        """Create a new session binding.
+
+        Returns:
+            ``(session_id, record)`` including a fresh CSRF token.
+        """
+        session_id = new_session_id()
+        record = BffSessionRecord(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            csrf_token=new_csrf_token(),
+            access_expires_at=time.time() + max(1, expires_in),
+            owner_id=owner_id,
+        )
+        self._set(session_id, record, ttl_seconds=ttl_seconds)
+        return session_id, record
+
+    def get(self, session_id: str) -> BffSessionRecord | None:
+        """Load a session by id, or ``None`` when missing/invalid."""
+        if not session_id:
+            return None
+        raw = self._get_raw(session_id)
+        if raw is None:
+            return None
+        try:
+            return BffSessionRecord.from_json(raw)
+        except ValueError:
+            logger.warning("Dropping corrupt BFF session id=%s…", session_id[:8])
+            self.delete(session_id)
+            return None
+
+    def update(self, session_id: str, record: BffSessionRecord, *, ttl_seconds: int | None = None) -> None:
+        """Overwrite an existing session binding (e.g. after refresh)."""
+        if not session_id:
+            return
+        self._set(session_id, record, ttl_seconds=ttl_seconds)
+
+    def delete(self, session_id: str) -> None:
+        """Remove a session binding (best-effort)."""
+        if not session_id:
+            return
+        if self._client is None:
+            with _memory_lock:
+                _memory_sessions.pop(session_id, None)
+            return
+        key = redis_key("bff", "session", session_id)
+        try:
+            self._client.delete(key)
+        except RedisError:
+            logger.exception("Failed to delete BFF session from Redis")
+
+    def _set(self, session_id: str, record: BffSessionRecord, *, ttl_seconds: int | None) -> None:
+        """Persist ``record`` under ``session_id`` (Redis preferred, memory fallback)."""
+        ttl = self._default_ttl_seconds if ttl_seconds is None else max(60, ttl_seconds)
+        payload = record.to_json()
+        if self._client is None:
+            with _memory_lock:
+                _memory_sessions[session_id] = payload
+            return
+        key = redis_key("bff", "session", session_id)
+        try:
+            self._client.setex(key, ttl, payload)
+        except RedisError:
+            logger.exception("Failed to persist BFF session to Redis; falling back to memory")
+            with _memory_lock:
+                _memory_sessions[session_id] = payload
+
+    def _get_raw(self, session_id: str) -> str | None:
+        """Return the raw JSON payload for ``session_id``, or ``None``."""
+        if self._client is None:
+            with _memory_lock:
+                return _memory_sessions.get(session_id)
+        key = redis_key("bff", "session", session_id)
+        try:
+            value = self._client.get(key)
+        except RedisError:
+            logger.exception("Failed to read BFF session from Redis; trying memory")
+            with _memory_lock:
+                return _memory_sessions.get(session_id)
+        if value is None:
+            with _memory_lock:
+                return _memory_sessions.get(session_id)
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        return str(value)
+
+
+def parse_owner_id_hint(subject: uuid.UUID | str | None) -> str | None:
+    """Normalize an optional owner id for session diagnostics."""
+    if subject is None:
+        return None
+    return str(subject)

--- a/modules/api/src/papita_txnsapi/core/bff_session.py
+++ b/modules/api/src/papita_txnsapi/core/bff_session.py
@@ -16,6 +16,7 @@ Key exports:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import secrets
@@ -169,7 +170,9 @@ class BffSessionStore:
         try:
             return BffSessionRecord.from_json(raw)
         except ValueError:
-            logger.warning("Dropping corrupt BFF session id=%s…", session_id[:8])
+            # Log only a truncated digest — never raw cookie/session material (log injection).
+            digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:12]
+            logger.warning("Dropping corrupt BFF session id_digest=%s", digest)
             self.delete(session_id)
             return None
 

--- a/modules/api/src/papita_txnsapi/dependencies/auth.py
+++ b/modules/api/src/papita_txnsapi/dependencies/auth.py
@@ -1,8 +1,8 @@
-"""Authentication dependencies — Bearer JWT to tenant owner.
+"""Authentication dependencies — Bearer JWT / BFF cookie to tenant owner.
 
-FastAPI ``Depends`` callables that extract OAuth2 bearer tokens, validate JWT
-claims, and resolve the active tenant owner via ``UsersService``. Used by
-protected v1 routes.
+FastAPI ``Depends`` callables that extract OAuth2 bearer tokens **or** resolve
+an HttpOnly BFF session cookie (PPT-049), validate JWT claims, and resolve the
+active tenant owner via ``UsersService``. Used by protected v1 routes.
 
 In ``AUTH_PROVIDER=supabase`` mode, missing local rows are provisioned from
 Auth claims (``sub`` → ``users.id``).
@@ -15,15 +15,20 @@ Key exports:
 
 from __future__ import annotations
 
+import logging
+import time
 import uuid
 from typing import Annotated, Any
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 
 from papita_txnsapi.config.settings import Settings, get_settings
+from papita_txnsapi.core.bff_session import BFF_SESSION_COOKIE, BffSessionRecord, BffSessionStore
 from papita_txnsapi.core.security import AuthSecurityManager
 from papita_txnsapi.core.session_store import SessionStore, SessionStoreUnavailableError
+from papita_txnsapi.core.supabase_auth import AuthApiError, AuthError, supabase_refresh_session
+from papita_txnsapi.dependencies.bff_session import get_bff_session_store
 from papita_txnsapi.dependencies.services import get_users_service
 from papita_txnsapi.dependencies.session_store import get_session_store
 from papita_txnsmodel.access.users.dto import UsersDTO
@@ -33,6 +38,7 @@ from papita_txnsmodel.services.users import UsersService
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login", auto_error=False)
 
 _UNAUTHORIZED_HEADERS = {"WWW-Authenticate": "Bearer"}
+logger = logging.getLogger(__name__)
 
 
 def _profile_from_supabase_claims(payload: dict[str, Any]) -> dict[str, Any]:
@@ -80,26 +86,77 @@ def get_auth_manager(settings: Annotated[Settings, Depends(get_settings)]) -> Au
     return AuthSecurityManager(settings)
 
 
-def get_current_owner(
+def _resolve_access_token_from_bff(
+    request: Request,
+    settings: Settings,
+    bff_store: BffSessionStore,
+) -> str | None:
+    """Resolve a bearer access token from the BFF session cookie when present.
+
+    When the stored access token is near expiry and a refresh token exists
+    (Supabase), rotates tokens in the session store before returning the new
+    access JWT.
+    """
+    session_id = request.cookies.get(BFF_SESSION_COOKIE)
+    if not session_id:
+        return None
+    record = bff_store.get(session_id)
+    if record is None:
+        return None
+
+    if record.access_expired() and record.refresh_token and settings.AUTH_PROVIDER == "supabase":
+        if not settings.SUPABASE_URL or not settings.SUPABASE_ANON_KEY:
+            return None
+        try:
+            auth_result = supabase_refresh_session(
+                supabase_url=settings.SUPABASE_URL,
+                anon_key=settings.SUPABASE_ANON_KEY,
+                refresh_token=record.refresh_token,
+            )
+            expires_in = max(1, int(auth_result.expires_in or settings.JWT_EXPIRATION_TIME_SECONDS))
+            updated = BffSessionRecord(
+                access_token=str(auth_result.access_token),
+                refresh_token=auth_result.refresh_token or record.refresh_token,
+                csrf_token=record.csrf_token,
+                access_expires_at=time.time() + expires_in,
+                owner_id=record.owner_id,
+            )
+            ttl = int(getattr(settings, "BFF_SESSION_MAX_AGE_SECONDS", 7 * 24 * 60 * 60))
+            bff_store.update(session_id, updated, ttl_seconds=ttl)
+            return updated.access_token
+        except (AuthApiError, AuthError, ValueError) as exc:
+            logger.info("BFF silent refresh failed: %s", exc)
+            bff_store.delete(session_id)
+            return None
+
+    return record.access_token
+
+
+def get_current_owner(  # pylint: disable=too-many-positional-arguments
+    request: Request,
     token: Annotated[str | None, Depends(oauth2_scheme)],
     settings: Annotated[Settings, Depends(get_settings)],
     users_service: Annotated[UsersService, Depends(get_users_service)],
     session_store: Annotated[SessionStore, Depends(get_session_store)],
+    bff_store: Annotated[BffSessionStore, Depends(get_bff_session_store)],
 ) -> UsersDTO:
-    """Decode bearer JWT and resolve the active tenant owner for protected routes.
+    """Decode bearer JWT (header or BFF cookie) and resolve the tenant owner.
 
-    Local mode validates signature, token-type claim, and loads ``sub``. Supabase
-    mode validates JWKS claims and provisions a local ``UsersDTO`` on first seen.
-    When Redis is enabled, revoked access tokens in the denylist are rejected
-    (PPT-043). Denylist checks **fail closed** when Redis is required: Redis
-    errors or a missing client yield HTTP 503 so a blip cannot resurrect a
-    revoked token (unlike cache/rate-limit fail-open).
+    Prefer ``Authorization: Bearer`` when present (token clients / ``auth-smoke``).
+    Otherwise resolve the HttpOnly BFF session cookie and attach the stored
+    access token in-process (PPT-049). Local mode validates signature,
+    token-type claim, and loads ``sub``. Supabase mode validates JWKS claims and
+    provisions a local ``UsersDTO`` on first seen. When Redis is enabled,
+    revoked access tokens in the denylist are rejected (PPT-043). Denylist
+    checks **fail closed** when Redis is required.
 
     Args:
+        request: Incoming request (BFF session cookie).
         token: Bearer token from the ``Authorization`` header (may be ``None``).
         settings: Injected API settings for JWT validation parameters.
         users_service: Injected service used to load/provision the owner.
         session_store: Optional Redis-backed JWT denylist.
+        bff_store: BFF session-id → token binding store.
 
     Returns:
         Active ``UsersDTO`` representing the authenticated tenant owner.
@@ -108,6 +165,9 @@ def get_current_owner(
         HTTPException: 401 when the token is missing, invalid, revoked, or the
             owner is not active; 503 when Redis denylist is required but unavailable.
     """
+    if not token:
+        token = _resolve_access_token_from_bff(request, settings, bff_store)
+
     if not token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/modules/api/src/papita_txnsapi/dependencies/bff_session.py
+++ b/modules/api/src/papita_txnsapi/dependencies/bff_session.py
@@ -1,0 +1,29 @@
+"""FastAPI dependencies for the BFF session binding store (PPT-049)."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends, Request
+
+from papita_txnsapi.config.settings import Settings, get_settings
+from papita_txnsapi.core.bff_session import DEFAULT_BFF_SESSION_MAX_AGE_SECONDS, BffSessionStore
+from papita_txnsapi.core.redis import get_redis_from_app
+
+
+def get_bff_session_store(
+    request: Request,
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> BffSessionStore:
+    """Return the BFF session map (Redis when enabled, else process memory).
+
+    Args:
+        request: Incoming request (``app.state.redis``).
+        settings: Application settings (Redis flags and session TTL).
+
+    Returns:
+        ``BffSessionStore`` suitable for cookie session create/lookup/delete.
+    """
+    client = get_redis_from_app(request.app) if settings.REDIS_ENABLED else None
+    ttl = getattr(settings, "BFF_SESSION_MAX_AGE_SECONDS", DEFAULT_BFF_SESSION_MAX_AGE_SECONDS)
+    return BffSessionStore(client, default_ttl_seconds=int(ttl))

--- a/modules/api/src/papita_txnsapi/main.py
+++ b/modules/api/src/papita_txnsapi/main.py
@@ -24,6 +24,7 @@ from papita_txnsapi.config.settings import Settings, get_settings
 from papita_txnsapi.core.handlers import register_exception_handlers
 from papita_txnsapi.core.rate_limit import bind_rate_limiters
 from papita_txnsapi.core.redis import close_redis, init_redis
+from papita_txnsapi.middleware.bff_csrf import BffCsrfMiddleware
 from papita_txnsapi.middleware.client_contract import ClientContractMiddleware
 from papita_txnsapi.middleware.request_logging import RequestLoggingMiddleware
 from papita_txnsapi.middleware.security_headers import SecurityHeadersMiddleware
@@ -39,6 +40,7 @@ _PROD_CORS_HEADERS = [
     "Accept",
     "Idempotency-Key",
     "X-Request-ID",
+    "X-Papita-CSRF",
 ]
 
 
@@ -118,6 +120,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     )
     app.add_middleware(SecurityHeadersMiddleware)
     app.add_middleware(ClientContractMiddleware)
+    # Cookie-session mutations require X-Papita-CSRF (PPT-049); Bearer clients exempt.
+    app.add_middleware(BffCsrfMiddleware)
     # Settings requires non-empty ALLOWED_HOSTS when DEBUG=false (staging/prod).
     if not app_settings.DEBUG:
         app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(app_settings.ALLOWED_HOSTS))

--- a/modules/api/src/papita_txnsapi/middleware/bff_csrf.py
+++ b/modules/api/src/papita_txnsapi/middleware/bff_csrf.py
@@ -1,0 +1,97 @@
+"""CSRF guard for cookie-authenticated BFF / API mutations (PPT-049).
+
+When a request carries the BFF session cookie and **no** ``Authorization: Bearer``
+header, unsafe methods must include ``X-Papita-CSRF`` matching the server-side
+session CSRF token. SameSite cookies alone are not enough for all browsers/tools.
+
+Login/register are exempt so a stale cookie cannot block a new sign-in.
+Token-path clients (``make auth-smoke``, Bearer) skip this middleware path.
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
+
+from papita_txnsapi.config.settings import Settings
+from papita_txnsapi.core.bff_session import (
+    BFF_CSRF_HEADER,
+    BFF_SESSION_COOKIE,
+    DEFAULT_BFF_SESSION_MAX_AGE_SECONDS,
+    BffSessionStore,
+)
+from papita_txnsapi.core.redis import get_redis_from_app
+
+logger = logging.getLogger(__name__)
+
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+_CSRF_EXEMPT_PATHS = frozenset(
+    {
+        "/api/v1/bff/auth/login",
+        "/api/v1/bff/auth/register",
+    }
+)
+
+
+def _csrf_required(request: Request) -> bool:
+    """Return whether this request must present a matching CSRF header.
+
+    Safe methods, login/register, and Bearer-authenticated calls are exempt.
+    """
+    if request.method in _SAFE_METHODS:
+        return False
+    if request.url.path in _CSRF_EXEMPT_PATHS:
+        return False
+    authorization = request.headers.get("authorization") or ""
+    if authorization.lower().startswith("bearer "):
+        return False
+    return bool(request.cookies.get(BFF_SESSION_COOKIE))
+
+
+class BffCsrfMiddleware(BaseHTTPMiddleware):
+    """Reject cookie-session mutations that omit or mismatch the CSRF header."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        """Enforce CSRF for cookie-session mutations; otherwise continue."""
+        if not _csrf_required(request):
+            return await call_next(request)
+
+        session_id = request.cookies.get(BFF_SESSION_COOKIE) or ""
+        settings: Settings | None = getattr(request.app.state, "settings", None)
+        redis_enabled = bool(settings.REDIS_ENABLED) if settings is not None else False
+        ttl = (
+            int(getattr(settings, "BFF_SESSION_MAX_AGE_SECONDS", DEFAULT_BFF_SESSION_MAX_AGE_SECONDS))
+            if settings is not None
+            else DEFAULT_BFF_SESSION_MAX_AGE_SECONDS
+        )
+        client = get_redis_from_app(request.app) if redis_enabled else None
+        store = BffSessionStore(client, default_ttl_seconds=ttl)
+        record = store.get(session_id)
+        if record is None:
+            return await call_next(request)
+
+        provided = (request.headers.get(BFF_CSRF_HEADER) or "").strip()
+        if not provided or not secrets_compare(provided, record.csrf_token):
+            logger.info("BFF CSRF rejected method=%s path=%s", request.method, request.url.path)
+            return JSONResponse(
+                status_code=403,
+                content={"detail": "CSRF validation failed"},
+                headers={"X-Papita-Error-Code": "csrf_failed"},
+            )
+        return await call_next(request)
+
+
+def secrets_compare(left: str, right: str) -> bool:
+    """Constant-time string compare for CSRF tokens."""
+    return hmac.compare_digest(left.encode("utf-8"), right.encode("utf-8"))
+
+
+__all__ = ["BffCsrfMiddleware", "BFF_CSRF_HEADER", "BFF_SESSION_COOKIE"]

--- a/modules/api/src/papita_txnsapi/routers/v1/__init__.py
+++ b/modules/api/src/papita_txnsapi/routers/v1/__init__.py
@@ -7,6 +7,7 @@ tenant-scoped CRUD routes.
 Routes exposed (prefix relative to app mount):
     ``/health`` — liveness, readiness, database, Auth, and composite health (no tenant scope).
     ``/auth`` — register, login, profile; refresh/logout via Supabase Auth sessions.
+    ``/bff/auth`` — HttpOnly cookie session (PPT-049); JWTs stay server-side.
     ``/accounts`` — tenant-scoped account CRUD via :class:`~papita_txnsmodel.services.accounts.AccountsService`.
     ``/categories`` — tenant + global seed categories via
         :class:`~papita_txnsmodel.services.categories.CategoriesService`.
@@ -27,6 +28,7 @@ from fastapi import APIRouter
 from papita_txnsapi.routers.v1 import (
     accounts,
     auth,
+    bff_auth,
     budgets,
     categories,
     health,
@@ -40,6 +42,7 @@ api_v1_router = APIRouter()
 api_v1_router.include_router(health.router)
 api_v1_router.include_router(meta.router)
 api_v1_router.include_router(auth.router)
+api_v1_router.include_router(bff_auth.router)
 api_v1_router.include_router(accounts.router)
 api_v1_router.include_router(categories.router)
 api_v1_router.include_router(transactions.router)

--- a/modules/api/src/papita_txnsapi/routers/v1/bff_auth.py
+++ b/modules/api/src/papita_txnsapi/routers/v1/bff_auth.py
@@ -1,0 +1,454 @@
+"""BFF cookie session routes — login/register/session/refresh/logout (PPT-049).
+
+Thin session boundary inside ``papita_txnsapi``. Wraps the same Supabase / local
+credential paths as ``/api/v1/auth/*`` but stores JWTs server-side and sets an
+HttpOnly session-id cookie. Direct token clients keep using ``/auth/*``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+
+from papita_txnsapi.config.settings import Settings, get_settings
+from papita_txnsapi.core.auth_errors import auth_error_detail, public_value_error_detail
+from papita_txnsapi.core.bff_session import (
+    BFF_COOKIE_PATH,
+    BFF_SESSION_COOKIE,
+    DEFAULT_BFF_SESSION_MAX_AGE_SECONDS,
+    BffSessionRecord,
+    BffSessionStore,
+    parse_owner_id_hint,
+)
+from papita_txnsapi.core.security import AuthSecurityManager
+from papita_txnsapi.core.session_store import SessionStore
+from papita_txnsapi.core.supabase_auth import (
+    AuthApiError,
+    AuthError,
+    SupabaseSignUpProfile,
+    classify_supabase_auth_error,
+    supabase_refresh_session,
+    supabase_sign_in,
+    supabase_sign_out,
+    supabase_sign_up,
+)
+from papita_txnsapi.dependencies.auth import get_auth_manager, get_current_owner, oauth2_scheme
+from papita_txnsapi.dependencies.bff_session import get_bff_session_store
+from papita_txnsapi.dependencies.rate_limit import (
+    enforce_auth_login_rate_limit,
+    enforce_auth_oauth_rate_limit,
+    enforce_auth_register_rate_limit,
+)
+from papita_txnsapi.dependencies.services import get_users_service
+from papita_txnsapi.dependencies.session_store import get_session_store
+from papita_txnsapi.routers.v1.auth import (
+    _UNAUTHORIZED_HEADERS,
+    _cleanup_orphan_auth_user,
+    _http_status_for_provision_error,
+    _require_supabase_auth_settings,
+    _token_response_from_auth,
+)
+from papita_txnsapi.schemas.auth import UserResponse
+from papita_txnsapi.schemas.bff_auth import BffLoginRequest, BffRegisterRequest, BffSessionResponse
+from papita_txnsmodel.access.users.dto import UsersDTO
+from papita_txnsmodel.services.users import UsersService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/bff/auth", tags=["BFF Authentication"])
+
+
+def _session_max_age(settings: Settings) -> int:
+    """Return the BFF session cookie max-age from settings."""
+    return int(getattr(settings, "BFF_SESSION_MAX_AGE_SECONDS", DEFAULT_BFF_SESSION_MAX_AGE_SECONDS))
+
+
+def _set_session_cookie(response: Response, *, session_id: str, settings: Settings) -> None:
+    """Attach the HttpOnly ``papita_sid`` cookie to ``response``."""
+    response.set_cookie(
+        key=BFF_SESSION_COOKIE,
+        value=session_id,
+        max_age=_session_max_age(settings),
+        httponly=True,
+        samesite="lax",
+        secure=settings.oauth_cookie_secure(),
+        path=BFF_COOKIE_PATH,
+    )
+
+
+def _clear_session_cookie(response: Response) -> None:
+    """Clear the BFF session cookie (logout / invalid session)."""
+    response.delete_cookie(key=BFF_SESSION_COOKIE, path=BFF_COOKIE_PATH)
+
+
+def _session_response(
+    *,
+    user: UsersDTO,
+    csrf_token: str | None,
+    backend: str,
+) -> BffSessionResponse:
+    """Build an authenticated BFF session JSON body (never includes JWTs)."""
+    return BffSessionResponse(
+        authenticated=True,
+        user=UserResponse.from_dto(user),
+        csrf_token=csrf_token,
+        session_backend=backend,
+    )
+
+
+def _issue_local_tokens(
+    *,
+    users_service: UsersService,
+    auth_manager: AuthSecurityManager,
+    settings: Settings,
+    email_or_username: str,
+    password: str,
+) -> tuple[str, str | None, int, UsersDTO]:
+    """Verify local credentials and return access token fields plus owner DTO."""
+    user = users_service.verify_credentials(email_or_username, password)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers=_UNAUTHORIZED_HEADERS,
+        )
+    token = auth_manager.generate_token(str(user.id))
+    return token, None, settings.JWT_EXPIRATION_TIME_SECONDS, user
+
+
+def _issue_supabase_tokens(
+    *,
+    settings: Settings,
+    users_service: UsersService,
+    email: str,
+    password: str,
+) -> tuple[str, str | None, int, UsersDTO]:
+    """Sign in via Supabase Auth and ensure the Papita tenant row exists."""
+    _require_supabase_auth_settings(settings)
+    auth_result = None
+    try:
+        auth_result = supabase_sign_in(
+            supabase_url=settings.SUPABASE_URL or "",
+            anon_key=settings.SUPABASE_ANON_KEY or "",
+            email=email,
+            password=password,
+        )
+        user = users_service.ensure_from_auth_subject(
+            subject=auth_result.user_id,
+            email=auth_result.email,
+        )
+        token = _token_response_from_auth(
+            access_token=str(auth_result.access_token),
+            refresh_token=auth_result.refresh_token,
+            expires_in=auth_result.expires_in,
+            settings=settings,
+        )
+        return token.access_token, token.refresh_token, token.expires_in, user
+    except (AuthApiError, AuthError) as exc:
+        http_status, detail = classify_supabase_auth_error(exc, fallback="login failed")
+        if http_status == 401:
+            detail = "Incorrect username or password"
+        raise HTTPException(
+            status_code=http_status if http_status in {401, 429} else status.HTTP_401_UNAUTHORIZED,
+            detail=detail if http_status in {401, 429} else "Incorrect username or password",
+            headers=_UNAUTHORIZED_HEADERS,
+        ) from exc
+    except ValueError as exc:
+        if auth_result is not None and str(exc) != "User is inactive or deleted":
+            _cleanup_orphan_auth_user(
+                settings=settings,
+                user_id=auth_result.user_id,
+                reason="bff-login",
+                require_recent=True,
+            )
+        raise HTTPException(
+            status_code=_http_status_for_provision_error(exc),
+            detail=public_value_error_detail(exc, fallback="Login failed"),
+            headers=_UNAUTHORIZED_HEADERS if str(exc) == "User is inactive or deleted" else None,
+        ) from exc
+
+
+def _refresh_record(
+    *,
+    settings: Settings,
+    record: BffSessionRecord,
+) -> BffSessionRecord:
+    """Rotate Supabase tokens in-place; local sessions cannot refresh."""
+    if settings.AUTH_PROVIDER != "supabase":
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="BFF refresh requires AUTH_PROVIDER=supabase",
+        )
+    if not record.refresh_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session has no refresh token",
+            headers=_UNAUTHORIZED_HEADERS,
+        )
+    _require_supabase_auth_settings(settings)
+    try:
+        auth_result = supabase_refresh_session(
+            supabase_url=settings.SUPABASE_URL or "",
+            anon_key=settings.SUPABASE_ANON_KEY or "",
+            refresh_token=record.refresh_token,
+        )
+        token = _token_response_from_auth(
+            access_token=str(auth_result.access_token),
+            refresh_token=auth_result.refresh_token or record.refresh_token,
+            expires_in=auth_result.expires_in,
+            settings=settings,
+        )
+    except (AuthApiError, AuthError) as exc:
+        detail = auth_error_detail(exc, fallback="Invalid or expired refresh token")
+        logger.info("BFF refresh failed: %s", detail)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+            headers=_UNAUTHORIZED_HEADERS,
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=public_value_error_detail(exc, fallback="Invalid or expired refresh token"),
+        ) from exc
+
+    return BffSessionRecord(
+        access_token=token.access_token,
+        refresh_token=token.refresh_token,
+        csrf_token=record.csrf_token,
+        access_expires_at=time.time() + max(1, token.expires_in),
+        owner_id=record.owner_id,
+    )
+
+
+@router.post("/login", response_model=BffSessionResponse)
+def bff_login(  # pylint: disable=too-many-positional-arguments
+    body: BffLoginRequest,
+    response: Response,
+    _rate_limit: Annotated[None, Depends(enforce_auth_login_rate_limit)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    users_service: Annotated[UsersService, Depends(get_users_service)],
+    auth_manager: Annotated[AuthSecurityManager, Depends(get_auth_manager)],
+    bff_store: Annotated[BffSessionStore, Depends(get_bff_session_store)],
+) -> BffSessionResponse:
+    """Authenticate and set an HttpOnly session-id cookie (JWTs stay server-side)."""
+    if settings.AUTH_PROVIDER == "supabase":
+        access, refresh, expires_in, user = _issue_supabase_tokens(
+            settings=settings,
+            users_service=users_service,
+            email=body.email.strip(),
+            password=body.password,
+        )
+    else:
+        access, refresh, expires_in, user = _issue_local_tokens(
+            users_service=users_service,
+            auth_manager=auth_manager,
+            settings=settings,
+            email_or_username=body.email.strip(),
+            password=body.password,
+        )
+
+    session_id, record = bff_store.create(
+        access_token=access,
+        refresh_token=refresh,
+        expires_in=expires_in,
+        owner_id=parse_owner_id_hint(user.id),
+        ttl_seconds=_session_max_age(settings),
+    )
+    _set_session_cookie(response, session_id=session_id, settings=settings)
+    return _session_response(user=user, csrf_token=record.csrf_token, backend=bff_store.backend)
+
+
+@router.post("/register", status_code=status.HTTP_201_CREATED, response_model=UserResponse)
+def bff_register(
+    body: BffRegisterRequest,
+    _rate_limit: Annotated[None, Depends(enforce_auth_register_rate_limit)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    users_service: Annotated[UsersService, Depends(get_users_service)],
+) -> UserResponse:
+    """Register via the same Auth/UsersService path as ``POST /auth/register``.
+
+    Does not create a BFF session — clients should call ``POST /bff/auth/login`` next.
+    """
+    resolved_username = body.username or UsersService.username_from_email(body.email)
+
+    if settings.AUTH_PROVIDER == "supabase":
+        _require_supabase_auth_settings(settings)
+        auth_result = None
+        try:
+            auth_result = supabase_sign_up(
+                supabase_url=settings.SUPABASE_URL or "",
+                anon_key=settings.SUPABASE_ANON_KEY or "",
+                email=body.email,
+                password=body.password,
+                profile=SupabaseSignUpProfile(
+                    username=resolved_username,
+                    display_name=body.display_name,
+                    phone=body.phone,
+                    provider=body.provider_type,
+                ),
+            )
+            user = users_service.ensure_from_auth_subject(
+                subject=auth_result.user_id,
+                email=auth_result.email,
+                username=resolved_username,
+                display_name=body.display_name,
+                phone=body.phone,
+                provider_type=body.provider_type,
+            )
+        except (AuthApiError, AuthError) as exc:
+            http_status, detail = classify_supabase_auth_error(exc, fallback="Supabase Auth registration failed")
+            raise HTTPException(status_code=http_status, detail=detail) from exc
+        except ValueError as exc:
+            if auth_result is not None:
+                _cleanup_orphan_auth_user(
+                    settings=settings,
+                    user_id=auth_result.user_id,
+                    reason="bff-register",
+                    require_recent=False,
+                )
+            raise HTTPException(
+                status_code=_http_status_for_provision_error(exc),
+                detail=public_value_error_detail(exc, fallback="Registration failed"),
+                headers=_UNAUTHORIZED_HEADERS if str(exc) == "User is inactive or deleted" else None,
+            ) from exc
+        return UserResponse.from_dto(user)
+
+    user = users_service.register(
+        email=body.email,
+        password=body.password,
+        username=resolved_username,
+        display_name=body.display_name,
+        phone=body.phone,
+        provider_type=body.provider_type,
+    )
+    return UserResponse.from_dto(user)
+
+
+@router.get("/session", response_model=BffSessionResponse)
+def bff_session(  # pylint: disable=too-many-positional-arguments
+    request: Request,
+    token: Annotated[str | None, Depends(oauth2_scheme)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    users_service: Annotated[UsersService, Depends(get_users_service)],
+    bff_store: Annotated[BffSessionStore, Depends(get_bff_session_store)],
+    session_store: Annotated[SessionStore, Depends(get_session_store)],
+) -> BffSessionResponse:
+    """Probe BFF session for SPA bootstrap.
+
+    Returns ``authenticated: false`` (200) when no valid cookie/Bearer — avoids
+    treating anonymous bootstrap as an error. When authenticated via cookie,
+    includes ``csrf_token`` for mutation headers.
+    """
+    try:
+        owner = get_current_owner(
+            request=request,
+            token=token,
+            settings=settings,
+            users_service=users_service,
+            session_store=session_store,
+            bff_store=bff_store,
+        )
+    except HTTPException as exc:
+        if exc.status_code in {status.HTTP_401_UNAUTHORIZED, status.HTTP_503_SERVICE_UNAVAILABLE}:
+            return BffSessionResponse(authenticated=False, session_backend=bff_store.backend)
+        raise
+
+    csrf_token: str | None = None
+    session_id = request.cookies.get(BFF_SESSION_COOKIE)
+    if session_id:
+        record = bff_store.get(session_id)
+        if record is not None:
+            csrf_token = record.csrf_token
+    return _session_response(user=owner, csrf_token=csrf_token, backend=bff_store.backend)
+
+
+@router.post("/refresh", response_model=BffSessionResponse)
+def bff_refresh(
+    request: Request,
+    response: Response,
+    _rate_limit: Annotated[None, Depends(enforce_auth_oauth_rate_limit)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    users_service: Annotated[UsersService, Depends(get_users_service)],
+    bff_store: Annotated[BffSessionStore, Depends(get_bff_session_store)],
+) -> BffSessionResponse:
+    """Rotate tokens inside the BFF session store (cookie required)."""
+    session_id = request.cookies.get(BFF_SESSION_COOKIE)
+    if not session_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing BFF session cookie",
+            headers=_UNAUTHORIZED_HEADERS,
+        )
+    record = bff_store.get(session_id)
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired BFF session",
+            headers=_UNAUTHORIZED_HEADERS,
+        )
+
+    updated = _refresh_record(settings=settings, record=record)
+    bff_store.update(session_id, updated, ttl_seconds=_session_max_age(settings))
+    _set_session_cookie(response, session_id=session_id, settings=settings)
+
+    auth_manager = AuthSecurityManager(settings)
+    expected_type = settings.JWT_TOKEN_TYPE if settings.AUTH_PROVIDER == "local" else None
+    payload = auth_manager.decode_token(updated.access_token, expected_type=expected_type)
+    if payload is None or "sub" not in payload:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers=_UNAUTHORIZED_HEADERS,
+        )
+    owner = users_service.get_owner(payload["sub"]) if settings.AUTH_PROVIDER == "local" else None
+    if settings.AUTH_PROVIDER == "supabase":
+        owner = users_service.ensure_from_auth_subject(
+            subject=uuid.UUID(str(payload["sub"])),
+            email=str(payload.get("email") or "").strip(),
+        )
+    if owner is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers=_UNAUTHORIZED_HEADERS,
+        )
+    return _session_response(user=owner, csrf_token=updated.csrf_token, backend=bff_store.backend)
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
+def bff_logout(
+    request: Request,
+    response: Response,
+    _rate_limit: Annotated[None, Depends(enforce_auth_oauth_rate_limit)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    bff_store: Annotated[BffSessionStore, Depends(get_bff_session_store)],
+    session_store: Annotated[SessionStore, Depends(get_session_store)],
+) -> Response:
+    """Clear BFF session cookie, revoke at IdP when possible, denylist access JWT."""
+    session_id = request.cookies.get(BFF_SESSION_COOKIE)
+    record = bff_store.get(session_id) if session_id else None
+
+    if record is not None and settings.AUTH_PROVIDER == "supabase" and record.refresh_token:
+        try:
+            _require_supabase_auth_settings(settings)
+            supabase_sign_out(
+                supabase_url=settings.SUPABASE_URL or "",
+                anon_key=settings.SUPABASE_ANON_KEY or "",
+                access_token=record.access_token,
+                refresh_token=record.refresh_token,
+            )
+        except (AuthApiError, AuthError, ValueError, HTTPException) as exc:
+            logger.info("BFF Supabase sign_out best-effort failed: %s", exc)
+
+    if record is not None and session_store.available:
+        session_store.revoke(record.access_token, ttl_seconds=settings.JWT_EXPIRATION_TIME_SECONDS)
+
+    if session_id:
+        bff_store.delete(session_id)
+    _clear_session_cookie(response)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/modules/api/src/papita_txnsapi/routers/v1/bff_auth.py
+++ b/modules/api/src/papita_txnsapi/routers/v1/bff_auth.py
@@ -8,6 +8,7 @@ HttpOnly session-id cookie. Direct token clients keep using ``/auth/*``.
 from __future__ import annotations
 
 import logging
+import re
 import time
 import uuid
 from typing import Annotated
@@ -22,6 +23,7 @@ from papita_txnsapi.core.bff_session import (
     DEFAULT_BFF_SESSION_MAX_AGE_SECONDS,
     BffSessionRecord,
     BffSessionStore,
+    new_session_id,
     parse_owner_id_hint,
 )
 from papita_txnsapi.core.security import AuthSecurityManager
@@ -59,6 +61,9 @@ from papita_txnsmodel.services.users import UsersService
 
 logger = logging.getLogger(__name__)
 
+# Opaque ids from ``secrets.token_urlsafe`` (and length bound for Set-Cookie safety).
+_BFF_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]{16,128}$")
+
 router = APIRouter(prefix="/bff/auth", tags=["BFF Authentication"])
 
 
@@ -68,7 +73,13 @@ def _session_max_age(settings: Settings) -> int:
 
 
 def _set_session_cookie(response: Response, *, session_id: str, settings: Settings) -> None:
-    """Attach the HttpOnly ``papita_sid`` cookie to ``response``."""
+    """Attach the HttpOnly ``papita_sid`` cookie to ``response``.
+
+    ``session_id`` must be server-generated opaque entropy (see ``new_session_id``),
+    never a client-supplied value. Callers must not pass ``request.cookies`` values.
+    """
+    if _BFF_SESSION_ID_RE.fullmatch(session_id) is None:
+        raise ValueError("invalid BFF session id for Set-Cookie")
     response.set_cookie(
         key=BFF_SESSION_COOKIE,
         value=session_id,
@@ -393,8 +404,11 @@ def bff_refresh(
         )
 
     updated = _refresh_record(settings=settings, record=record)
-    bff_store.update(session_id, updated, ttl_seconds=_session_max_age(settings))
-    _set_session_cookie(response, session_id=session_id, settings=settings)
+    # Rotate the opaque cookie id so Set-Cookie never echoes a client-supplied value.
+    rotated_id = new_session_id()
+    bff_store.delete(session_id)
+    bff_store.update(rotated_id, updated, ttl_seconds=_session_max_age(settings))
+    _set_session_cookie(response, session_id=rotated_id, settings=settings)
 
     auth_manager = AuthSecurityManager(settings)
     expected_type = settings.JWT_TOKEN_TYPE if settings.AUTH_PROVIDER == "local" else None

--- a/modules/api/src/papita_txnsapi/schemas/bff_auth.py
+++ b/modules/api/src/papita_txnsapi/schemas/bff_auth.py
@@ -1,0 +1,48 @@
+"""Request/response schemas for ``/api/v1/bff/auth/*`` (PPT-049).
+
+BFF responses never include access or refresh JWTs — those stay server-side in
+the session binding store. The SPA receives only the public user profile and a
+CSRF token for mutation headers.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from papita_txnsapi.schemas.auth import RegisterRequest, UserResponse
+
+
+class BffLoginRequest(BaseModel):
+    """JSON body for ``POST /bff/auth/login``.
+
+    Attributes:
+        email: Canonical login identity (OAuth2 ``username`` field for token login).
+        password: Plain-text password (never logged or echoed).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    email: str = Field(min_length=5, max_length=255, pattern=r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+    password: str = Field(min_length=8, max_length=128)
+
+
+class BffRegisterRequest(RegisterRequest):
+    """JSON body for ``POST /bff/auth/register`` (same fields as ``/auth/register``)."""
+
+
+class BffSessionResponse(BaseModel):
+    """Public BFF session probe / login response (no JWTs).
+
+    Attributes:
+        authenticated: Whether a valid session cookie was resolved.
+        user: Public profile when authenticated.
+        csrf_token: Value for ``X-Papita-CSRF`` on cookie-authenticated mutations.
+        session_backend: ``redis`` or ``memory`` (ops visibility; not a secret).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    authenticated: bool
+    user: UserResponse | None = None
+    csrf_token: str | None = None
+    session_backend: str | None = None

--- a/modules/api/tests/conftest.py
+++ b/modules/api/tests/conftest.py
@@ -39,9 +39,12 @@ from papita_txnsmodel.access.users.dto import UsersDTO
 
 def _clear_auth_singletons() -> None:
     """Reset Settings cache and AuthSecurityManager after env/provider changes."""
+    from papita_txnsapi.core.bff_session import clear_memory_bff_sessions
+
     get_settings.cache_clear()
     AuthSecurityManager.reset_instances()
     clear_transactions_service_cache()
+    clear_memory_bff_sessions()
 
 
 @pytest.fixture

--- a/modules/api/tests/conftest.py
+++ b/modules/api/tests/conftest.py
@@ -15,6 +15,9 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 os.environ.setdefault("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characters")
 # Force local HS256 for unit tests even when environments/local/.env has supabase Auth.
 os.environ["AUTH_PROVIDER"] = "local"
+# TestClient is HTTP — Secure cookies are not stored/sent; keep BFF cookies usable in CI
+# even when DEBUG=false (CI default) would otherwise imply Secure cookies.
+os.environ["AUTH_COOKIE_SECURE"] = "false"
 os.environ.setdefault("AUTH_RATE_LIMIT_ENABLED", "false")
 os.environ.setdefault("API_RATE_LIMIT_ENABLED", "false")
 os.environ.setdefault("HEALTH_RATE_LIMIT_ENABLED", "false")

--- a/modules/api/tests/test_bff_auth.py
+++ b/modules/api/tests/test_bff_auth.py
@@ -2,18 +2,31 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import time
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
 
+import jwt
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi.testclient import TestClient
+from supabase_auth.errors import AuthApiError
 
 from auth_helpers import make_user
 from papita_txnsapi.config.settings import get_settings
-from papita_txnsapi.core.bff_session import BFF_CSRF_HEADER, BFF_SESSION_COOKIE, clear_memory_bff_sessions
+from papita_txnsapi.core.bff_session import (
+    BFF_CSRF_HEADER,
+    BFF_SESSION_COOKIE,
+    BffSessionStore,
+    clear_memory_bff_sessions,
+)
 from papita_txnsapi.core.rate_limit import InMemoryRateLimiter
-from papita_txnsapi.core.security import AuthSecurityManager
+from papita_txnsapi.core.security import AuthSecurityManager, supabase_issuer
 from papita_txnsapi.dependencies.services import get_users_service
 from papita_txnsapi.main import create_app
+from papita_txnsmodel.access.users.dto import UsersDTO
 
 
 @pytest.fixture
@@ -36,6 +49,67 @@ def bff_client() -> tuple[TestClient, MagicMock]:
     app.dependency_overrides.clear()
     clear_memory_bff_sessions()
     get_settings.cache_clear()
+
+
+@pytest.fixture
+def rsa_keypair():
+    """Ephemeral RSA keypair for minting Supabase-style JWTs in BFF tests."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _mint_supabase_token(
+    private_pem: bytes,
+    *,
+    subject: uuid.UUID,
+    email: str,
+    supabase_url: str,
+) -> str:
+    now = int(time.time())
+    payload = {
+        "sub": str(subject),
+        "email": email,
+        "aud": "authenticated",
+        "iss": supabase_issuer(supabase_url),
+        "role": "authenticated",
+        "iat": now,
+        "exp": now + 3600,
+    }
+    return jwt.encode(payload, private_pem, algorithm="RS256", headers={"kid": "test-kid"})
+
+
+def _configure_supabase_jwks(public_pem: bytes) -> None:
+    AuthSecurityManager.reset_instances()
+    settings = get_settings()
+    manager = AuthSecurityManager(settings)
+
+    class _Key:
+        key = public_pem
+
+    manager._jwks_client = MagicMock()
+    manager._jwks_client.get_signing_key_from_jwt.return_value = _Key()
+
+
+def _supabase_owner(subject: uuid.UUID, email: str) -> UsersDTO:
+    return UsersDTO.model_construct(
+        id=subject,
+        username="bffuser",
+        email=email,
+        password=None,
+        auth_provider="supabase",
+        active=True,
+        deleted_at=None,
+        created_at=datetime.now(timezone.utc),
+    )
 
 
 class TestBffCookieSession:
@@ -65,6 +139,19 @@ class TestBffCookieSession:
         assert response.status_code == 200
         assert response.json()["authenticated"] is False
 
+    def test_session_probe_authenticated_includes_csrf(self, bff_client: tuple[TestClient, MagicMock]) -> None:
+        client, _ = bff_client
+        login = client.post(
+            "/api/v1/bff/auth/login",
+            json={"email": "bff@example.com", "password": "password12"},
+        )
+        csrf = login.json()["csrf_token"]
+        session = client.get("/api/v1/bff/auth/session")
+        assert session.status_code == 200
+        body = session.json()
+        assert body["authenticated"] is True
+        assert body["csrf_token"] == csrf
+
     def test_cookie_authorizes_auth_me(self, bff_client: tuple[TestClient, MagicMock]) -> None:
         client, _ = bff_client
         login = client.post(
@@ -76,6 +163,15 @@ class TestBffCookieSession:
         assert me.status_code == 200
         assert me.json()["email"] == "bff@example.com"
 
+    def test_login_rejects_bad_credentials(self, bff_client: tuple[TestClient, MagicMock]) -> None:
+        client, mock_users = bff_client
+        mock_users.verify_credentials.return_value = None
+        response = client.post(
+            "/api/v1/bff/auth/login",
+            json={"email": "bff@example.com", "password": "wrong-password"},
+        )
+        assert response.status_code == 401
+
     def test_mutation_without_csrf_is_forbidden(self, bff_client: tuple[TestClient, MagicMock]) -> None:
         client, _ = bff_client
         login = client.post(
@@ -86,6 +182,23 @@ class TestBffCookieSession:
         denied = client.post("/api/v1/bff/auth/logout")
         assert denied.status_code == 403
         assert "CSRF" in denied.json()["detail"]
+
+    def test_mutation_with_wrong_csrf_is_forbidden(self, bff_client: tuple[TestClient, MagicMock]) -> None:
+        client, _ = bff_client
+        login = client.post(
+            "/api/v1/bff/auth/login",
+            json={"email": "bff@example.com", "password": "password12"},
+        )
+        assert login.status_code == 200
+        denied = client.post("/api/v1/bff/auth/logout", headers={BFF_CSRF_HEADER: "not-the-token"})
+        assert denied.status_code == 403
+
+    def test_unknown_cookie_skips_csrf_and_continues(self, bff_client: tuple[TestClient, MagicMock]) -> None:
+        client, _ = bff_client
+        client.cookies.set(BFF_SESSION_COOKIE, "unknown-session-id-abcdefgh")
+        # No matching store record → CSRF middleware continues; logout clears cookie.
+        response = client.post("/api/v1/bff/auth/logout")
+        assert response.status_code == 204
 
     def test_logout_with_csrf_clears_session(self, bff_client: tuple[TestClient, MagicMock]) -> None:
         client, _ = bff_client
@@ -124,3 +237,696 @@ class TestBffCookieSession:
         )
         assert login.status_code == 200
         assert login.json()["authenticated"] is True
+
+    def test_refresh_requires_supabase_provider(self, bff_client: tuple[TestClient, MagicMock]) -> None:
+        client, _ = bff_client
+        login = client.post(
+            "/api/v1/bff/auth/login",
+            json={"email": "bff@example.com", "password": "password12"},
+        )
+        csrf = login.json()["csrf_token"]
+        refresh = client.post("/api/v1/bff/auth/refresh", headers={BFF_CSRF_HEADER: csrf})
+        assert refresh.status_code == 501
+        assert "supabase" in refresh.json()["detail"].lower()
+
+    def test_refresh_missing_cookie_is_unauthorized(self, bff_client: tuple[TestClient, MagicMock]) -> None:
+        client, _ = bff_client
+        response = client.post("/api/v1/bff/auth/refresh")
+        assert response.status_code == 401
+
+    def test_refresh_invalid_session_is_unauthorized(self, bff_client: tuple[TestClient, MagicMock]) -> None:
+        client, _ = bff_client
+        client.cookies.set(BFF_SESSION_COOKIE, "missing-session-abcdefghij")
+        response = client.post("/api/v1/bff/auth/refresh")
+        assert response.status_code == 401
+
+
+class TestBffSupabaseCookieSession:
+    """Supabase IdP branches for BFF login/register/refresh/logout + silent refresh."""
+
+    def test_login_sets_cookie_and_authorizes_me(
+        self, rsa_keypair, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        private_pem, public_pem = rsa_keypair
+        supabase_url = "https://example.supabase.co"
+        subject = uuid.uuid4()
+        email = "bff-sb@example.local"
+        access = _mint_supabase_token(
+            private_pem, subject=subject, email=email, supabase_url=supabase_url
+        )
+
+        monkeypatch.setenv("AUTH_PROVIDER", "supabase")
+        monkeypatch.setenv("SUPABASE_URL", supabase_url)
+        monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+        monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characters")
+        monkeypatch.setenv("DATABASE_URL", "")
+        monkeypatch.setenv("AUTH_COOKIE_SECURE", "false")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+        clear_memory_bff_sessions()
+
+        app = create_app()
+        mock_users = MagicMock()
+        mock_users.ensure_from_auth_subject.return_value = _supabase_owner(subject, email)
+        app.dependency_overrides[get_users_service] = lambda: mock_users
+        _configure_supabase_jwks(public_pem)
+
+        auth_result = MagicMock()
+        auth_result.user_id = subject
+        auth_result.email = email
+        auth_result.access_token = access
+        auth_result.refresh_token = "sb-refresh"
+        auth_result.expires_in = 3600
+
+        with patch("papita_txnsapi.routers.v1.bff_auth.supabase_sign_in", return_value=auth_result):
+            client = TestClient(app)
+            login = client.post(
+                "/api/v1/bff/auth/login",
+                json={"email": email, "password": "SecurePass1!"},
+            )
+            assert login.status_code == 200
+            assert login.json()["authenticated"] is True
+            assert BFF_SESSION_COOKIE in login.cookies
+            me = client.get("/api/v1/auth/me")
+            assert me.status_code == 200
+            assert me.json()["id"] == str(subject)
+
+        app.dependency_overrides.clear()
+        AuthSecurityManager.reset_instances()
+        get_settings.cache_clear()
+        clear_memory_bff_sessions()
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+
+    def test_login_maps_auth_api_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTH_PROVIDER", "supabase")
+        monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+        monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+        monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characters")
+        monkeypatch.setenv("DATABASE_URL", "")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+        clear_memory_bff_sessions()
+
+        app = create_app()
+        app.dependency_overrides[get_users_service] = lambda: MagicMock()
+        with patch(
+            "papita_txnsapi.routers.v1.bff_auth.supabase_sign_in",
+            side_effect=AuthApiError("Invalid login credentials", 400, "invalid_credentials"),
+        ):
+            client = TestClient(app)
+            response = client.post(
+                "/api/v1/bff/auth/login",
+                json={"email": "x@example.local", "password": "bad-password"},
+            )
+        assert response.status_code == 401
+        app.dependency_overrides.clear()
+        AuthSecurityManager.reset_instances()
+        get_settings.cache_clear()
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+
+    def test_login_provision_value_error_inactive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTH_PROVIDER", "supabase")
+        monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+        monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+        monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characters")
+        monkeypatch.setenv("DATABASE_URL", "")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+        clear_memory_bff_sessions()
+
+        subject = uuid.uuid4()
+        app = create_app()
+        mock_users = MagicMock()
+        mock_users.ensure_from_auth_subject.side_effect = ValueError("User is inactive or deleted")
+        app.dependency_overrides[get_users_service] = lambda: mock_users
+        auth_result = MagicMock()
+        auth_result.user_id = subject
+        auth_result.email = "inactive@example.local"
+        auth_result.access_token = "tok"
+        auth_result.refresh_token = "ref"
+        auth_result.expires_in = 3600
+        with patch("papita_txnsapi.routers.v1.bff_auth.supabase_sign_in", return_value=auth_result):
+            client = TestClient(app)
+            response = client.post(
+                "/api/v1/bff/auth/login",
+                json={"email": "inactive@example.local", "password": "SecurePass1!"},
+            )
+        assert response.status_code == 401
+        app.dependency_overrides.clear()
+        AuthSecurityManager.reset_instances()
+        get_settings.cache_clear()
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+
+    def test_register_uses_supabase_sign_up(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        subject = uuid.uuid4()
+        email = "new-bff@example.local"
+        monkeypatch.setenv("AUTH_PROVIDER", "supabase")
+        monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+        monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+        monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characters")
+        monkeypatch.setenv("DATABASE_URL", "")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+        clear_memory_bff_sessions()
+
+        app = create_app()
+        mock_users = MagicMock()
+        mock_users.ensure_from_auth_subject.return_value = _supabase_owner(subject, email)
+        app.dependency_overrides[get_users_service] = lambda: mock_users
+        auth_result = MagicMock()
+        auth_result.user_id = subject
+        auth_result.email = email
+        with patch(
+            "papita_txnsapi.routers.v1.bff_auth.supabase_sign_up", return_value=auth_result
+        ) as mock_sign_up:
+            client = TestClient(app)
+            response = client.post(
+                "/api/v1/bff/auth/register",
+                json={"email": email, "password": "SecurePass1!"},
+            )
+        assert response.status_code == 201
+        assert response.json()["id"] == str(subject)
+        mock_sign_up.assert_called_once()
+        app.dependency_overrides.clear()
+        AuthSecurityManager.reset_instances()
+        get_settings.cache_clear()
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+
+    def test_register_maps_conflict(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTH_PROVIDER", "supabase")
+        monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+        monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+        monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characters")
+        monkeypatch.setenv("DATABASE_URL", "")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+        clear_memory_bff_sessions()
+
+        app = create_app()
+        app.dependency_overrides[get_users_service] = lambda: MagicMock()
+        with patch(
+            "papita_txnsapi.routers.v1.bff_auth.supabase_sign_up",
+            side_effect=AuthApiError("User already registered", 400, "email_exists"),
+        ):
+            client = TestClient(app)
+            response = client.post(
+                "/api/v1/bff/auth/register",
+                json={"email": "dup@example.local", "password": "SecurePass1!"},
+            )
+        assert response.status_code == 409
+        app.dependency_overrides.clear()
+        AuthSecurityManager.reset_instances()
+        get_settings.cache_clear()
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+
+    def test_register_provision_failure_cleans_orphan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        subject = uuid.uuid4()
+        monkeypatch.setenv("AUTH_PROVIDER", "supabase")
+        monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+        monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role")
+        monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characters")
+        monkeypatch.setenv("DATABASE_URL", "")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+        clear_memory_bff_sessions()
+
+        app = create_app()
+        mock_users = MagicMock()
+        mock_users.ensure_from_auth_subject.side_effect = ValueError("email already linked")
+        app.dependency_overrides[get_users_service] = lambda: mock_users
+        auth_result = MagicMock()
+        auth_result.user_id = subject
+        auth_result.email = "orphan@example.local"
+        with (
+            patch("papita_txnsapi.routers.v1.bff_auth.supabase_sign_up", return_value=auth_result),
+            patch("papita_txnsapi.routers.v1.bff_auth._cleanup_orphan_auth_user") as mock_cleanup,
+        ):
+            client = TestClient(app)
+            response = client.post(
+                "/api/v1/bff/auth/register",
+                json={"email": "orphan@example.local", "password": "SecurePass1!"},
+            )
+        assert response.status_code in {400, 409, 500, 502}
+        mock_cleanup.assert_called_once()
+        app.dependency_overrides.clear()
+        AuthSecurityManager.reset_instances()
+        get_settings.cache_clear()
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+        monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+
+    def test_refresh_rotates_cookie_and_tokens(
+        self, rsa_keypair, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        private_pem, public_pem = rsa_keypair
+        supabase_url = "https://example.supabase.co"
+        subject = uuid.uuid4()
+        email = "refresh@example.local"
+        access = _mint_supabase_token(
+            private_pem, subject=subject, email=email, supabase_url=supabase_url
+        )
+        rotated = _mint_supabase_token(
+            private_pem, subject=subject, email=email, supabase_url=supabase_url
+        )
+
+        monkeypatch.setenv("AUTH_PROVIDER", "supabase")
+        monkeypatch.setenv("SUPABASE_URL", supabase_url)
+        monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+        monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characters")
+        monkeypatch.setenv("DATABASE_URL", "")
+        monkeypatch.setenv("AUTH_COOKIE_SECURE", "false")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+        clear_memory_bff_sessions()
+
+        app = create_app()
+        mock_users = MagicMock()
+        mock_users.ensure_from_auth_subject.return_value = _supabase_owner(subject, email)
+        app.dependency_overrides[get_users_service] = lambda: mock_users
+        _configure_supabase_jwks(public_pem)
+
+        login_result = MagicMock()
+        login_result.user_id = subject
+        login_result.email = email
+        login_result.access_token = access
+        login_result.refresh_token = "old-refresh"
+        login_result.expires_in = 3600
+
+        refresh_result = MagicMock()
+        refresh_result.user_id = subject
+        refresh_result.email = email
+        refresh_result.access_token = rotated
+        refresh_result.refresh_token = "new-refresh"
+        refresh_result.expires_in = 1800
+
+        with (
+            patch("papita_txnsapi.routers.v1.bff_auth.supabase_sign_in", return_value=login_result),
+            patch(
+                "papita_txnsapi.routers.v1.bff_auth.supabase_refresh_session",
+                return_value=refresh_result,
+            ) as mock_refresh,
+        ):
+            client = TestClient(app)
+            login = client.post(
+                "/api/v1/bff/auth/login",
+                json={"email": email, "password": "SecurePass1!"},
+            )
+            assert login.status_code == 200
+            old_sid = login.cookies.get(BFF_SESSION_COOKIE)
+            csrf = login.json()["csrf_token"]
+            refreshed = client.post(
+                "/api/v1/bff/auth/refresh",
+                headers={BFF_CSRF_HEADER: csrf},
+            )
+            assert refreshed.status_code == 200
+            assert refreshed.json()["authenticated"] is True
+            assert refreshed.json()["csrf_token"] == csrf
+            new_sid = refreshed.cookies.get(BFF_SESSION_COOKIE)
+            assert new_sid
+            assert new_sid != old_sid
+            mock_refresh.assert_called_once()
+            me = client.get("/api/v1/auth/me")
+            assert me.status_code == 200
+
+        app.dependency_overrides.clear()
+        AuthSecurityManager.reset_instances()
+        get_settings.cache_clear()
+        clear_memory_bff_sessions()
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+
+    def test_refresh_without_refresh_token_is_unauthorized(
+        self, rsa_keypair, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        private_pem, public_pem = rsa_keypair
+        supabase_url = "https://example.supabase.co"
+        subject = uuid.uuid4()
+        email = "noref@example.local"
+        access = _mint_supabase_token(
+            private_pem, subject=subject, email=email, supabase_url=supabase_url
+        )
+
+        monkeypatch.setenv("AUTH_PROVIDER", "supabase")
+        monkeypatch.setenv("SUPABASE_URL", supabase_url)
+        monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+        monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characters")
+        monkeypatch.setenv("DATABASE_URL", "")
+        monkeypatch.setenv("AUTH_COOKIE_SECURE", "false")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+        clear_memory_bff_sessions()
+
+        app = create_app()
+        mock_users = MagicMock()
+        mock_users.ensure_from_auth_subject.return_value = _supabase_owner(subject, email)
+        app.dependency_overrides[get_users_service] = lambda: mock_users
+        _configure_supabase_jwks(public_pem)
+
+        store = BffSessionStore(None, default_ttl_seconds=3600)
+        sid, record = store.create(
+            access_token=access,
+            refresh_token=None,
+            expires_in=3600,
+            owner_id=str(subject),
+        )
+        client = TestClient(app)
+        client.cookies.set(BFF_SESSION_COOKIE, sid)
+        response = client.post(
+            "/api/v1/bff/auth/refresh",
+            headers={BFF_CSRF_HEADER: record.csrf_token},
+        )
+        assert response.status_code == 401
+        assert "refresh token" in response.json()["detail"].lower()
+
+        app.dependency_overrides.clear()
+        AuthSecurityManager.reset_instances()
+        get_settings.cache_clear()
+        clear_memory_bff_sessions()
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+
+    def test_refresh_auth_error_is_unauthorized(
+        self, rsa_keypair, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        private_pem, public_pem = rsa_keypair
+        supabase_url = "https://example.supabase.co"
+        subject = uuid.uuid4()
+        email = "badref@example.local"
+        access = _mint_supabase_token(
+            private_pem, subject=subject, email=email, supabase_url=supabase_url
+        )
+
+        monkeypatch.setenv("AUTH_PROVIDER", "supabase")
+        monkeypatch.setenv("SUPABASE_URL", supabase_url)
+        monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+        monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characters")
+        monkeypatch.setenv("DATABASE_URL", "")
+        monkeypatch.setenv("AUTH_COOKIE_SECURE", "false")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+        clear_memory_bff_sessions()
+
+        app = create_app()
+        mock_users = MagicMock()
+        mock_users.ensure_from_auth_subject.return_value = _supabase_owner(subject, email)
+        app.dependency_overrides[get_users_service] = lambda: mock_users
+        _configure_supabase_jwks(public_pem)
+
+        login_result = MagicMock()
+        login_result.user_id = subject
+        login_result.email = email
+        login_result.access_token = access
+        login_result.refresh_token = "stale-refresh"
+        login_result.expires_in = 3600
+
+        with (
+            patch("papita_txnsapi.routers.v1.bff_auth.supabase_sign_in", return_value=login_result),
+            patch(
+                "papita_txnsapi.routers.v1.bff_auth.supabase_refresh_session",
+                side_effect=AuthApiError("Invalid refresh token", 401, "invalid_grant"),
+            ),
+        ):
+            client = TestClient(app)
+            login = client.post(
+                "/api/v1/bff/auth/login",
+                json={"email": email, "password": "SecurePass1!"},
+            )
+            csrf = login.json()["csrf_token"]
+            refreshed = client.post(
+                "/api/v1/bff/auth/refresh",
+                headers={BFF_CSRF_HEADER: csrf},
+            )
+        assert refreshed.status_code == 401
+
+        app.dependency_overrides.clear()
+        AuthSecurityManager.reset_instances()
+        get_settings.cache_clear()
+        clear_memory_bff_sessions()
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+
+    def test_logout_calls_supabase_sign_out(
+        self, rsa_keypair, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        private_pem, public_pem = rsa_keypair
+        supabase_url = "https://example.supabase.co"
+        subject = uuid.uuid4()
+        email = "out@example.local"
+        access = _mint_supabase_token(
+            private_pem, subject=subject, email=email, supabase_url=supabase_url
+        )
+
+        monkeypatch.setenv("AUTH_PROVIDER", "supabase")
+        monkeypatch.setenv("SUPABASE_URL", supabase_url)
+        monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+        monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characters")
+        monkeypatch.setenv("DATABASE_URL", "")
+        monkeypatch.setenv("AUTH_COOKIE_SECURE", "false")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+        clear_memory_bff_sessions()
+
+        app = create_app()
+        mock_users = MagicMock()
+        mock_users.ensure_from_auth_subject.return_value = _supabase_owner(subject, email)
+        app.dependency_overrides[get_users_service] = lambda: mock_users
+        _configure_supabase_jwks(public_pem)
+
+        login_result = MagicMock()
+        login_result.user_id = subject
+        login_result.email = email
+        login_result.access_token = access
+        login_result.refresh_token = "logout-refresh"
+        login_result.expires_in = 3600
+
+        with (
+            patch("papita_txnsapi.routers.v1.bff_auth.supabase_sign_in", return_value=login_result),
+            patch("papita_txnsapi.routers.v1.bff_auth.supabase_sign_out") as mock_sign_out,
+        ):
+            client = TestClient(app)
+            login = client.post(
+                "/api/v1/bff/auth/login",
+                json={"email": email, "password": "SecurePass1!"},
+            )
+            csrf = login.json()["csrf_token"]
+            logout = client.post(
+                "/api/v1/bff/auth/logout",
+                headers={BFF_CSRF_HEADER: csrf},
+            )
+        assert logout.status_code == 204
+        mock_sign_out.assert_called_once()
+        assert mock_sign_out.call_args.kwargs["refresh_token"] == "logout-refresh"
+
+        app.dependency_overrides.clear()
+        AuthSecurityManager.reset_instances()
+        get_settings.cache_clear()
+        clear_memory_bff_sessions()
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+
+    def test_logout_sign_out_failure_is_best_effort(
+        self, rsa_keypair, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        private_pem, public_pem = rsa_keypair
+        supabase_url = "https://example.supabase.co"
+        subject = uuid.uuid4()
+        email = "outfail@example.local"
+        access = _mint_supabase_token(
+            private_pem, subject=subject, email=email, supabase_url=supabase_url
+        )
+
+        monkeypatch.setenv("AUTH_PROVIDER", "supabase")
+        monkeypatch.setenv("SUPABASE_URL", supabase_url)
+        monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+        monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characters")
+        monkeypatch.setenv("DATABASE_URL", "")
+        monkeypatch.setenv("AUTH_COOKIE_SECURE", "false")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+        clear_memory_bff_sessions()
+
+        app = create_app()
+        mock_users = MagicMock()
+        mock_users.ensure_from_auth_subject.return_value = _supabase_owner(subject, email)
+        app.dependency_overrides[get_users_service] = lambda: mock_users
+        _configure_supabase_jwks(public_pem)
+
+        login_result = MagicMock()
+        login_result.user_id = subject
+        login_result.email = email
+        login_result.access_token = access
+        login_result.refresh_token = "logout-refresh"
+        login_result.expires_in = 3600
+
+        with (
+            patch("papita_txnsapi.routers.v1.bff_auth.supabase_sign_in", return_value=login_result),
+            patch(
+                "papita_txnsapi.routers.v1.bff_auth.supabase_sign_out",
+                side_effect=AuthApiError("gone", 401, "session_not_found"),
+            ),
+        ):
+            client = TestClient(app)
+            login = client.post(
+                "/api/v1/bff/auth/login",
+                json={"email": email, "password": "SecurePass1!"},
+            )
+            csrf = login.json()["csrf_token"]
+            logout = client.post(
+                "/api/v1/bff/auth/logout",
+                headers={BFF_CSRF_HEADER: csrf},
+            )
+        assert logout.status_code == 204
+
+        app.dependency_overrides.clear()
+        AuthSecurityManager.reset_instances()
+        get_settings.cache_clear()
+        clear_memory_bff_sessions()
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+
+    def test_silent_refresh_on_expired_access(
+        self, rsa_keypair, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        private_pem, public_pem = rsa_keypair
+        supabase_url = "https://example.supabase.co"
+        subject = uuid.uuid4()
+        email = "silent@example.local"
+        stale = _mint_supabase_token(
+            private_pem, subject=subject, email=email, supabase_url=supabase_url
+        )
+        fresh = _mint_supabase_token(
+            private_pem, subject=subject, email=email, supabase_url=supabase_url
+        )
+
+        monkeypatch.setenv("AUTH_PROVIDER", "supabase")
+        monkeypatch.setenv("SUPABASE_URL", supabase_url)
+        monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+        monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characters")
+        monkeypatch.setenv("DATABASE_URL", "")
+        monkeypatch.setenv("AUTH_COOKIE_SECURE", "false")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+        clear_memory_bff_sessions()
+
+        app = create_app()
+        mock_users = MagicMock()
+        mock_users.ensure_from_auth_subject.return_value = _supabase_owner(subject, email)
+        app.dependency_overrides[get_users_service] = lambda: mock_users
+        _configure_supabase_jwks(public_pem)
+
+        store = BffSessionStore(None, default_ttl_seconds=3600)
+        # expires_in=1 → immediately inside the 30s skew window → silent refresh.
+        sid, _ = store.create(
+            access_token=stale,
+            refresh_token="silent-refresh",
+            expires_in=1,
+            owner_id=str(subject),
+        )
+
+        refresh_result = MagicMock()
+        refresh_result.user_id = subject
+        refresh_result.email = email
+        refresh_result.access_token = fresh
+        refresh_result.refresh_token = "silent-refresh-2"
+        refresh_result.expires_in = 3600
+
+        with patch(
+            "papita_txnsapi.dependencies.auth.supabase_refresh_session",
+            return_value=refresh_result,
+        ) as mock_refresh:
+            client = TestClient(app)
+            client.cookies.set(BFF_SESSION_COOKIE, sid)
+            me = client.get("/api/v1/auth/me")
+        assert me.status_code == 200
+        mock_refresh.assert_called_once()
+
+        app.dependency_overrides.clear()
+        AuthSecurityManager.reset_instances()
+        get_settings.cache_clear()
+        clear_memory_bff_sessions()
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+
+    def test_silent_refresh_failure_clears_session(
+        self, rsa_keypair, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        private_pem, public_pem = rsa_keypair
+        supabase_url = "https://example.supabase.co"
+        subject = uuid.uuid4()
+        email = "silent-fail@example.local"
+        stale = _mint_supabase_token(
+            private_pem, subject=subject, email=email, supabase_url=supabase_url
+        )
+
+        monkeypatch.setenv("AUTH_PROVIDER", "supabase")
+        monkeypatch.setenv("SUPABASE_URL", supabase_url)
+        monkeypatch.setenv("SUPABASE_ANON_KEY", "test-anon-key")
+        monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-minimum-32-characters")
+        monkeypatch.setenv("DATABASE_URL", "")
+        monkeypatch.setenv("AUTH_COOKIE_SECURE", "false")
+        get_settings.cache_clear()
+        AuthSecurityManager.reset_instances()
+        InMemoryRateLimiter().reset()
+        clear_memory_bff_sessions()
+
+        app = create_app()
+        mock_users = MagicMock()
+        mock_users.ensure_from_auth_subject.return_value = _supabase_owner(subject, email)
+        app.dependency_overrides[get_users_service] = lambda: mock_users
+        _configure_supabase_jwks(public_pem)
+
+        store = BffSessionStore(None, default_ttl_seconds=3600)
+        sid, _ = store.create(
+            access_token=stale,
+            refresh_token="dead-refresh",
+            expires_in=1,
+            owner_id=str(subject),
+        )
+
+        with patch(
+            "papita_txnsapi.dependencies.auth.supabase_refresh_session",
+            side_effect=AuthApiError("Invalid refresh token", 401, "invalid_grant"),
+        ):
+            client = TestClient(app)
+            client.cookies.set(BFF_SESSION_COOKIE, sid)
+            me = client.get("/api/v1/auth/me")
+        assert me.status_code == 401
+        assert store.get(sid) is None
+
+        app.dependency_overrides.clear()
+        AuthSecurityManager.reset_instances()
+        get_settings.cache_clear()
+        clear_memory_bff_sessions()
+        monkeypatch.setenv("AUTH_PROVIDER", "local")
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)

--- a/modules/api/tests/test_bff_auth.py
+++ b/modules/api/tests/test_bff_auth.py
@@ -1,0 +1,126 @@
+"""Tests for BFF HttpOnly cookie sessions (PPT-049)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from auth_helpers import make_user
+from papita_txnsapi.config.settings import get_settings
+from papita_txnsapi.core.bff_session import BFF_CSRF_HEADER, BFF_SESSION_COOKIE, clear_memory_bff_sessions
+from papita_txnsapi.core.rate_limit import InMemoryRateLimiter
+from papita_txnsapi.core.security import AuthSecurityManager
+from papita_txnsapi.dependencies.services import get_users_service
+from papita_txnsapi.main import create_app
+
+
+@pytest.fixture
+def bff_client() -> tuple[TestClient, MagicMock]:
+    """Test client with mocked UsersService for local BFF auth."""
+    get_settings.cache_clear()
+    AuthSecurityManager.reset_instances()
+    InMemoryRateLimiter().reset()
+    clear_memory_bff_sessions()
+
+    app = create_app()
+    owner = make_user(email="bff@example.com")
+    mock_users = MagicMock()
+    mock_users.verify_credentials.return_value = owner
+    mock_users.get_owner.return_value = owner
+    mock_users.register.return_value = owner
+    app.dependency_overrides[get_users_service] = lambda: mock_users
+    client = TestClient(app)
+    yield client, mock_users
+    app.dependency_overrides.clear()
+    clear_memory_bff_sessions()
+    get_settings.cache_clear()
+
+
+class TestBffCookieSession:
+    """Cookie flags, session lifecycle, CSRF, and cookie→protected route path."""
+
+    def test_login_sets_httponly_session_cookie(self, bff_client: tuple[TestClient, MagicMock]) -> None:
+        client, _ = bff_client
+        response = client.post(
+            "/api/v1/bff/auth/login",
+            json={"email": "bff@example.com", "password": "password12"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["authenticated"] is True
+        assert body["csrf_token"]
+        assert "access_token" not in body
+        assert "refresh_token" not in body
+        assert BFF_SESSION_COOKIE in response.cookies
+        # Starlette TestClient exposes cookie jar; Set-Cookie flags via headers.
+        set_cookie = response.headers.get("set-cookie", "")
+        assert "HttpOnly" in set_cookie or "httponly" in set_cookie.lower()
+        assert "Path=/api" in set_cookie or "path=/api" in set_cookie.lower()
+
+    def test_session_probe_unauthenticated(self, bff_client: tuple[TestClient, MagicMock]) -> None:
+        client, _ = bff_client
+        response = client.get("/api/v1/bff/auth/session")
+        assert response.status_code == 200
+        assert response.json()["authenticated"] is False
+
+    def test_cookie_authorizes_auth_me(self, bff_client: tuple[TestClient, MagicMock]) -> None:
+        client, _ = bff_client
+        login = client.post(
+            "/api/v1/bff/auth/login",
+            json={"email": "bff@example.com", "password": "password12"},
+        )
+        assert login.status_code == 200
+        me = client.get("/api/v1/auth/me")
+        assert me.status_code == 200
+        assert me.json()["email"] == "bff@example.com"
+
+    def test_mutation_without_csrf_is_forbidden(self, bff_client: tuple[TestClient, MagicMock]) -> None:
+        client, _ = bff_client
+        login = client.post(
+            "/api/v1/bff/auth/login",
+            json={"email": "bff@example.com", "password": "password12"},
+        )
+        assert login.status_code == 200
+        denied = client.post("/api/v1/bff/auth/logout")
+        assert denied.status_code == 403
+        assert "CSRF" in denied.json()["detail"]
+
+    def test_logout_with_csrf_clears_session(self, bff_client: tuple[TestClient, MagicMock]) -> None:
+        client, _ = bff_client
+        login = client.post(
+            "/api/v1/bff/auth/login",
+            json={"email": "bff@example.com", "password": "password12"},
+        )
+        csrf = login.json()["csrf_token"]
+        logout = client.post("/api/v1/bff/auth/logout", headers={BFF_CSRF_HEADER: csrf})
+        assert logout.status_code == 204
+        me = client.get("/api/v1/auth/me")
+        assert me.status_code == 401
+        session = client.get("/api/v1/bff/auth/session")
+        assert session.json()["authenticated"] is False
+
+    def test_bearer_still_works_without_cookie(self, bff_client: tuple[TestClient, MagicMock]) -> None:
+        """Token-path / auth-smoke coexistence: Bearer bypasses BFF cookie + CSRF."""
+        client, mock_users = bff_client
+        owner = mock_users.verify_credentials.return_value
+        settings = get_settings()
+        token = AuthSecurityManager(settings).generate_token(str(owner.id))
+        me = client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+        assert me.status_code == 200
+
+    def test_register_then_login(self, bff_client: tuple[TestClient, MagicMock]) -> None:
+        client, mock_users = bff_client
+        registered = client.post(
+            "/api/v1/bff/auth/register",
+            json={"email": "bff@example.com", "password": "password12"},
+        )
+        assert registered.status_code == 201
+        mock_users.register.assert_called_once()
+        login = client.post(
+            "/api/v1/bff/auth/login",
+            json={"email": "bff@example.com", "password": "password12"},
+        )
+        assert login.status_code == 200
+        assert login.json()["authenticated"] is True

--- a/modules/api/tests/test_bff_session_store.py
+++ b/modules/api/tests/test_bff_session_store.py
@@ -1,0 +1,143 @@
+"""Unit tests for BFF session store serialization and Redis fallbacks (PPT-049)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from redis.exceptions import RedisError
+
+from papita_txnsapi.core.bff_session import (
+    BffSessionRecord,
+    BffSessionStore,
+    clear_memory_bff_sessions,
+    parse_owner_id_hint,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_memory() -> None:
+    clear_memory_bff_sessions()
+    yield
+    clear_memory_bff_sessions()
+
+
+class TestBffSessionRecord:
+    """JSON round-trip and expiry helpers."""
+
+    def test_round_trip(self) -> None:
+        record = BffSessionRecord(
+            access_token="a",
+            refresh_token="r",
+            csrf_token="c",
+            access_expires_at=1.5,
+            owner_id="o",
+        )
+        parsed = BffSessionRecord.from_json(record.to_json())
+        assert parsed.access_token == "a"
+        assert parsed.refresh_token == "r"
+        assert parsed.csrf_token == "c"
+        assert parsed.access_expires_at == 1.5
+        assert parsed.owner_id == "o"
+
+    def test_from_json_rejects_malformed(self) -> None:
+        with pytest.raises(ValueError, match="invalid BFF session"):
+            BffSessionRecord.from_json("{not-json")
+        with pytest.raises(ValueError, match="invalid BFF session"):
+            BffSessionRecord.from_json('{"access_token":"a"}')
+
+    def test_access_expired_respects_skew(self) -> None:
+        record = BffSessionRecord(
+            access_token="a",
+            refresh_token=None,
+            csrf_token="c",
+            access_expires_at=0.0,
+        )
+        assert record.access_expired() is True
+
+
+class TestBffSessionStoreMemory:
+    """Process-local map behavior."""
+
+    def test_create_get_update_delete(self) -> None:
+        store = BffSessionStore(None, default_ttl_seconds=120)
+        assert store.backend == "memory"
+        sid, record = store.create(
+            access_token="access",
+            refresh_token=None,
+            expires_in=60,
+            owner_id="owner-1",
+        )
+        assert store.get(sid) is not None
+        assert store.get("") is None
+        updated = BffSessionRecord(
+            access_token="rotated",
+            refresh_token=record.refresh_token,
+            csrf_token=record.csrf_token,
+            access_expires_at=record.access_expires_at,
+            owner_id=record.owner_id,
+        )
+        store.update(sid, updated)
+        assert store.get(sid).access_token == "rotated"
+        store.update("", updated)
+        store.delete(sid)
+        assert store.get(sid) is None
+        store.delete("")
+
+    def test_corrupt_payload_is_dropped(self) -> None:
+        store = BffSessionStore(None, default_ttl_seconds=120)
+        sid, _ = store.create(access_token="a", refresh_token=None, expires_in=30)
+        # Poison the memory map with invalid JSON under the same key.
+        from papita_txnsapi.core import bff_session as mod
+
+        with mod._memory_lock:
+            mod._memory_sessions[sid] = "{bad"
+        assert store.get(sid) is None
+
+
+class TestBffSessionStoreRedis:
+    """Redis client success and RedisError fallbacks."""
+
+    def test_redis_set_get_delete(self) -> None:
+        client = MagicMock()
+        client.get.return_value = None
+        store = BffSessionStore(client, default_ttl_seconds=120)
+        assert store.backend == "redis"
+        sid, record = store.create(access_token="a", refresh_token="r", expires_in=30)
+        client.setex.assert_called()
+        client.get.return_value = record.to_json().encode("utf-8")
+        assert store.get(sid) is not None
+        store.delete(sid)
+        client.delete.assert_called()
+
+    def test_redis_errors_fall_back_to_memory(self) -> None:
+        client = MagicMock()
+        client.setex.side_effect = RedisError("down")
+        client.get.side_effect = RedisError("down")
+        client.delete.side_effect = RedisError("down")
+        store = BffSessionStore(client, default_ttl_seconds=120)
+        sid, _ = store.create(access_token="a", refresh_token=None, expires_in=30)
+        # setex failed → memory fallback; get Redis fails → memory hit.
+        assert store.get(sid) is not None
+        store.delete(sid)
+
+    def test_redis_miss_checks_memory(self) -> None:
+        client = MagicMock()
+        client.get.return_value = None
+        store = BffSessionStore(client, default_ttl_seconds=120)
+        from papita_txnsapi.core import bff_session as mod
+
+        record = BffSessionRecord(
+            access_token="mem",
+            refresh_token=None,
+            csrf_token="c",
+            access_expires_at=9_999_999_999.0,
+        )
+        with mod._memory_lock:
+            mod._memory_sessions["sid-mem"] = record.to_json()
+        assert store.get("sid-mem") is not None
+
+
+def test_parse_owner_id_hint() -> None:
+    assert parse_owner_id_hint(None) is None
+    assert parse_owner_id_hint("abc") == "abc"

--- a/modules/web/README.md
+++ b/modules/web/README.md
@@ -80,9 +80,25 @@ Presentation-only client under `src/api/`. **No** `papita_txnsmodel` business lo
 | Probes           | `src/api/meta.ts`, `health.ts`                 | Unauthenticated health + `GET /api/v1/meta/client-contract`                  |
 | Query            | `queryKeys.ts`, `queries.ts`, `queryClient.ts` | `queryOptions()`; `staleTime` 60s; **no 4xx retries**                        |
 
-**Credentials policy:** always send cookies (`credentials: 'include'`) so PPT-049 BFF HttpOnly sessions work without client changes. Do **not** store JWTs in `localStorage` / JS-readable storage or attach Bearer tokens from the SPA (PDF Axios interceptor pattern is superseded).
+**Credentials policy:** always send cookies (`credentials: 'include'`) for BFF HttpOnly sessions (PPT-049 / #115). Do **not** store JWTs in `localStorage` / JS-readable storage or attach Bearer tokens from the SPA (PDF Axios interceptor pattern is superseded).
 
-**Local smoke:** `make api-up` then `make web-dev` — the App scaffold shows health status + bulk/report limits from the contract probe.
+## BFF cookie auth (PPT-049 / #115)
+
+| Piece         | Location                      | Notes                                                                                   |
+| ------------- | ----------------------------- | --------------------------------------------------------------------------------------- |
+| BFF routes    | `POST/GET /api/v1/bff/auth/*` | login, register, session, refresh, logout                                               |
+| Cookie        | `papita_sid`                  | HttpOnly, `SameSite=Lax`, `Path=/api`, `Secure` when not DEBUG                          |
+| CSRF          | `X-Papita-CSRF`               | Required on cookie-authenticated mutations; token from login/session JSON (memory only) |
+| SPA routes    | `/login`, `/register`, `/`    | `RequireAuth` redirects anonymous users to login                                        |
+| Session query | `queryKeys.auth.session()`    | Bootstrap via `GET /bff/auth/session`                                                   |
+
+**Threat model (short):**
+
+- **XSS:** HttpOnly session cookie is not readable from JS, so stolen XSS cannot exfiltrate JWTs from storage. Treat XSS as still critical (CSRF token + UI state are reachable). Prefer CSP / dependency hygiene.
+- **CSRF:** SameSite=Lax plus required `X-Papita-CSRF` on unsafe methods when the session cookie is present (Bearer token clients are exempt).
+- **Token clients:** `make auth-smoke` and direct `Authorization: Bearer` against `/api/v1/auth/*` still work; they coexist with BFF cookies.
+
+**Local smoke:** `make api-up` then `make web-dev` — open `/login`, sign in (local HS256 or Supabase), confirm `/` shows session + contract probes. Memory BFF sessions are process-local (document multi-worker limitation; Redis when `REDIS_ENABLED=true`).
 
 ## Vite `/api` proxy
 
@@ -109,4 +125,4 @@ Presentation-only client under `src/api/`. **No** `papita_txnsmodel` business lo
 
 ## Out of scope here
 
-Feature screens, BFF cookie auth, thin HTTP/Query client (#114), design system / shadcn shell, nginx image — see epic children under [#112](https://github.com/Elmorralito/save-ma-money/issues/112).
+Feature CRUD screens, design system / shadcn shell, nginx image, Redis session durability polish (#124), auth edge-case matrix (#125) — see epic children under [#112](https://github.com/Elmorralito/save-ma-money/issues/112).

--- a/modules/web/openapi/openapi.json
+++ b/modules/web/openapi/openapi.json
@@ -500,6 +500,148 @@
         "title": "BankingDetailsSchema",
         "type": "object"
       },
+      "BffLoginRequest": {
+        "additionalProperties": false,
+        "description": "JSON body for ``POST /bff/auth/login``.\n\nAttributes:\n    email: Canonical login identity (OAuth2 ``username`` field for token login).\n    password: Plain-text password (never logged or echoed).",
+        "properties": {
+          "email": {
+            "maxLength": 255,
+            "minLength": 5,
+            "pattern": "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$",
+            "title": "Email",
+            "type": "string"
+          },
+          "password": {
+            "maxLength": 128,
+            "minLength": 8,
+            "title": "Password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "BffLoginRequest",
+        "type": "object"
+      },
+      "BffRegisterRequest": {
+        "additionalProperties": false,
+        "description": "JSON body for ``POST /bff/auth/register`` (same fields as ``/auth/register``).",
+        "properties": {
+          "display_name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "email": {
+            "maxLength": 255,
+            "minLength": 5,
+            "pattern": "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$",
+            "title": "Email",
+            "type": "string"
+          },
+          "password": {
+            "maxLength": 128,
+            "minLength": 8,
+            "title": "Password",
+            "type": "string"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "maxLength": 32,
+                "minLength": 7,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "provider": {
+            "const": "email",
+            "default": "email",
+            "title": "Provider",
+            "type": "string"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 6,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Username"
+          }
+        },
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "BffRegisterRequest",
+        "type": "object"
+      },
+      "BffSessionResponse": {
+        "additionalProperties": false,
+        "description": "Public BFF session probe / login response (no JWTs).\n\nAttributes:\n    authenticated: Whether a valid session cookie was resolved.\n    user: Public profile when authenticated.\n    csrf_token: Value for ``X-Papita-CSRF`` on cookie-authenticated mutations.\n    session_backend: ``redis`` or ``memory`` (ops visibility; not a secret).",
+        "properties": {
+          "authenticated": {
+            "title": "Authenticated",
+            "type": "boolean"
+          },
+          "csrf_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Csrf Token"
+          },
+          "session_backend": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Backend"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UserResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "authenticated"
+        ],
+        "title": "BffSessionResponse",
+        "type": "object"
+      },
       "Body_login_api_v1_auth_login_post": {
         "properties": {
           "client_id": {
@@ -3599,6 +3741,154 @@
         "summary": "Complete Sso",
         "tags": [
           "Authentication"
+        ]
+      }
+    },
+    "/api/v1/bff/auth/login": {
+      "post": {
+        "description": "Authenticate and set an HttpOnly session-id cookie (JWTs stay server-side).",
+        "operationId": "bff_login_api_v1_bff_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BffLoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BffSessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Bff Login",
+        "tags": [
+          "BFF Authentication"
+        ]
+      }
+    },
+    "/api/v1/bff/auth/logout": {
+      "post": {
+        "description": "Clear BFF session cookie, revoke at IdP when possible, denylist access JWT.",
+        "operationId": "bff_logout_api_v1_bff_auth_logout_post",
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Bff Logout",
+        "tags": [
+          "BFF Authentication"
+        ]
+      }
+    },
+    "/api/v1/bff/auth/refresh": {
+      "post": {
+        "description": "Rotate tokens inside the BFF session store (cookie required).",
+        "operationId": "bff_refresh_api_v1_bff_auth_refresh_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BffSessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Bff Refresh",
+        "tags": [
+          "BFF Authentication"
+        ]
+      }
+    },
+    "/api/v1/bff/auth/register": {
+      "post": {
+        "description": "Register via the same Auth/UsersService path as ``POST /auth/register``.\n\nDoes not create a BFF session — clients should call ``POST /bff/auth/login`` next.",
+        "operationId": "bff_register_api_v1_bff_auth_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BffRegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Bff Register",
+        "tags": [
+          "BFF Authentication"
+        ]
+      }
+    },
+    "/api/v1/bff/auth/session": {
+      "get": {
+        "description": "Probe BFF session for SPA bootstrap.\n\nReturns ``authenticated: false`` (200) when no valid cookie/Bearer — avoids\ntreating anonymous bootstrap as an error. When authenticated via cookie,\nincludes ``csrf_token`` for mutation headers.",
+        "operationId": "bff_session_api_v1_bff_auth_session_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BffSessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Bff Session",
+        "tags": [
+          "BFF Authentication"
         ]
       }
     },

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@tanstack/react-query": "^5",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react-dom": "^19.2.7",
+    "react-router-dom": "^7.18.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/modules/web/src/App.css
+++ b/modules/web/src/App.css
@@ -28,3 +28,33 @@
 .app button:hover {
   background: #ececec;
 }
+
+.auth-form {
+  display: grid;
+  gap: 0.85rem;
+  margin-bottom: 1.25rem;
+}
+
+.auth-form label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.auth-form input {
+  padding: 0.5rem 0.65rem;
+  border: 1px solid #bbb;
+  border-radius: 0.25rem;
+  font: inherit;
+}
+
+.auth-error {
+  color: #8b1e1e;
+  margin: 0;
+}
+
+.auth-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}

--- a/modules/web/src/App.test.tsx
+++ b/modules/web/src/App.test.tsx
@@ -1,8 +1,20 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import App from "@/App";
+import * as authApi from "@/api/auth";
+import { RequireAuth } from "@/auth/RequireAuth";
+import { HomePage } from "@/pages/HomePage";
+import { LoginPage } from "@/pages/LoginPage";
 import { QueryTestProvider } from "@/test/queryWrapper";
+
+vi.mock("@/api/auth", () => ({
+  getBffSession: vi.fn(),
+  bffLogin: vi.fn(),
+  bffLogout: vi.fn(),
+  bffRegister: vi.fn(),
+  bffRefresh: vi.fn(),
+}));
 
 vi.mock("@/api/health", () => ({
   getHealth: vi.fn(async () => ({
@@ -58,14 +70,86 @@ vi.mock("@/api/meta", () => ({
   })),
 }));
 
-describe("App", () => {
-  it("renders the scaffold heading and contract probe section", () => {
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  vi.mocked(authApi.getBffSession).mockResolvedValue({
+    authenticated: false,
+    user: null,
+    csrf_token: null,
+    session_backend: "memory",
+  });
+});
+
+describe("auth routing", () => {
+  it("redirects unauthenticated users from / to /login", async () => {
     render(
       <QueryTestProvider>
-        <App />
+        <MemoryRouter initialEntries={["/"]}>
+          <Routes>
+            <Route path="/login" element={<LoginPage />} />
+            <Route
+              path="/"
+              element={
+                <RequireAuth>
+                  <HomePage />
+                </RequireAuth>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
       </QueryTestProvider>,
     );
-    expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { level: 1, name: "Sign in" })).toBeInTheDocument();
+    });
+  });
+
+  it("renders the login page", () => {
+    render(
+      <QueryTestProvider>
+        <MemoryRouter initialEntries={["/login"]}>
+          <LoginPage />
+        </MemoryRouter>
+      </QueryTestProvider>,
+    );
+    expect(screen.getByRole("heading", { level: 1, name: "Sign in" })).toBeInTheDocument();
+  });
+});
+
+describe("HomePage (authenticated)", () => {
+  it("renders probes when session is authenticated", async () => {
+    vi.mocked(authApi.getBffSession).mockResolvedValue({
+      authenticated: true,
+      user: {
+        id: "00000000-0000-0000-0000-000000000001",
+        username: "tester",
+        email: "tester@example.com",
+        display_name: null,
+        phone: null,
+        provider: "email",
+        auth_provider: "local",
+        created_at: "2026-07-29T00:00:00Z",
+      },
+      csrf_token: "csrf-test",
+      session_backend: "memory",
+    });
+
+    render(
+      <QueryTestProvider>
+        <MemoryRouter>
+          <HomePage />
+        </MemoryRouter>
+      </QueryTestProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/tester@example.com/)).toBeInTheDocument();
+    });
     expect(screen.getByRole("region", { name: "API probe status" })).toBeInTheDocument();
   });
 });

--- a/modules/web/src/App.tsx
+++ b/modules/web/src/App.tsx
@@ -1,55 +1,31 @@
-import { useQuery } from "@tanstack/react-query";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
-import {
-  bulkMaxTransactions,
-  clientContractQueryOptions,
-  healthQueryOptions,
-  reportWindowMaxDays,
-} from "@/api";
+import { AuthRedirectBridge } from "@/auth/AuthRedirectBridge";
+import { RequireAuth } from "@/auth/RequireAuth";
+import { HomePage } from "@/pages/HomePage";
+import { LoginPage } from "@/pages/LoginPage";
+import { RegisterPage } from "@/pages/RegisterPage";
 
 import "./App.css";
 
 function App() {
-  const title = import.meta.env.VITE_APP_TITLE ?? "Papita";
-  const healthQuery = useQuery(healthQueryOptions());
-  const contractQuery = useQuery(clientContractQueryOptions());
-
-  const bulkMax = bulkMaxTransactions(contractQuery.data);
-  const windowMax = reportWindowMaxDays(contractQuery.data);
-
   return (
-    <main className="app">
-      <h1>{title}</h1>
-      <p>
-        Thin API client wiring (PPT-048). Domain features land in later epic children; auth cookies
-        land in PPT-049.
-      </p>
-      <section aria-label="API probe status">
-        <h2>Contract probes</h2>
-        <ul>
-          <li>
-            Health:{" "}
-            {healthQuery.isPending
-              ? "loading…"
-              : healthQuery.isError
-                ? "unavailable (start API with make api-up)"
-                : (healthQuery.data?.status ?? "unknown")}
-          </li>
-          <li>
-            Bulk max:{" "}
-            {contractQuery.isPending ? "loading…" : contractQuery.isError ? "—" : (bulkMax ?? "—")}
-          </li>
-          <li>
-            Report window max days:{" "}
-            {contractQuery.isPending
-              ? "loading…"
-              : contractQuery.isError
-                ? "—"
-                : (windowMax ?? "—")}
-          </li>
-        </ul>
-      </section>
-    </main>
+    <BrowserRouter>
+      <AuthRedirectBridge />
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route
+          path="/"
+          element={
+            <RequireAuth>
+              <HomePage />
+            </RequireAuth>
+          }
+        />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/modules/web/src/api/auth.ts
+++ b/modules/web/src/api/auth.ts
@@ -1,0 +1,84 @@
+import { apiFetch } from "@/api/http";
+import { clearCsrfToken, setCsrfToken } from "@/api/csrf";
+
+export type BffUser = {
+  id: string;
+  username: string;
+  email: string;
+  display_name: string | null;
+  phone: string | null;
+  provider: string;
+  auth_provider: string;
+  created_at: string;
+};
+
+export type BffSession = {
+  authenticated: boolean;
+  user: BffUser | null;
+  csrf_token: string | null;
+  session_backend: string | null;
+};
+
+function rememberCsrf(session: BffSession): BffSession {
+  if (session.authenticated && session.csrf_token) {
+    setCsrfToken(session.csrf_token);
+  }
+  if (!session.authenticated) {
+    clearCsrfToken();
+  }
+  return session;
+}
+
+/** GET /api/v1/bff/auth/session — SPA bootstrap (200 even when anonymous). */
+export async function getBffSession(signal?: AbortSignal): Promise<BffSession> {
+  const { data } = await apiFetch<BffSession>("/api/v1/bff/auth/session", {
+    signal,
+    skipAuthRefresh: true,
+  });
+  return rememberCsrf(data);
+}
+
+/** POST /api/v1/bff/auth/login — sets HttpOnly session cookie; no JWT in body. */
+export async function bffLogin(input: { email: string; password: string }): Promise<BffSession> {
+  const { data } = await apiFetch<BffSession>("/api/v1/bff/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+    skipAuthRefresh: true,
+  });
+  return rememberCsrf(data);
+}
+
+/** POST /api/v1/bff/auth/register — creates user; does not open a session. */
+export async function bffRegister(input: {
+  email: string;
+  password: string;
+  display_name?: string;
+}): Promise<BffUser> {
+  const { data } = await apiFetch<BffUser>("/api/v1/bff/auth/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+    skipAuthRefresh: true,
+  });
+  return data;
+}
+
+/** POST /api/v1/bff/auth/refresh — rotate tokens server-side. */
+export async function bffRefresh(signal?: AbortSignal): Promise<BffSession> {
+  const { data } = await apiFetch<BffSession>("/api/v1/bff/auth/refresh", {
+    method: "POST",
+    signal,
+    skipAuthRefresh: true,
+  });
+  return rememberCsrf(data);
+}
+
+/** POST /api/v1/bff/auth/logout — clears cookie + server session. */
+export async function bffLogout(): Promise<void> {
+  await apiFetch<undefined>("/api/v1/bff/auth/logout", {
+    method: "POST",
+    skipAuthRefresh: true,
+  });
+  clearCsrfToken();
+}

--- a/modules/web/src/api/csrf.ts
+++ b/modules/web/src/api/csrf.ts
@@ -1,0 +1,20 @@
+/**
+ * In-memory CSRF token for BFF cookie-authenticated mutations (PPT-049).
+ *
+ * Not persisted to localStorage — JWTs never live in JS storage; the CSRF token
+ * is only a mutation header companion to the HttpOnly session cookie.
+ */
+
+let csrfToken: string | null = null;
+
+export function getCsrfToken(): string | null {
+  return csrfToken;
+}
+
+export function setCsrfToken(token: string | null): void {
+  csrfToken = token;
+}
+
+export function clearCsrfToken(): void {
+  csrfToken = null;
+}

--- a/modules/web/src/api/http.ts
+++ b/modules/web/src/api/http.ts
@@ -1,5 +1,6 @@
 import { buildApiUrl } from "@/api/config";
-import { papitaApiErrorFromResponse } from "@/api/errors";
+import { getCsrfToken, setCsrfToken } from "@/api/csrf";
+import { isPapitaApiError, papitaApiErrorFromResponse } from "@/api/errors";
 import { parseDiscoveryHeaders, type DiscoveryHeaders } from "@/api/headers";
 
 export type ApiFetchOptions = {
@@ -9,6 +10,8 @@ export type ApiFetchOptions = {
   body?: BodyInit | null;
   /** Override default JSON Accept header. */
   accept?: string;
+  /** Skip one-shot BFF refresh + retry on 401 (auth endpoints). */
+  skipAuthRefresh?: boolean;
 };
 
 export type ApiFetchResult<T> = {
@@ -17,32 +20,100 @@ export type ApiFetchResult<T> = {
   discovery: DiscoveryHeaders;
 };
 
+const CSRF_HEADER = "X-Papita-CSRF";
+const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+type AuthRedirectHandler = () => void;
+
+let onUnauthorized: AuthRedirectHandler | null = null;
+let refreshInFlight: Promise<boolean> | null = null;
+
+/** Register SPA navigation when BFF refresh cannot restore the session. */
+export function setUnauthorizedHandler(handler: AuthRedirectHandler | null): void {
+  onUnauthorized = handler;
+}
+
+async function tryBffRefresh(): Promise<boolean> {
+  if (refreshInFlight) {
+    return refreshInFlight;
+  }
+  refreshInFlight = (async () => {
+    try {
+      const response = await fetch(buildApiUrl("/api/v1/bff/auth/refresh"), {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          Accept: "application/json",
+          ...(getCsrfToken() ? { [CSRF_HEADER]: getCsrfToken() as string } : {}),
+        },
+      });
+      if (!response.ok) {
+        return false;
+      }
+      const body = (await response.json()) as { csrf_token?: string | null };
+      if (typeof body.csrf_token === "string" && body.csrf_token.length > 0) {
+        setCsrfToken(body.csrf_token);
+      }
+      return true;
+    } catch {
+      return false;
+    } finally {
+      refreshInFlight = null;
+    }
+  })();
+  return refreshInFlight;
+}
+
 /**
  * Thin Fetch wrapper for papita_txnsapi / BFF.
  *
  * - Uses same-origin `/api/...` by default (Vite proxy / nginx).
- * - Always sends `credentials: 'include'` for future BFF cookie sessions (#115).
- * - Does **not** attach `Authorization` — JWTs stay server-side after BFF lands.
+ * - Always sends `credentials: 'include'` for BFF cookie sessions (#115).
+ * - Attaches `X-Papita-CSRF` on unsafe methods when a CSRF token is known.
+ * - Does **not** attach `Authorization` — JWTs stay server-side.
  */
 export async function apiFetch<T>(
   path: string,
   options: ApiFetchOptions = {},
 ): Promise<ApiFetchResult<T>> {
+  const method = (options.method ?? "GET").toUpperCase();
   const headers = new Headers(options.headers);
   if (!headers.has("Accept")) {
     headers.set("Accept", options.accept ?? "application/json");
   }
+  if (UNSAFE_METHODS.has(method) && !headers.has(CSRF_HEADER)) {
+    const csrf = getCsrfToken();
+    if (csrf) {
+      headers.set(CSRF_HEADER, csrf);
+    }
+  }
 
-  const response = await fetch(buildApiUrl(path), {
-    method: options.method ?? "GET",
-    signal: options.signal,
-    credentials: "include",
-    headers,
-    body: options.body,
-  });
+  const execute = async (): Promise<Response> =>
+    fetch(buildApiUrl(path), {
+      method,
+      signal: options.signal,
+      credentials: "include",
+      headers,
+      body: options.body,
+    });
+
+  let response = await execute();
+
+  if (response.status === 401 && !options.skipAuthRefresh) {
+    const refreshed = await tryBffRefresh();
+    if (refreshed) {
+      response = await execute();
+    } else {
+      onUnauthorized?.();
+    }
+  }
 
   if (!response.ok) {
-    throw await papitaApiErrorFromResponse(response);
+    const error = await papitaApiErrorFromResponse(response);
+    if (error.status === 401 && !options.skipAuthRefresh) {
+      onUnauthorized?.();
+    }
+    throw error;
   }
 
   const discovery = parseDiscoveryHeaders(response.headers);
@@ -59,3 +130,6 @@ export async function apiFetch<T>(
   const text = (await response.text()) as T;
   return { data: text, response, discovery };
 }
+
+/** Re-export for callers that branch on auth failures. */
+export { isPapitaApiError };

--- a/modules/web/src/api/index.ts
+++ b/modules/web/src/api/index.ts
@@ -12,7 +12,22 @@ export {
   parseDiscoveryHeaders,
   type DiscoveryHeaders,
 } from "@/api/headers";
-export { apiFetch, type ApiFetchOptions, type ApiFetchResult } from "@/api/http";
+export {
+  bffLogin,
+  bffLogout,
+  bffRefresh,
+  bffRegister,
+  getBffSession,
+  type BffSession,
+  type BffUser,
+} from "@/api/auth";
+export { clearCsrfToken, getCsrfToken, setCsrfToken } from "@/api/csrf";
+export {
+  apiFetch,
+  setUnauthorizedHandler,
+  type ApiFetchOptions,
+  type ApiFetchResult,
+} from "@/api/http";
 export { getHealth, getHealthLive } from "@/api/health";
 export { getClientContract } from "@/api/meta";
 export {

--- a/modules/web/src/api/queryKeys.test.ts
+++ b/modules/web/src/api/queryKeys.test.ts
@@ -5,14 +5,16 @@ import { queryKeys } from "@/api/queryKeys";
 describe("queryKeys", () => {
   it("keeps hierarchical prefixes stable", () => {
     expect(queryKeys.all).toEqual(["papita"]);
+    expect(queryKeys.auth.all).toEqual(["papita", "auth"]);
     expect(queryKeys.meta.all).toEqual(["papita", "meta"]);
     expect(queryKeys.health.all).toEqual(["papita", "health"]);
   });
 
-  it("builds distinct leaf keys for meta and health probes", () => {
+  it("builds distinct leaf keys for meta, health, and auth probes", () => {
     expect(queryKeys.meta.clientContract()).toEqual(["papita", "meta", "client-contract"]);
     expect(queryKeys.health.root()).toEqual(["papita", "health", "root"]);
     expect(queryKeys.health.live()).toEqual(["papita", "health", "live"]);
+    expect(queryKeys.auth.session()).toEqual(["papita", "auth", "session"]);
     expect(queryKeys.meta.clientContract()).not.toEqual(queryKeys.health.root());
   });
 });

--- a/modules/web/src/api/queryKeys.ts
+++ b/modules/web/src/api/queryKeys.ts
@@ -6,6 +6,10 @@
  */
 export const queryKeys = {
   all: ["papita"] as const,
+  auth: {
+    all: ["papita", "auth"] as const,
+    session: () => ["papita", "auth", "session"] as const,
+  },
   meta: {
     all: ["papita", "meta"] as const,
     clientContract: () => ["papita", "meta", "client-contract"] as const,

--- a/modules/web/src/auth/AuthRedirectBridge.tsx
+++ b/modules/web/src/auth/AuthRedirectBridge.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { setUnauthorizedHandler } from "@/api/http";
+
+/** Wires apiFetch 401 / failed BFF refresh to a login redirect. */
+export function AuthRedirectBridge(): null {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setUnauthorizedHandler(() => {
+      void navigate("/login", { replace: true });
+    });
+    return () => {
+      setUnauthorizedHandler(null);
+    };
+  }, [navigate]);
+
+  return null;
+}

--- a/modules/web/src/auth/RequireAuth.tsx
+++ b/modules/web/src/auth/RequireAuth.tsx
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import type { ReactElement, ReactNode } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+
+import { bffSessionQueryOptions } from "@/auth/sessionQueries";
+
+/** Route guard — redirects anonymous users to login with return location. */
+export function RequireAuth({ children }: { children: ReactNode }): ReactElement {
+  const location = useLocation();
+  const sessionQuery = useQuery(bffSessionQueryOptions());
+
+  if (sessionQuery.isPending) {
+    return (
+      <main className="app">
+        <p>Checking session…</p>
+      </main>
+    );
+  }
+
+  if (!sessionQuery.data?.authenticated) {
+    return <Navigate to="/login" replace state={{ from: location.pathname }} />;
+  }
+
+  return <>{children}</>;
+}

--- a/modules/web/src/auth/sessionQueries.ts
+++ b/modules/web/src/auth/sessionQueries.ts
@@ -1,0 +1,14 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { getBffSession } from "@/api/auth";
+import { queryKeys } from "@/api/queryKeys";
+
+/** Shared BFF session bootstrap query (cookie credentials). */
+export function bffSessionQueryOptions() {
+  return queryOptions({
+    queryKey: queryKeys.auth.session(),
+    queryFn: ({ signal }) => getBffSession(signal),
+    staleTime: 30_000,
+    retry: false,
+  });
+}

--- a/modules/web/src/pages/HomePage.tsx
+++ b/modules/web/src/pages/HomePage.tsx
@@ -1,0 +1,100 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useNavigate } from "react-router-dom";
+
+import {
+  bulkMaxTransactions,
+  clientContractQueryOptions,
+  healthQueryOptions,
+  reportWindowMaxDays,
+} from "@/api";
+import { bffLogout } from "@/api/auth";
+import { queryKeys } from "@/api/queryKeys";
+import { bffSessionQueryOptions } from "@/auth/sessionQueries";
+
+export function HomePage() {
+  const title = import.meta.env.VITE_APP_TITLE ?? "Papita";
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const sessionQuery = useQuery(bffSessionQueryOptions());
+  const healthQuery = useQuery(healthQueryOptions());
+  const contractQuery = useQuery(clientContractQueryOptions());
+
+  const logoutMutation = useMutation({
+    mutationFn: bffLogout,
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.auth.all });
+      await navigate("/login", { replace: true });
+    },
+  });
+
+  const bulkMax = bulkMaxTransactions(contractQuery.data);
+  const windowMax = reportWindowMaxDays(contractQuery.data);
+  const user = sessionQuery.data?.user;
+
+  return (
+    <main className="app">
+      <h1>{title}</h1>
+      <p>
+        BFF cookie session (PPT-049). Domain features land in later epic children.
+        {user ? (
+          <>
+            {" "}
+            Signed in as <strong>{user.email}</strong>.
+          </>
+        ) : null}
+      </p>
+      <p className="auth-actions">
+        {user ? (
+          <button
+            type="button"
+            onClick={() => {
+              logoutMutation.mutate();
+            }}
+            disabled={logoutMutation.isPending}
+          >
+            {logoutMutation.isPending ? "Signing out…" : "Sign out"}
+          </button>
+        ) : (
+          <>
+            <Link to="/login">Sign in</Link>
+            {" · "}
+            <Link to="/register">Register</Link>
+          </>
+        )}
+      </p>
+      <section aria-label="API probe status">
+        <h2>Contract probes</h2>
+        <ul>
+          <li>
+            Health:{" "}
+            {healthQuery.isPending
+              ? "loading…"
+              : healthQuery.isError
+                ? "unavailable (start API with make api-up)"
+                : (healthQuery.data?.status ?? "unknown")}
+          </li>
+          <li>
+            Session:{" "}
+            {sessionQuery.isPending
+              ? "loading…"
+              : sessionQuery.data?.authenticated
+                ? "authenticated"
+                : "anonymous"}
+          </li>
+          <li>
+            Bulk max:{" "}
+            {contractQuery.isPending ? "loading…" : contractQuery.isError ? "—" : (bulkMax ?? "—")}
+          </li>
+          <li>
+            Report window max days:{" "}
+            {contractQuery.isPending
+              ? "loading…"
+              : contractQuery.isError
+                ? "—"
+                : (windowMax ?? "—")}
+          </li>
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/modules/web/src/pages/LoginPage.tsx
+++ b/modules/web/src/pages/LoginPage.tsx
@@ -1,0 +1,93 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState, type FormEvent } from "react";
+import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
+
+import { bffLogin } from "@/api/auth";
+import { isPapitaApiError } from "@/api/errors";
+import { queryKeys } from "@/api/queryKeys";
+import { bffSessionQueryOptions } from "@/auth/sessionQueries";
+
+export function LoginPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const queryClient = useQueryClient();
+  const sessionQuery = useQuery(bffSessionQueryOptions());
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const loginMutation = useMutation({
+    mutationFn: bffLogin,
+    onSuccess: async (session) => {
+      queryClient.setQueryData(queryKeys.auth.session(), session);
+      const from =
+        typeof location.state === "object" &&
+        location.state !== null &&
+        "from" in location.state &&
+        typeof (location.state as { from?: unknown }).from === "string"
+          ? (location.state as { from: string }).from
+          : "/";
+      await navigate(from, { replace: true });
+    },
+    onError: (err: unknown) => {
+      setError(isPapitaApiError(err) ? err.message : "Login failed");
+    },
+  });
+
+  if (sessionQuery.data?.authenticated) {
+    return <Navigate to="/" replace />;
+  }
+
+  function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    loginMutation.mutate({ email: email.trim(), password });
+  }
+
+  return (
+    <main className="app">
+      <h1>Sign in</h1>
+      <p>Session cookies only — JWTs never touch the browser.</p>
+      <form className="auth-form" onSubmit={onSubmit}>
+        <label>
+          Email
+          <input
+            type="email"
+            name="email"
+            autoComplete="username"
+            required
+            value={email}
+            onChange={(event) => {
+              setEmail(event.target.value);
+            }}
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            name="password"
+            autoComplete="current-password"
+            required
+            minLength={8}
+            value={password}
+            onChange={(event) => {
+              setPassword(event.target.value);
+            }}
+          />
+        </label>
+        {error ? (
+          <p role="alert" className="auth-error">
+            {error}
+          </p>
+        ) : null}
+        <button type="submit" disabled={loginMutation.isPending}>
+          {loginMutation.isPending ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+      <p>
+        No account? <Link to="/register">Register</Link>
+      </p>
+    </main>
+  );
+}

--- a/modules/web/src/pages/RegisterPage.tsx
+++ b/modules/web/src/pages/RegisterPage.tsx
@@ -1,0 +1,93 @@
+import { useMutation } from "@tanstack/react-query";
+import { useState, type FormEvent } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+import { bffRegister } from "@/api/auth";
+import { isPapitaApiError } from "@/api/errors";
+
+export function RegisterPage() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const registerMutation = useMutation({
+    mutationFn: bffRegister,
+    onSuccess: async () => {
+      await navigate("/login", { replace: true, state: { registered: true } });
+    },
+    onError: (err: unknown) => {
+      setError(isPapitaApiError(err) ? err.message : "Registration failed");
+    },
+  });
+
+  function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    registerMutation.mutate({
+      email: email.trim(),
+      password,
+      display_name: displayName.trim() || undefined,
+    });
+  }
+
+  return (
+    <main className="app">
+      <h1>Create account</h1>
+      <p>Uses the API register path; sign in afterward to open a BFF session.</p>
+      <form className="auth-form" onSubmit={onSubmit}>
+        <label>
+          Email
+          <input
+            type="email"
+            name="email"
+            autoComplete="username"
+            required
+            value={email}
+            onChange={(event) => {
+              setEmail(event.target.value);
+            }}
+          />
+        </label>
+        <label>
+          Display name
+          <input
+            type="text"
+            name="display_name"
+            autoComplete="name"
+            value={displayName}
+            onChange={(event) => {
+              setDisplayName(event.target.value);
+            }}
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            name="password"
+            autoComplete="new-password"
+            required
+            minLength={8}
+            value={password}
+            onChange={(event) => {
+              setPassword(event.target.value);
+            }}
+          />
+        </label>
+        {error ? (
+          <p role="alert" className="auth-error">
+            {error}
+          </p>
+        ) : null}
+        <button type="submit" disabled={registerMutation.isPending}>
+          {registerMutation.isPending ? "Creating…" : "Register"}
+        </button>
+      </form>
+      <p>
+        Already registered? <Link to="/login">Sign in</Link>
+      </p>
+    </main>
+  );
+}

--- a/modules/web/src/types/api.d.ts
+++ b/modules/web/src/types/api.d.ts
@@ -487,6 +487,112 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/bff/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Bff Login
+         * @description Authenticate and set an HttpOnly session-id cookie (JWTs stay server-side).
+         */
+        post: operations["bff_login_api_v1_bff_auth_login_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/bff/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Bff Logout
+         * @description Clear BFF session cookie, revoke at IdP when possible, denylist access JWT.
+         */
+        post: operations["bff_logout_api_v1_bff_auth_logout_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/bff/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Bff Refresh
+         * @description Rotate tokens inside the BFF session store (cookie required).
+         */
+        post: operations["bff_refresh_api_v1_bff_auth_refresh_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/bff/auth/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Bff Register
+         * @description Register via the same Auth/UsersService path as ``POST /auth/register``.
+         *
+         *     Does not create a BFF session — clients should call ``POST /bff/auth/login`` next.
+         */
+        post: operations["bff_register_api_v1_bff_auth_register_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/bff/auth/session": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Bff Session
+         * @description Probe BFF session for SPA bootstrap.
+         *
+         *     Returns ``authenticated: false`` (200) when no valid cookie/Bearer — avoids
+         *     treating anonymous bootstrap as an error. When authenticated via cookie,
+         *     includes ``csrf_token`` for mutation headers.
+         */
+        get: operations["bff_session_api_v1_bff_auth_session_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/budgets": {
         parameters: {
             query?: never;
@@ -1701,6 +1807,61 @@ export interface components {
             account_number?: string | null;
             /** Entity */
             entity: string;
+        };
+        /**
+         * BffLoginRequest
+         * @description JSON body for ``POST /bff/auth/login``.
+         *
+         *     Attributes:
+         *         email: Canonical login identity (OAuth2 ``username`` field for token login).
+         *         password: Plain-text password (never logged or echoed).
+         */
+        BffLoginRequest: {
+            /** Email */
+            email: string;
+            /** Password */
+            password: string;
+        };
+        /**
+         * BffRegisterRequest
+         * @description JSON body for ``POST /bff/auth/register`` (same fields as ``/auth/register``).
+         */
+        BffRegisterRequest: {
+            /** Display Name */
+            display_name?: string | null;
+            /** Email */
+            email: string;
+            /** Password */
+            password: string;
+            /** Phone */
+            phone?: string | null;
+            /**
+             * Provider
+             * @default email
+             * @constant
+             */
+            provider: "email";
+            /** Username */
+            username?: string | null;
+        };
+        /**
+         * BffSessionResponse
+         * @description Public BFF session probe / login response (no JWTs).
+         *
+         *     Attributes:
+         *         authenticated: Whether a valid session cookie was resolved.
+         *         user: Public profile when authenticated.
+         *         csrf_token: Value for ``X-Papita-CSRF`` on cookie-authenticated mutations.
+         *         session_backend: ``redis`` or ``memory`` (ops visibility; not a secret).
+         */
+        BffSessionResponse: {
+            /** Authenticated */
+            authenticated: boolean;
+            /** Csrf Token */
+            csrf_token?: string | null;
+            /** Session Backend */
+            session_backend?: string | null;
+            user?: components["schemas"]["UserResponse"] | null;
         };
         /** Body_login_api_v1_auth_login_post */
         Body_login_api_v1_auth_login_post: {
@@ -3355,6 +3516,130 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    bff_login_api_v1_bff_auth_login_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BffLoginRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BffSessionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    bff_logout_api_v1_bff_auth_logout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    bff_refresh_api_v1_bff_auth_refresh_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BffSessionResponse"];
+                };
+            };
+        };
+    };
+    bff_register_api_v1_bff_auth_register_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BffRegisterRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    bff_session_api_v1_bff_auth_session_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BffSessionResponse"];
                 };
             };
         };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.8(react@19.2.8)
+      react-router-dom:
+        specifier: ^7.18.2
+        version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -683,6 +686,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1159,6 +1166,23 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-router-dom@7.18.2:
+    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.18.2:
+    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
@@ -1191,6 +1215,9 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2058,6 +2085,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2489,6 +2518,20 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-router-dom@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-router: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+
+  react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.8
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.8(react@19.2.8)
+
   react@19.2.8: {}
 
   redent@3.0.0:
@@ -2528,6 +2571,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.5: {}
+
+  set-cookie-parser@2.7.2: {}
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
**Branch:** `feat/PPT-049` · **Base:** `main` · **1 commit** · **35 files**

**Suggested title:** `feat/PPT-049: [web] BFF HttpOnly cookie session with Supabase IdP`

## Summary

Delivers **PPT-049 / #115**: browser auth terminates at a thin BFF inside `papita_txnsapi`. The SPA keeps only an HttpOnly session-id cookie; access/refresh JWTs stay server-side and are attached in-process for existing `get_current_owner` routes. Login/register/session/logout UX lands under `modules/web` with CSRF on cookie-authenticated mutations. Local Compose also injects `DEBUG` / `ALLOWED_HOSTS` so the API no longer crash-loops when TrustedHost validation runs without those vars.

## Out of scope / Highlights

**Out of scope**

- Email confirmation vertical ([#139](https://github.com/Elmorralito/save-ma-money/issues/139) PPT-068)
- Redis session durability polish ([#124](https://github.com/Elmorralito/save-ma-money/issues/124) PPT-059)
- Auth edge-case matrix ([#125](https://github.com/Elmorralito/save-ma-money/issues/125) PPT-060)
- Session user chip ([#127](https://github.com/Elmorralito/save-ma-money/issues/127) PPT-062)
- Feature CRUD screens (#117+)
- TypeScript ports of `UsersService` / model business rules ([#140](https://github.com/Elmorralito/save-ma-money/issues/140) PPT-069)

**Highlights**

- Cookie `papita_sid` + separate `BffSessionStore` (not JWT denylist)
- CSRF via `X-Papita-CSRF`; Bearer / `make auth-smoke` coexistence
- SPA route guards + 401 → BFF refresh → login redirect

## Changes

**API / BFF**

- New `/api/v1/bff/auth/*` (login, register, session, refresh, logout)
- `BffSessionStore` (Redis when `REDIS_ENABLED`, else memory)
- `get_current_owner` accepts Bearer **or** BFF cookie (optional silent Supabase refresh)
- `BffCsrfMiddleware` for cookie-session mutations
- `BFF_SESSION_MAX_AGE_SECONDS` setting; CORS allowlist includes `X-Papita-CSRF`

**Web**

- `react-router-dom`: `/login`, `/register`, guarded `/`
- BFF client helpers, in-memory CSRF, `credentials: 'include'`
- Session `queryOptions` + RequireAuth + unauthorized redirect bridge
- Threat-model note in `modules/web/README.md`

**Ops**

- Compose injects `DEBUG`, `DOCS_ENABLED`, `ALLOWED_HOSTS`, `AUTH_COOKIE_SECURE` for local API boot

**Contract / docs**

- Regenerated OpenAPI artifact + `api.d.ts`; API README catalog row; AGENTS note

**Tests**

- API BFF cookie/CSRF/Bearer coexistence tests; web auth routing tests

## File changes

<details>
<summary>File changes (35 files)</summary>

```
 .cursor/AGENTS.md                                  |   2 +
 docker/docker-compose.yml                          |   8 +-
 docs/interrogate_badge.svg                         |   8 +-
 modules/api/README.md                              |   1 +
 modules/api/src/papita_txnsapi/config/settings.py  |   2 +
 modules/api/src/papita_txnsapi/core/bff_session.py | 236 +
 modules/api/src/papita_txnsapi/dependencies/auth.py|  86 +-
 modules/api/src/papita_txnsapi/dependencies/bff_session.py | 29 +
 modules/api/src/papita_txnsapi/main.py             |   4 +
 modules/api/src/papita_txnsapi/middleware/bff_csrf.py | 97 +
 modules/api/src/papita_txnsapi/routers/v1/__init__.py | 3 +
 modules/api/src/papita_txnsapi/routers/v1/bff_auth.py | 454 +
 modules/api/src/papita_txnsapi/schemas/bff_auth.py |  48 +
 modules/api/tests/conftest.py                      |   3 +
 modules/api/tests/test_bff_auth.py                 | 126 +
 modules/web/README.md                              |  22 +-
 modules/web/openapi/openapi.json                   | 290 +
 modules/web/package.json                           |   3 +-
 modules/web/src/App.css                            |  30 +
 modules/web/src/App.test.tsx                       |  98 +-
 modules/web/src/App.tsx                            |  68 +-
 modules/web/src/api/auth.ts                        |  84 +
 modules/web/src/api/csrf.ts                        |  20 +
 modules/web/src/api/http.ts                        |  96 +-
 modules/web/src/api/index.ts                       |  17 +-
 modules/web/src/api/queryKeys.test.ts              |   4 +-
 modules/web/src/api/queryKeys.ts                   |   4 +
 modules/web/src/auth/*                             | new
 modules/web/src/pages/*                            | new
 modules/web/src/types/api.d.ts                     | 285 +
 pnpm-lock.yaml                                     |  45 +
```

</details>

## Commits

- `7c9397b` feat/PPT-049: [web] Add BFF HttpOnly cookie session with Supabase IdP

## Checks, tests, and validation already done

- `poetry run pytest modules/api/tests/test_bff_auth.py` (+ related auth tests) — pass (earlier in session)
- `pnpm --filter @papita/web test` / `lint` / `build` — pass (earlier in session)
- Pre-commit on commit (isort, black, flake8, pylint, mypy, interrogate, prettier, etc.) — pass
- CI on this PR — not observed yet

## QA / test plan

- [ ] `make api-up` then `make web-dev`; open `/login`, register/login with Supabase (or local if configured)
- [ ] Confirm DevTools: HttpOnly `papita_sid`; no access/refresh JWT in `localStorage` / JS storage
- [ ] Mutation without `X-Papita-CSRF` → 403; with CSRF from session → logout succeeds
- [ ] `GET /api/v1/auth/me` with Bearer still works (`make auth-smoke` coexistence)
- [ ] Web CI + API CI green on the PR

## Risks

> [!CAUTION]
>
> ### Risks
>
> - Memory BFF sessions are process-local (multi-worker needs Redis — follow-up #124)
> - Compose now defaults `DEBUG=true` for local B0 when unset; staging/prod must set `DEBUG`/`ALLOWED_HOSTS` explicitly via env file
> - OpenAPI artifact regenerated — API↔web contract CI must stay green

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - Supabase confirm-email may block usable sessions until #139; pending-confirm UX is not in this PR
> - Design-system shell (#116) may still stub auth in parallel; this PR ships functional BFF pages

## References

- Closes [#115](https://github.com/Elmorralito/save-ma-money/issues/115) (PPT-049)
- Parent epic: [#112](https://github.com/Elmorralito/save-ma-money/issues/112) (PPT-046)
- Related: [#139](https://github.com/Elmorralito/save-ma-money/issues/139), [#124](https://github.com/Elmorralito/save-ma-money/issues/124), [#125](https://github.com/Elmorralito/save-ma-money/issues/125)

Made with [Cursor](https://cursor.com)