### PR TITLE
feat/PPT-055: [web] Forms validation and loading UX standards

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -78,7 +78,7 @@ Domain entities in the model layer include **accounts**, **transactions**, **cat
 
 **Web BFF cookie auth (PPT-049):** API `/api/v1/bff/auth/*` + `BffSessionStore` (Redis or memory; **not** JWT denylist). Cookie `papita_sid` (HttpOnly); CSRF `X-Papita-CSRF`. SPA login/register + `RequireAuth`; `get_current_owner` accepts Bearer **or** BFF cookie. `make auth-smoke` (Bearer) still valid alongside BFF.
 
-**Web accounts/categories UI (PPT-052 / #117):** presentation-only screens under `modules/web/src/pages/{Accounts,AccountDetail,Categories}Page.tsx` + `components/{accounts,categories}/`. Controlled forms (Zod/RHF → #120). Global category write 404 → read-only UX.
+**Web accounts/categories UI (PPT-052 / #117):** presentation-only screens under `modules/web/src/pages/{Accounts,AccountDetail,Categories}Page.tsx` + `components/{accounts,categories}/`. Forms use Zod + RHF (`src/forms/`, PPT-055 / #120). Global category write 404 → read-only UX.
 
 **Local Supabase email confirm:** `AUTH_AUTO_CONFIRM_EMAIL` (default on for `PAPITA_ENV=local`) + service role → Admin register without SMTP; login auto-confirm only when Auth email is unconfirmed (see `modules/api/README.md` Authentication).
 

--- a/.strata/issues/20260803-04-ppt055-forms-ux-standards.md
+++ b/.strata/issues/20260803-04-ppt055-forms-ux-standards.md
@@ -1,0 +1,29 @@
+---
+id: 20260803-04
+type: feature
+status: in-progress
+priority: medium
+area: modules/web
+created: 2026-08-03
+tags: [PPT-055, web, forms]
+---
+
+# PPT-055 / #120 — Forms validation and loading UX standards
+
+## Intent
+
+Ship Zod + RHF kit under `modules/web/src/forms/`, document UX standards, migrate accounts + categories forms. Locked decisions: custom `FormField` (not shadcn Form); toast vs inline by error class; no reports/dashboard files in this change.
+
+## Progress
+
+- [x] Install `zod`, `react-hook-form`, `@hookform/resolvers`
+- [x] `mapServerErrors` / `applyMutationError` / `FormField` / schemas
+- [x] `formatDate` / `formatDateTime` via Intl
+- [x] Migrate `AccountFormDialog` + `CategoryFormDialog`
+- [x] README + Vitest for mapper/schemas/dates
+- [ ] PR + close GitHub #120
+
+## Notes
+
+Does not touch `components/reports/**` or dashboard (PPT-054 / #119).
+Strata id `20260803-04` (avoids clash with archived PPT-060 `20260803-03`).

--- a/.strata/issues/ACTIVE.md
+++ b/.strata/issues/ACTIVE.md
@@ -7,5 +7,6 @@ Everything `status: in-progress`. Loaded at `/strata:load`.
 
 | Id          | Type    | Sev  | Area        | What                                                                                         |
 | ----------- | ------- | ---- | ----------- | -------------------------------------------------------------------------------------------- |
+| 20260803-04 | feature | med  | modules/web | PPT-055 [#120] forms + UX standards (kit + accounts/categories migrated; PR pending)         |
 | 20260803-02 | feature | high | modules/web | PPT-054 [#119] dashboard + reports UI (spending slice done; CF/trends/export/dashboard open) |
 | 20260713-01 | feature | high | modules/api | PPT-038 [#48] tenant-scoped `/reports/*` on feat/PPT-038                                     |

--- a/.strata/memory/MEMORY.md
+++ b/.strata/memory/MEMORY.md
@@ -4,10 +4,10 @@ Pure hot index: live pointers + the generated rules-by-trigger table. Keep ≤80
 
 ## Live pointers
 
-- [Project state](project_state.md) — PPT-053 transactions/movements UI done; PPT-052 PR path still open.
-- [Active issues](../issues/ACTIVE.md) — PPT-052 web UI; legacy PPT-038 reports row may linger.
-- [Open backlog](../issues/OPEN.md) — PPT-040 Codecov; PPT-043 Redis; later PPT-046 children (054+).
-- [Archived](../issues/archive/ARCHIVE.md) — PPT-053 [#118] `20260803-01`.
+- [Project state](project_state.md) — PPT-055 forms kit in progress; PPT-054 reports still open.
+- [Active issues](../issues/ACTIVE.md) — PPT-055 [#120] `20260803-04`; PPT-054 [#119] `20260803-02`.
+- [Open backlog](../issues/OPEN.md) — PPT-040 Codecov; PPT-043 Redis; later PPT-046 children.
+- [Archived](../issues/archive/ARCHIVE.md) — PPT-060 [#125] `20260803-03`; PPT-053 [#118] `20260803-01`.
 
 ## Rules by trigger
 
@@ -21,3 +21,4 @@ Pure hot index: live pointers + the generated rules-by-trigger table. Keep ≤80
 | Commit when `modules/` or `bin/` changed                    | [strata-strict-pairing.md](learnings/strata-strict-pairing.md)               |
 | Wire `/reports/*` or ReportService                          | [report-tenant-scoping.md](learnings/report-tenant-scoping.md)               |
 | Add transactions/movements/bulk UI in `modules/web`         | [web-ledger-ui-no-domain.md](learnings/web-ledger-ui-no-domain.md)           |
+| Add or refactor SPA forms / Zod / RHF / mutation errors     | [web-forms-ux-kit.md](learnings/web-forms-ux-kit.md)                         |

--- a/.strata/memory/learnings/web-forms-ux-kit.md
+++ b/.strata/memory/learnings/web-forms-ux-kit.md
@@ -1,0 +1,14 @@
+---
+name: web-forms-ux-kit
+description: Use modules/web/src/forms/ Zod+RHF kit for feature forms; toast vs inline by error class.
+---
+
+# Web forms UX kit (PPT-055)
+
+When adding or changing SPA forms under `modules/web`:
+
+1. Prefer `zod` + `react-hook-form` + `@hookform/resolvers/zod` via `src/forms/`.
+2. Keep OpenAPI payload mapping in `*FormState` → `to*Create/Update` — Zod is UX validation only.
+3. On mutation failure call `applyMutationError` (422 fields inline; 429/network/5xx toast + root).
+4. Reuse `FormField` / `FormRootError` and `formatMoney` / `formatDate` — do not invent domain rules in TS.
+5. Documented SSOT: `modules/web/README.md` § Forms & UX standards.

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -14,30 +14,31 @@ project**. Papita API verifies JWTs + links `users` by `sub` — it is not the I
   assumptions; API Auth cross-link; `formatApiError` confirm-email remap; Login/
   Register 429 page tests. Strata archived `20260803-03`. Password reset deferred;
   email-confirm product UX remains PPT-068 (#139).
+- **PPT-055 / #120 (in progress):** Forms + UX standards kit in `modules/web`:
+  `zod` + `react-hook-form` + `@hookform/resolvers`; `src/forms/` (schemas,
+  `mapServerErrors`, `applyMutationError`, `FormField`); `formatDate`; accounts +
+  categories dialogs migrated; README UX section; Vitest green (87).
 - **PPT-054 / #119 (in progress):** Dashboard + reports UI — PR1 spending slice in
-  `modules/web`: `lib/reportWindow.ts` (mirrors API window delta), `api/reports.ts`,
-  `ReportFilters` + `SpendingReportView`, `ReportsPage` (stub replaced), error-code
-  copy for `report_window_too_large` / `report_account_not_found`. Vitest + lint green.
+  `modules/web`: `lib/reportWindow.ts`, `api/reports.ts`, `ReportFilters` +
+  `SpendingReportView`, `ReportsPage`; error-code copy for report window / foreign
+  account. Vitest + lint green.
 - **PPT-053 / #118 / PR #147:** Transactions + movements UI — typed client,
   Idempotency-Key, bulk cap, movements execute/cancel, Retry-After on 429; strata
   archived `20260803-01` + learning `web-ledger-ui-no-domain.md`
 - **PPT-052 / #117:** Closed — accounts/categories UI + local auth DX via PR #143
-- **CodeQL JS/TS + web pre-commit:** Independent `codeql-javascript.yml`; local
-  `web-eslint` / `web-prettier` / `web-tsc` / `web-vitest-related` via
-  `.github/scripts/pre_commit_web.sh`
 - **PPT-051 / #116 · PPT-049 / #115 · PPT-048 / #114:** Prior web epic foundations (merged)
 
 ### Next action
 
+- Finish #120: open PR, close GitHub issue after merge
 - Finish #119: cash-flow + trends tabs → export download + 501 UX → dashboard compose
   (balances from `listAccounts`; recent activity via `GET /transactions` from #118)
-- Then PPT-056 (#121) E2E (use PPT-060 confirmed-user assumptions); PPT-055 forms
-  (#120); PPT-068 (#139) check-email/resend; PPT-069 (#140)
+- Then PPT-056 (#121) E2E (use PPT-060 confirmed-user assumptions); PPT-068 (#139)
+  check-email/resend; PPT-069 (#140)
 
 ### Uncommitted / staging notes
 
 - Do not commit `environments/**/.env` or `modules/web` secrets (`VITE_*` public only)
-- `modules/**` changes need a paired `.strata/` touch (strict mode) — PPT-060 paired
-  (`project_state`, archive `20260803-03`)
-- Unrelated WIP left unstaged: `modules/web/src/forms/`, `formatDate.ts` (likely #120)
+- `modules/**` changes need a paired `.strata/` touch (strict mode) — PPT-055 paired
+  (`project_state`, issue `20260803-04` for PPT-055)
 - PSR → `modules/model/CHANGELOG.md` only; root CHANGELOG = auto-updates.yml

--- a/modules/web/README.md
+++ b/modules/web/README.md
@@ -165,9 +165,37 @@ Feature pages should consume tokens / `ui/*` primitives — avoid one-off hex co
 - **Local pre-commit (web):** when staging `modules/web/**`, [`.pre-commit-config.yaml`](../../.pre-commit-config.yaml) runs `web-eslint`, `web-prettier`, `web-tsc`, and `web-vitest-related` via [`.github/scripts/pre_commit_web.sh`](../../.github/scripts/pre_commit_web.sh) (same tools as husky+lint-staged, without husky). Requires `pnpm install`. Skipped in Python quality-control CI; [`.github/workflows/web-ci.yml`](../../.github/workflows/web-ci.yml) remains the merge gate.
 - Not using husky/commitlint here — commit titles follow repo PPT notation (`feat/PPT-NNN: [web] …`); Stylelint omitted (Tailwind v4 + token CSS, no separate SCSS pipeline).
 
+## Forms & UX standards (PPT-055 / #120)
+
+Shared validation and mutation error UX live under `src/forms/`. Feature screens should use this kit instead of ad-hoc `useState` + throw validation.
+
+| Piece           | Location                                          | Notes                                                                           |
+| --------------- | ------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Deps            | `zod`, `react-hook-form`, `@hookform/resolvers`   | Owned by PPT-055                                                                |
+| Schemas         | `src/forms/schemas/*`                             | UX shape checks aligned to OpenAPI write models — **not** a second domain layer |
+| Field chrome    | `src/forms/FormField.tsx`                         | Label + control + inline `role="alert"` error                                   |
+| Server → fields | `src/forms/mapServerErrors.ts`                    | FastAPI 422 `loc` + optional `fieldMap` → RHF paths                             |
+| Mutation policy | `src/forms/applyMutationError.ts`                 | See error table below                                                           |
+| Money / dates   | `src/lib/formatMoney.ts`, `src/lib/formatDate.ts` | `Intl` presentation helpers only                                                |
+| Query chrome    | `src/components/QueryState.tsx`                   | Pending / empty / error for list-detail fetches                                 |
+
+**Mutation error policy**
+
+| Class                        | UX                                                                                |
+| ---------------------------- | --------------------------------------------------------------------------------- |
+| Zod client validation        | Inline field errors only                                                          |
+| HTTP 422 with mappable `loc` | Inline `setError` (field / root); **no** toast                                    |
+| 429 / network / 502–504      | Toast via `formatApiError` (+ `Retry-After` when present) **and** root form error |
+| Other 4xx/5xx                | Toast + root form error                                                           |
+| Global category 404          | Inline + toast (read-only seed signal; unchanged)                                 |
+
+**Pending:** disable submit while `mutation.isPending` or `formState.isSubmitting`; button label `Saving…`.
+
+Reference migrations: `AccountFormDialog` + `CategoryFormDialog`. Ledger/auth forms may adopt the same kit later.
+
 ## Feature screens (PPT-052)
 
-Accounts and categories call `/api/v1/accounts` and `/api/v1/categories` via `src/api/accounts.ts` / `categories.ts` + `queryOptions` (`credentials: 'include'` via `apiFetch`). Forms are controlled (Login-style) until Zod/RHF lands in [#120](https://github.com/Elmorralito/save-ma-money/issues/120). Global seed category writes surface as HTTP 404 `Category not found` and are mapped to a read-only UX.
+Accounts and categories call `/api/v1/accounts` and `/api/v1/categories` via `src/api/accounts.ts` / `categories.ts` + `queryOptions` (`credentials: 'include'` via `apiFetch`). Forms use Zod + RHF (`src/forms/`, PPT-055 / [#120](https://github.com/Elmorralito/save-ma-money/issues/120)). Global seed category writes surface as HTTP 404 `Category not found` and are mapped to a read-only UX.
 
 | Detail          | Behavior                                                                                       |
 | --------------- | ---------------------------------------------------------------------------------------------- |
@@ -179,7 +207,7 @@ Accounts and categories call `/api/v1/accounts` and `/api/v1/categories` via `sr
 
 ## Ledger screens (PPT-053 / #118)
 
-Transactions and movements call `/api/v1/transactions` and `/api/v1/movements` via `src/api/transactions.ts` / `movements.ts` + `queryOptions`. Presentation only — no TypeScript ports of ledger services. Forms remain controlled until [#120](https://github.com/Elmorralito/save-ma-money/issues/120).
+Transactions and movements call `/api/v1/transactions` and `/api/v1/movements` via `src/api/transactions.ts` / `movements.ts` + `queryOptions`. Presentation only — no TypeScript ports of ledger services. Forms are still controlled `useState` (optional follow-on onto the PPT-055 kit).
 
 | Detail           | Behavior                                                                                          |
 | ---------------- | ------------------------------------------------------------------------------------------------- |
@@ -193,4 +221,4 @@ Transactions and movements call `/api/v1/transactions` and `/api/v1/movements` v
 
 ## Out of scope here
 
-Dashboard/reports UI (PPT-054), transaction split v4 UI, Zod/RHF forms kit (#120), nginx image, Redis session durability polish (#124) — see epic children under [#112](https://github.com/Elmorralito/save-ma-money/issues/112). Auth edge-case matrix is above (PPT-060 / #125); email-confirm product UX is [#139](https://github.com/Elmorralito/save-ma-money/issues/139).
+Dashboard/reports UI (PPT-054), transaction split v4 UI, migrating remaining ledger/auth forms onto PPT-055, nginx image, Redis session durability polish (#124) — see epic children under [#112](https://github.com/Elmorralito/save-ma-money/issues/112). Auth edge-case matrix is above (PPT-060 / #125); email-confirm product UX is [#139](https://github.com/Elmorralito/save-ma-money/issues/139).

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -20,6 +20,7 @@
     "check-types": "node ./scripts/check-types.mjs"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.7.1",
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@radix-ui/react-label": "^2.1.15",
@@ -31,10 +32,12 @@
     "lucide-react": "^1.28.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "react-hook-form": "^7.84.0",
     "react-router-dom": "^7.18.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/modules/web/src/components/accounts/AccountFormDialog.tsx
+++ b/modules/web/src/components/accounts/AccountFormDialog.tsx
@@ -1,5 +1,6 @@
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useState, type FormEvent } from "react";
+import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
 import { createAccount, updateAccount } from "@/api/accounts";
@@ -21,7 +22,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { formatApiError } from "@/lib/formatApiError";
+import { applyMutationError } from "@/forms/applyMutationError";
+import { ACCOUNT_SERVER_FIELD_MAP } from "@/forms/fieldMaps";
+import { FormRootError } from "@/forms/FormField";
+import { accountFormSchema } from "@/forms/schemas/account";
 import type { AccountResponse } from "@/types/domain";
 
 type AccountFormDialogProps = {
@@ -39,20 +43,21 @@ type AccountFormBodyProps = {
 
 function AccountFormBody({ mode, account, onOpenChange }: AccountFormBodyProps) {
   const queryClient = useQueryClient();
-  const [form, setForm] = useState<AccountFormState>(() =>
-    mode === "edit" && account ? accountFormFromResponse(account) : emptyAccountFormState(),
-  );
-  const [error, setError] = useState<string | null>(null);
+  const form = useForm<AccountFormState>({
+    resolver: zodResolver(accountFormSchema),
+    defaultValues:
+      mode === "edit" && account ? accountFormFromResponse(account) : emptyAccountFormState(),
+  });
 
   const mutation = useMutation({
-    mutationFn: async () => {
+    mutationFn: async (values: AccountFormState) => {
       if (mode === "create") {
-        return createAccount(toAccountCreate(form));
+        return createAccount(toAccountCreate(values));
       }
       if (!account) {
         throw new Error("Missing account");
       }
-      return updateAccount(account.id, toAccountUpdate(form));
+      return updateAccount(account.id, toAccountUpdate(values));
     },
     onSuccess: async (saved) => {
       await queryClient.invalidateQueries({ queryKey: queryKeys.accounts.lists() });
@@ -61,39 +66,30 @@ function AccountFormBody({ mode, account, onOpenChange }: AccountFormBodyProps) 
       onOpenChange(false);
     },
     onError: (err: unknown) => {
-      setError(formatApiError(err));
+      applyMutationError(err, {
+        setError: form.setError,
+        fieldMap: ACCOUNT_SERVER_FIELD_MAP,
+      });
     },
   });
 
-  function onSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setError(null);
-    try {
-      if (mode === "create") {
-        toAccountCreate(form);
-      } else {
-        toAccountUpdate(form);
-      }
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Invalid form");
-      return;
-    }
-    mutation.mutate();
-  }
+  const isPending = mutation.isPending || form.formState.isSubmitting;
 
   return (
-    <form className="space-y-4" onSubmit={onSubmit}>
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        void form.handleSubmit((values) => {
+          mutation.mutate(values);
+        })(event);
+      }}
+    >
       <AccountFormFields
+        form={form}
         idPrefix={mode === "create" ? "acct-create" : "acct-edit"}
         mode={mode}
-        value={form}
-        onChange={setForm}
       />
-      {error ? (
-        <p role="alert" className="text-sm text-destructive">
-          {error}
-        </p>
-      ) : null}
+      <FormRootError message={form.formState.errors.root?.message} />
       <DialogFooter>
         <Button
           type="button"
@@ -104,8 +100,8 @@ function AccountFormBody({ mode, account, onOpenChange }: AccountFormBodyProps) 
         >
           Cancel
         </Button>
-        <Button type="submit" disabled={mutation.isPending}>
-          {mutation.isPending ? "Saving…" : "Save"}
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "Saving…" : "Save"}
         </Button>
       </DialogFooter>
     </form>

--- a/modules/web/src/components/accounts/AccountFormFields.tsx
+++ b/modules/web/src/components/accounts/AccountFormFields.tsx
@@ -1,71 +1,66 @@
+import type { UseFormReturn } from "react-hook-form";
+
+import type { AccountFormState } from "@/components/accounts/accountFormState";
+import { FormField } from "@/forms/FormField";
 import {
   ACCOUNT_KIND_SLUGS,
   AREA_UNIT_SLUGS,
+  defaultLedgerSideForKind,
   extensionFieldForAccountKind,
   LEDGER_SIDE_SLUGS,
   OWNERSHIP_SLUGS,
   type AccountKindSlug,
 } from "@/lib/accountKinds";
-import {
-  applyAccountKindChange,
-  type AccountFormState,
-} from "@/components/accounts/accountFormState";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { NativeSelect } from "@/components/ui/native-select";
 
 type AccountFormFieldsProps = {
-  value: AccountFormState;
-  onChange: (next: AccountFormState) => void;
+  form: UseFormReturn<AccountFormState>;
   /** When editing, account_kind / ledger_side are immutable on the API. */
   mode: "create" | "edit";
   idPrefix: string;
 };
 
-export function AccountFormFields({ value, onChange, mode, idPrefix }: AccountFormFieldsProps) {
-  const extension = extensionFieldForAccountKind(value.account_kind);
-
-  function patch(partial: Partial<AccountFormState>) {
-    onChange({ ...value, ...partial });
-  }
+export function AccountFormFields({ form, mode, idPrefix }: AccountFormFieldsProps) {
+  const {
+    register,
+    watch,
+    setValue,
+    formState: { errors },
+  } = form;
+  const accountKind = watch("account_kind");
+  const extension = extensionFieldForAccountKind(accountKind);
 
   return (
     <div className="grid max-h-[60vh] gap-3 overflow-y-auto pr-1">
-      <div className="space-y-2">
-        <Label htmlFor={`${idPrefix}-name`}>Name</Label>
-        <Input
-          id={`${idPrefix}-name`}
-          required
-          maxLength={255}
-          value={value.name}
-          onChange={(event) => {
-            patch({ name: event.target.value });
-          }}
-        />
-      </div>
+      <FormField label="Name" htmlFor={`${idPrefix}-name`} error={errors.name?.message}>
+        <Input id={`${idPrefix}-name`} maxLength={255} {...register("name")} />
+      </FormField>
 
-      <div className="space-y-2">
-        <Label htmlFor={`${idPrefix}-description`}>Description</Label>
-        <Input
-          id={`${idPrefix}-description`}
-          value={value.description}
-          onChange={(event) => {
-            patch({ description: event.target.value });
-          }}
-        />
-      </div>
+      <FormField
+        label="Description"
+        htmlFor={`${idPrefix}-description`}
+        error={errors.description?.message}
+      >
+        <Input id={`${idPrefix}-description`} {...register("description")} />
+      </FormField>
 
       <div className="grid gap-3 sm:grid-cols-2">
-        <div className="space-y-2">
-          <Label htmlFor={`${idPrefix}-kind`}>Account kind</Label>
+        <FormField
+          label="Account kind"
+          htmlFor={`${idPrefix}-kind`}
+          error={errors.account_kind?.message}
+        >
           <NativeSelect
             id={`${idPrefix}-kind`}
-            required
             disabled={mode === "edit"}
-            value={value.account_kind}
-            onChange={(event) => {
-              onChange(applyAccountKindChange(value, event.target.value as AccountKindSlug));
-            }}
+            {...register("account_kind", {
+              onChange: (event) => {
+                const kind = event.target.value as AccountKindSlug;
+                setValue("account_kind", kind);
+                setValue("ledger_side", defaultLedgerSideForKind(kind));
+              },
+            })}
           >
             {ACCOUNT_KIND_SLUGS.map((kind) => (
               <option key={kind} value={kind}>
@@ -73,17 +68,16 @@ export function AccountFormFields({ value, onChange, mode, idPrefix }: AccountFo
               </option>
             ))}
           </NativeSelect>
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor={`${idPrefix}-ledger`}>Ledger side</Label>
+        </FormField>
+        <FormField
+          label="Ledger side"
+          htmlFor={`${idPrefix}-ledger`}
+          error={errors.ledger_side?.message}
+        >
           <NativeSelect
             id={`${idPrefix}-ledger`}
-            required
             disabled={mode === "edit"}
-            value={value.ledger_side}
-            onChange={(event) => {
-              patch({ ledger_side: event.target.value as AccountFormState["ledger_side"] });
-            }}
+            {...register("ledger_side")}
           >
             {LEDGER_SIDE_SLUGS.map((side) => (
               <option key={side} value={side}>
@@ -91,47 +85,44 @@ export function AccountFormFields({ value, onChange, mode, idPrefix }: AccountFo
               </option>
             ))}
           </NativeSelect>
-        </div>
+        </FormField>
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2">
-        <div className="space-y-2">
-          <Label htmlFor={`${idPrefix}-currency`}>Currency</Label>
+        <FormField
+          label="Currency"
+          htmlFor={`${idPrefix}-currency`}
+          error={errors.currency?.message}
+        >
           <Input
             id={`${idPrefix}-currency`}
-            required
             minLength={3}
             maxLength={3}
-            value={value.currency}
-            onChange={(event) => {
-              patch({ currency: event.target.value.toUpperCase() });
-            }}
+            {...register("currency", {
+              onChange: (event) => {
+                setValue("currency", event.target.value.toUpperCase());
+              },
+            })}
           />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor={`${idPrefix}-initial`}>Initial value</Label>
+        </FormField>
+        <FormField
+          label="Initial value"
+          htmlFor={`${idPrefix}-initial`}
+          error={errors.initial_value?.message}
+        >
           <Input
             id={`${idPrefix}-initial`}
             type="number"
             min={0}
             step="any"
-            value={value.initial_value}
-            onChange={(event) => {
-              patch({ initial_value: event.target.value });
-            }}
+            {...register("initial_value")}
           />
-        </div>
+        </FormField>
       </div>
 
       {mode === "edit" ? (
         <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={value.is_active}
-            onChange={(event) => {
-              patch({ is_active: event.target.checked });
-            }}
-          />
+          <input type="checkbox" {...register("is_active")} />
           Active
         </label>
       ) : null}
@@ -139,27 +130,20 @@ export function AccountFormFields({ value, onChange, mode, idPrefix }: AccountFo
       {extension === "banking_details" ? (
         <fieldset className="space-y-3 rounded-md border border-border p-3">
           <legend className="px-1 text-sm font-medium">Banking details</legend>
-          <div className="space-y-2">
-            <Label htmlFor={`${idPrefix}-entity`}>Entity</Label>
-            <Input
-              id={`${idPrefix}-entity`}
-              required
-              value={value.banking_entity}
-              onChange={(event) => {
-                patch({ banking_entity: event.target.value });
-              }}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor={`${idPrefix}-acct-num`}>Account number</Label>
-            <Input
-              id={`${idPrefix}-acct-num`}
-              value={value.banking_account_number}
-              onChange={(event) => {
-                patch({ banking_account_number: event.target.value });
-              }}
-            />
-          </div>
+          <FormField
+            label="Entity"
+            htmlFor={`${idPrefix}-entity`}
+            error={errors.banking_entity?.message}
+          >
+            <Input id={`${idPrefix}-entity`} {...register("banking_entity")} />
+          </FormField>
+          <FormField
+            label="Account number"
+            htmlFor={`${idPrefix}-acct-num`}
+            error={errors.banking_account_number?.message}
+          >
+            <Input id={`${idPrefix}-acct-num`} {...register("banking_account_number")} />
+          </FormField>
         </fieldset>
       ) : null}
 
@@ -167,34 +151,32 @@ export function AccountFormFields({ value, onChange, mode, idPrefix }: AccountFo
         <fieldset className="space-y-3 rounded-md border border-border p-3">
           <legend className="px-1 text-sm font-medium">Trading details</legend>
           <div className="grid gap-3 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor={`${idPrefix}-buy`}>Buy value</Label>
+            <FormField
+              label="Buy value"
+              htmlFor={`${idPrefix}-buy`}
+              error={errors.trading_buy_value?.message}
+            >
               <Input
                 id={`${idPrefix}-buy`}
                 type="number"
                 min={0}
                 step="any"
-                required
-                value={value.trading_buy_value}
-                onChange={(event) => {
-                  patch({ trading_buy_value: event.target.value });
-                }}
+                {...register("trading_buy_value")}
               />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor={`${idPrefix}-units`}>Units</Label>
+            </FormField>
+            <FormField
+              label="Units"
+              htmlFor={`${idPrefix}-units`}
+              error={errors.trading_units?.message}
+            >
               <Input
                 id={`${idPrefix}-units`}
                 type="number"
                 min={1}
                 step={1}
-                required
-                value={value.trading_units}
-                onChange={(event) => {
-                  patch({ trading_units: event.target.value });
-                }}
+                {...register("trading_units")}
               />
-            </div>
+            </FormField>
           </div>
         </fieldset>
       ) : null}
@@ -202,20 +184,19 @@ export function AccountFormFields({ value, onChange, mode, idPrefix }: AccountFo
       {extension === "credit_card_details" ? (
         <fieldset className="space-y-3 rounded-md border border-border p-3">
           <legend className="px-1 text-sm font-medium">Credit card details</legend>
-          <div className="space-y-2">
-            <Label htmlFor={`${idPrefix}-limit`}>Credit limit</Label>
+          <FormField
+            label="Credit limit"
+            htmlFor={`${idPrefix}-limit`}
+            error={errors.credit_limit?.message}
+          >
             <Input
               id={`${idPrefix}-limit`}
               type="number"
               min={0}
               step="any"
-              required
-              value={value.credit_limit}
-              onChange={(event) => {
-                patch({ credit_limit: event.target.value });
-              }}
+              {...register("credit_limit")}
             />
-          </div>
+          </FormField>
         </fieldset>
       ) : null}
 
@@ -223,42 +204,36 @@ export function AccountFormFields({ value, onChange, mode, idPrefix }: AccountFo
         <fieldset className="space-y-3 rounded-md border border-border p-3">
           <legend className="px-1 text-sm font-medium">Loan details</legend>
           <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={value.loan_is_paid_off}
-              onChange={(event) => {
-                patch({ loan_is_paid_off: event.target.checked });
-              }}
-            />
+            <input type="checkbox" {...register("loan_is_paid_off")} />
             Paid off
           </label>
           <div className="grid gap-3 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor={`${idPrefix}-ins`}>Insurance payment</Label>
+            <FormField
+              label="Insurance payment"
+              htmlFor={`${idPrefix}-ins`}
+              error={errors.loan_insurance_payment?.message}
+            >
               <Input
                 id={`${idPrefix}-ins`}
                 type="number"
                 min={0}
                 step="any"
-                value={value.loan_insurance_payment}
-                onChange={(event) => {
-                  patch({ loan_insurance_payment: event.target.value });
-                }}
+                {...register("loan_insurance_payment")}
               />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor={`${idPrefix}-extras`}>Extras payment</Label>
+            </FormField>
+            <FormField
+              label="Extras payment"
+              htmlFor={`${idPrefix}-extras`}
+              error={errors.loan_extras_payment?.message}
+            >
               <Input
                 id={`${idPrefix}-extras`}
                 type="number"
                 min={0}
                 step="any"
-                value={value.loan_extras_payment}
-                onChange={(event) => {
-                  patch({ loan_extras_payment: event.target.value });
-                }}
+                {...register("loan_extras_payment")}
               />
-            </div>
+            </FormField>
           </div>
         </fieldset>
       ) : null}
@@ -266,119 +241,94 @@ export function AccountFormFields({ value, onChange, mode, idPrefix }: AccountFo
       {extension === "real_estate_details" ? (
         <fieldset className="space-y-3 rounded-md border border-border p-3">
           <legend className="px-1 text-sm font-medium">Real estate details</legend>
-          <div className="space-y-2">
-            <Label htmlFor={`${idPrefix}-address`}>Address</Label>
-            <Input
-              id={`${idPrefix}-address`}
-              required
-              value={value.re_address}
-              onChange={(event) => {
-                patch({ re_address: event.target.value });
-              }}
-            />
+          <FormField
+            label="Address"
+            htmlFor={`${idPrefix}-address`}
+            error={errors.re_address?.message}
+          >
+            <Input id={`${idPrefix}-address`} {...register("re_address")} />
+          </FormField>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <FormField label="City" htmlFor={`${idPrefix}-city`} error={errors.re_city?.message}>
+              <Input id={`${idPrefix}-city`} {...register("re_city")} />
+            </FormField>
+            <FormField
+              label="Country"
+              htmlFor={`${idPrefix}-country`}
+              error={errors.re_country?.message}
+            >
+              <Input id={`${idPrefix}-country`} {...register("re_country")} />
+            </FormField>
           </div>
           <div className="grid gap-3 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor={`${idPrefix}-city`}>City</Label>
-              <Input
-                id={`${idPrefix}-city`}
-                required
-                value={value.re_city}
-                onChange={(event) => {
-                  patch({ re_city: event.target.value });
-                }}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor={`${idPrefix}-country`}>Country</Label>
-              <Input
-                id={`${idPrefix}-country`}
-                required
-                value={value.re_country}
-                onChange={(event) => {
-                  patch({ re_country: event.target.value });
-                }}
-              />
-            </div>
-          </div>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor={`${idPrefix}-total`}>Total area</Label>
+            <FormField
+              label="Total area"
+              htmlFor={`${idPrefix}-total`}
+              error={errors.re_total_area?.message}
+            >
               <Input
                 id={`${idPrefix}-total`}
                 type="number"
                 min={0}
                 step="any"
-                required
-                value={value.re_total_area}
-                onChange={(event) => {
-                  patch({ re_total_area: event.target.value });
-                }}
+                {...register("re_total_area")}
               />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor={`${idPrefix}-built`}>Built area</Label>
+            </FormField>
+            <FormField
+              label="Built area"
+              htmlFor={`${idPrefix}-built`}
+              error={errors.re_built_area?.message}
+            >
               <Input
                 id={`${idPrefix}-built`}
                 type="number"
                 min={0}
                 step="any"
-                required
-                value={value.re_built_area}
-                onChange={(event) => {
-                  patch({ re_built_area: event.target.value });
-                }}
+                {...register("re_built_area")}
               />
-            </div>
+            </FormField>
           </div>
           <div className="grid gap-3 sm:grid-cols-3">
-            <div className="space-y-2">
-              <Label htmlFor={`${idPrefix}-unit`}>Area unit</Label>
-              <NativeSelect
-                id={`${idPrefix}-unit`}
-                value={value.re_area_unit}
-                onChange={(event) => {
-                  patch({ re_area_unit: event.target.value });
-                }}
-              >
+            <FormField
+              label="Area unit"
+              htmlFor={`${idPrefix}-unit`}
+              error={errors.re_area_unit?.message}
+            >
+              <NativeSelect id={`${idPrefix}-unit`} {...register("re_area_unit")}>
                 {AREA_UNIT_SLUGS.map((unit) => (
                   <option key={unit} value={unit}>
                     {unit}
                   </option>
                 ))}
               </NativeSelect>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor={`${idPrefix}-own`}>Ownership</Label>
-              <NativeSelect
-                id={`${idPrefix}-own`}
-                value={value.re_ownership}
-                onChange={(event) => {
-                  patch({ re_ownership: event.target.value });
-                }}
-              >
+            </FormField>
+            <FormField
+              label="Ownership"
+              htmlFor={`${idPrefix}-own`}
+              error={errors.re_ownership?.message}
+            >
+              <NativeSelect id={`${idPrefix}-own`} {...register("re_ownership")}>
                 {OWNERSHIP_SLUGS.map((ownership) => (
                   <option key={ownership} value={ownership}>
                     {ownership}
                   </option>
                 ))}
               </NativeSelect>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor={`${idPrefix}-part`}>Participation</Label>
+            </FormField>
+            <FormField
+              label="Participation"
+              htmlFor={`${idPrefix}-part`}
+              error={errors.re_participation?.message}
+            >
               <Input
                 id={`${idPrefix}-part`}
                 type="number"
                 min={0}
                 max={1}
                 step="any"
-                required
-                value={value.re_participation}
-                onChange={(event) => {
-                  patch({ re_participation: event.target.value });
-                }}
+                {...register("re_participation")}
               />
-            </div>
+            </FormField>
           </div>
         </fieldset>
       ) : null}

--- a/modules/web/src/components/categories/CategoryFormDialog.tsx
+++ b/modules/web/src/components/categories/CategoryFormDialog.tsx
@@ -1,5 +1,6 @@
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useState, type FormEvent } from "react";
+import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
 import { createCategory, updateCategory } from "@/api/categories";
@@ -21,10 +22,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { NativeSelect } from "@/components/ui/native-select";
+import { applyMutationError } from "@/forms/applyMutationError";
+import { CATEGORY_SERVER_FIELD_MAP } from "@/forms/fieldMaps";
+import { FormField, FormRootError } from "@/forms/FormField";
+import { categoryFormSchema } from "@/forms/schemas/category";
 import { CATEGORY_TYPE_SLUGS } from "@/lib/categoryTypes";
-import { formatApiError, isGlobalOrMissingCategoryError } from "@/lib/formatApiError";
+import { isGlobalOrMissingCategoryError } from "@/lib/formatApiError";
 import type { CategoryResponse } from "@/types/domain";
 
 type CategoryFormDialogProps = {
@@ -53,20 +57,21 @@ function CategoryFormBody({
   onGlobalMutationBlocked,
 }: CategoryFormBodyProps) {
   const queryClient = useQueryClient();
-  const [form, setForm] = useState<CategoryFormState>(() =>
-    mode === "edit" && category ? categoryFormFromResponse(category) : emptyCategoryFormState(),
-  );
-  const [error, setError] = useState<string | null>(null);
+  const form = useForm<CategoryFormState>({
+    resolver: zodResolver(categoryFormSchema),
+    defaultValues:
+      mode === "edit" && category ? categoryFormFromResponse(category) : emptyCategoryFormState(),
+  });
 
   const mutation = useMutation({
-    mutationFn: async () => {
+    mutationFn: async (values: CategoryFormState) => {
       if (mode === "create") {
-        return createCategory(toCategoryCreate(form));
+        return createCategory(toCategoryCreate(values));
       }
       if (!category) {
         throw new Error("Missing category");
       }
-      return updateCategory(category.id, toCategoryUpdate(form));
+      return updateCategory(category.id, toCategoryUpdate(values));
     },
     onSuccess: async (saved) => {
       await queryClient.invalidateQueries({ queryKey: queryKeys.categories.lists() });
@@ -77,80 +82,60 @@ function CategoryFormBody({
     onError: (err: unknown) => {
       if (mode === "edit" && category && isGlobalOrMissingCategoryError(err)) {
         const message = "This category cannot be modified (global seed or not found).";
-        setError(message);
+        form.setError("root", { type: "server", message });
         onGlobalMutationBlocked?.(category.id);
         toast.error(message);
         return;
       }
-      setError(formatApiError(err));
+      applyMutationError(err, {
+        setError: form.setError,
+        fieldMap: CATEGORY_SERVER_FIELD_MAP,
+      });
     },
   });
 
-  function onSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setError(null);
-    mutation.mutate();
-  }
-
-  function patch(partial: Partial<CategoryFormState>) {
-    setForm((prev) => ({ ...prev, ...partial }));
-  }
-
   const idPrefix = mode === "create" ? "cat-create" : "cat-edit";
+  const {
+    register,
+    formState: { errors },
+  } = form;
+  const isPending = mutation.isPending || form.formState.isSubmitting;
 
   return (
-    <form className="space-y-4" onSubmit={onSubmit}>
-      <div className="space-y-2">
-        <Label htmlFor={`${idPrefix}-name`}>Name</Label>
-        <Input
-          id={`${idPrefix}-name`}
-          required
-          maxLength={255}
-          value={form.name}
-          onChange={(event) => {
-            patch({ name: event.target.value });
-          }}
-        />
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor={`${idPrefix}-description`}>Description</Label>
-        <Input
-          id={`${idPrefix}-description`}
-          value={form.description}
-          onChange={(event) => {
-            patch({ description: event.target.value });
-          }}
-        />
-      </div>
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        void form.handleSubmit((values) => {
+          mutation.mutate(values);
+        })(event);
+      }}
+    >
+      <FormField label="Name" htmlFor={`${idPrefix}-name`} error={errors.name?.message}>
+        <Input id={`${idPrefix}-name`} maxLength={255} {...register("name")} />
+      </FormField>
+      <FormField
+        label="Description"
+        htmlFor={`${idPrefix}-description`}
+        error={errors.description?.message}
+      >
+        <Input id={`${idPrefix}-description`} {...register("description")} />
+      </FormField>
       <div className="grid gap-3 sm:grid-cols-2">
-        <div className="space-y-2">
-          <Label htmlFor={`${idPrefix}-type`}>Category type</Label>
-          <NativeSelect
-            id={`${idPrefix}-type`}
-            required
-            value={form.category_type}
-            onChange={(event) => {
-              patch({
-                category_type: event.target.value as CategoryFormState["category_type"],
-              });
-            }}
-          >
+        <FormField
+          label="Category type"
+          htmlFor={`${idPrefix}-type`}
+          error={errors.category_type?.message}
+        >
+          <NativeSelect id={`${idPrefix}-type`} {...register("category_type")}>
             {CATEGORY_TYPE_SLUGS.map((type) => (
               <option key={type} value={type}>
                 {type}
               </option>
             ))}
           </NativeSelect>
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor={`${idPrefix}-parent`}>Parent</Label>
-          <NativeSelect
-            id={`${idPrefix}-parent`}
-            value={form.parent_id}
-            onChange={(event) => {
-              patch({ parent_id: event.target.value });
-            }}
-          >
+        </FormField>
+        <FormField label="Parent" htmlFor={`${idPrefix}-parent`} error={errors.parent_id?.message}>
+          <NativeSelect id={`${idPrefix}-parent`} {...register("parent_id")}>
             <option value="">None</option>
             {parentOptions
               .filter((option) => option.id !== category?.id)
@@ -160,50 +145,28 @@ function CategoryFormBody({
                 </option>
               ))}
           </NativeSelect>
-        </div>
+        </FormField>
       </div>
       <div className="grid gap-3 sm:grid-cols-2">
-        <div className="space-y-2">
-          <Label htmlFor={`${idPrefix}-icon`}>Icon</Label>
-          <Input
-            id={`${idPrefix}-icon`}
-            maxLength={64}
-            value={form.icon}
-            onChange={(event) => {
-              patch({ icon: event.target.value });
-            }}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor={`${idPrefix}-color`}>Color</Label>
+        <FormField label="Icon" htmlFor={`${idPrefix}-icon`} error={errors.icon?.message}>
+          <Input id={`${idPrefix}-icon`} maxLength={64} {...register("icon")} />
+        </FormField>
+        <FormField label="Color" htmlFor={`${idPrefix}-color`} error={errors.color?.message}>
           <Input
             id={`${idPrefix}-color`}
             maxLength={7}
             placeholder="#RRGGBB"
-            value={form.color}
-            onChange={(event) => {
-              patch({ color: event.target.value });
-            }}
+            {...register("color")}
           />
-        </div>
+        </FormField>
       </div>
       {mode === "edit" ? (
         <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={form.is_active}
-            onChange={(event) => {
-              patch({ is_active: event.target.checked });
-            }}
-          />
+          <input type="checkbox" {...register("is_active")} />
           Active
         </label>
       ) : null}
-      {error ? (
-        <p role="alert" className="text-sm text-destructive">
-          {error}
-        </p>
-      ) : null}
+      <FormRootError message={errors.root?.message} />
       <DialogFooter>
         <Button
           type="button"
@@ -214,8 +177,8 @@ function CategoryFormBody({
         >
           Cancel
         </Button>
-        <Button type="submit" disabled={mutation.isPending}>
-          {mutation.isPending ? "Saving…" : "Save"}
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "Saving…" : "Save"}
         </Button>
       </DialogFooter>
     </form>

--- a/modules/web/src/forms/FormField.tsx
+++ b/modules/web/src/forms/FormField.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+
+import { Label } from "@/components/ui/label";
+
+type FormFieldProps = {
+  label: string;
+  htmlFor: string;
+  error?: string;
+  children: ReactNode;
+};
+
+/** Label + control + inline field error (PPT-055). */
+export function FormField({ label, htmlFor, error, children }: FormFieldProps) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      {children}
+      {error ? (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+type FormRootErrorProps = {
+  message?: string;
+};
+
+/** Form-level (root) error alert. */
+export function FormRootError({ message }: FormRootErrorProps) {
+  if (!message) {
+    return null;
+  }
+  return (
+    <p role="alert" className="text-sm text-destructive">
+      {message}
+    </p>
+  );
+}

--- a/modules/web/src/forms/applyMutationError.ts
+++ b/modules/web/src/forms/applyMutationError.ts
@@ -1,0 +1,56 @@
+import type { FieldValues, Path, UseFormSetError } from "react-hook-form";
+import { toast } from "sonner";
+
+import { isPapitaApiError } from "@/api/errors";
+import { mapServerErrors, shouldToastMutationError } from "@/forms/mapServerErrors";
+import { formatApiError } from "@/lib/formatApiError";
+
+type ApplyMutationErrorOptions<TFieldValues extends FieldValues> = {
+  setError: UseFormSetError<TFieldValues>;
+  /** OpenAPI body path → form field name (flat RHF keys). */
+  fieldMap?: Record<string, string>;
+  /** Override toast decision; default uses {@link shouldToastMutationError}. */
+  toast?: boolean;
+};
+
+/**
+ * Apply a mutation failure to RHF + toast per PPT-055 policy:
+ *
+ * - 422 with mappable field locs → inline ``setError`` only
+ * - 429 / network / 5xx → toast (+ root form error)
+ * - other errors → toast + root
+ */
+export function applyMutationError<TFieldValues extends FieldValues>(
+  error: unknown,
+  options: ApplyMutationErrorOptions<TFieldValues>,
+): void {
+  const summary = formatApiError(error);
+  const mapped = mapServerErrors(error, options.fieldMap ?? {});
+  const isField422 = isPapitaApiError(error) && error.status === 422 && mapped.fields.length > 0;
+
+  if (isField422) {
+    for (const field of mapped.fields) {
+      options.setError(field.name as Path<TFieldValues>, {
+        type: "server",
+        message: field.message,
+      });
+    }
+    if (mapped.root) {
+      options.setError("root" as Path<TFieldValues>, {
+        type: "server",
+        message: mapped.root,
+      });
+    }
+    return;
+  }
+
+  const useToast = options.toast ?? shouldToastMutationError(error);
+  if (useToast) {
+    toast.error(summary);
+  }
+
+  options.setError("root" as Path<TFieldValues>, {
+    type: "server",
+    message: summary,
+  });
+}

--- a/modules/web/src/forms/fieldMaps.ts
+++ b/modules/web/src/forms/fieldMaps.ts
@@ -1,0 +1,37 @@
+/** OpenAPI AccountCreate/Update body paths → AccountFormState keys. */
+export const ACCOUNT_SERVER_FIELD_MAP: Record<string, string> = {
+  name: "name",
+  description: "description",
+  account_kind: "account_kind",
+  ledger_side: "ledger_side",
+  currency: "currency",
+  initial_value: "initial_value",
+  is_active: "is_active",
+  "banking_details.entity": "banking_entity",
+  "banking_details.account_number": "banking_account_number",
+  "trading_details.buy_value": "trading_buy_value",
+  "trading_details.units": "trading_units",
+  "credit_card_details.credit_limit": "credit_limit",
+  "loan_details.is_paid_off": "loan_is_paid_off",
+  "loan_details.insurance_payment": "loan_insurance_payment",
+  "loan_details.extras_payment": "loan_extras_payment",
+  "real_estate_details.address": "re_address",
+  "real_estate_details.city": "re_city",
+  "real_estate_details.country": "re_country",
+  "real_estate_details.total_area": "re_total_area",
+  "real_estate_details.built_area": "re_built_area",
+  "real_estate_details.area_unit": "re_area_unit",
+  "real_estate_details.ownership": "re_ownership",
+  "real_estate_details.participation": "re_participation",
+};
+
+/** OpenAPI CategoryCreate/Update body paths → CategoryFormState keys. */
+export const CATEGORY_SERVER_FIELD_MAP: Record<string, string> = {
+  name: "name",
+  description: "description",
+  category_type: "category_type",
+  parent_id: "parent_id",
+  icon: "icon",
+  color: "color",
+  is_active: "is_active",
+};

--- a/modules/web/src/forms/index.ts
+++ b/modules/web/src/forms/index.ts
@@ -1,0 +1,12 @@
+export { applyMutationError } from "@/forms/applyMutationError";
+export { ACCOUNT_SERVER_FIELD_MAP, CATEGORY_SERVER_FIELD_MAP } from "@/forms/fieldMaps";
+export { FormField, FormRootError } from "@/forms/FormField";
+export {
+  apiLocToPath,
+  mapServerErrors,
+  shouldToastMutationError,
+  type MappedFieldError,
+  type MappedServerErrors,
+} from "@/forms/mapServerErrors";
+export { accountFormSchema, type AccountFormSchema } from "@/forms/schemas/account";
+export { categoryFormSchema, type CategoryFormSchema } from "@/forms/schemas/category";

--- a/modules/web/src/forms/mapServerErrors.test.ts
+++ b/modules/web/src/forms/mapServerErrors.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { PapitaApiError } from "@/api/errors";
+import { ACCOUNT_SERVER_FIELD_MAP } from "@/forms/fieldMaps";
+import { apiLocToPath, mapServerErrors, shouldToastMutationError } from "@/forms/mapServerErrors";
+
+const emptyDiscovery = {
+  breakingChanges: null,
+  bulkMax: null,
+  reportWindowMaxDays: null,
+  cashFlowRefreshDefault: null,
+  reportsForeignAccountStatus: null,
+  errorCode: null,
+  compatActive: [] as string[],
+};
+
+describe("apiLocToPath", () => {
+  it("strips body prefix from FastAPI loc", () => {
+    expect(apiLocToPath(["body", "name"])).toBe("name");
+    expect(apiLocToPath(["body", "banking_details", "entity"])).toBe("banking_details.entity");
+  });
+});
+
+describe("mapServerErrors", () => {
+  it("maps 422 detail locs onto form fields via fieldMap", () => {
+    const error = new PapitaApiError({
+      message: "Request validation failed",
+      status: 422,
+      discovery: emptyDiscovery,
+      body: {
+        detail: [
+          { loc: ["body", "name"], msg: "Field required", type: "missing" },
+          {
+            loc: ["body", "banking_details", "entity"],
+            msg: "Entity required",
+            type: "missing",
+          },
+        ],
+      },
+    });
+
+    const mapped = mapServerErrors(error, ACCOUNT_SERVER_FIELD_MAP);
+    expect(mapped.fields).toEqual([
+      { name: "name", message: "Field required" },
+      { name: "banking_entity", message: "Entity required" },
+    ]);
+    expect(mapped.root).toBeNull();
+  });
+
+  it("puts unmapped nested locs on root", () => {
+    const error = new PapitaApiError({
+      message: "Request validation failed",
+      status: 422,
+      discovery: emptyDiscovery,
+      body: {
+        detail: [{ loc: ["body", "unknown_block", "x"], msg: "bad", type: "value_error" }],
+      },
+    });
+    const mapped = mapServerErrors(error, ACCOUNT_SERVER_FIELD_MAP);
+    expect(mapped.fields).toEqual([]);
+    expect(mapped.root).toBe("unknown_block.x: bad");
+  });
+
+  it("surfaces X-Papita-Error-Code on root when there are no field details", () => {
+    const error = new PapitaApiError({
+      message: "bulk too large",
+      status: 400,
+      code: "bulk_too_large",
+      discovery: { ...emptyDiscovery, errorCode: "bulk_too_large" },
+    });
+    const mapped = mapServerErrors(error);
+    expect(mapped.fields).toEqual([]);
+    expect(mapped.root).toBe("bulk too large [bulk_too_large]");
+  });
+});
+
+describe("shouldToastMutationError", () => {
+  it("toasts 429 and network failures", () => {
+    expect(
+      shouldToastMutationError(
+        new PapitaApiError({
+          message: "rate limited",
+          status: 429,
+          discovery: emptyDiscovery,
+          retryAfter: 30,
+        }),
+      ),
+    ).toBe(true);
+    expect(shouldToastMutationError(new TypeError("Failed to fetch"))).toBe(true);
+  });
+
+  it("does not toast field-mapped 422 by status alone", () => {
+    expect(
+      shouldToastMutationError(
+        new PapitaApiError({
+          message: "Request validation failed",
+          status: 422,
+          discovery: emptyDiscovery,
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/modules/web/src/forms/mapServerErrors.ts
+++ b/modules/web/src/forms/mapServerErrors.ts
@@ -1,0 +1,130 @@
+import { isPapitaApiError } from "@/api/errors";
+
+export type MappedFieldError = {
+  /** RHF field name (after fieldMap), or a top-level form key. */
+  name: string;
+  message: string;
+};
+
+export type MappedServerErrors = {
+  fields: MappedFieldError[];
+  /** Unmapped / form-level message. */
+  root: string | null;
+};
+
+type FastApiDetailItem = {
+  loc?: unknown;
+  msg?: unknown;
+};
+
+function isDetailItem(value: unknown): value is FastApiDetailItem {
+  return value !== null && typeof value === "object";
+}
+
+/** Strip body/query/path prefixes from FastAPI ``loc`` and join remaining segments. */
+export function apiLocToPath(loc: unknown): string | null {
+  if (!Array.isArray(loc) || loc.length === 0) {
+    return null;
+  }
+  const parts = loc
+    .filter(
+      (segment): segment is string | number =>
+        typeof segment === "string" || typeof segment === "number",
+    )
+    .map(String);
+  if (parts.length === 0) {
+    return null;
+  }
+  const first = parts[0];
+  const start = first === "body" || first === "query" || first === "path" ? 1 : 0;
+  const rest = parts.slice(start);
+  if (rest.length === 0) {
+    return null;
+  }
+  return rest.join(".");
+}
+
+function resolveFormFieldName(apiPath: string, fieldMap: Record<string, string>): string | null {
+  if (fieldMap[apiPath]) {
+    return fieldMap[apiPath];
+  }
+  // Top-level OpenAPI body keys match flat form state when unmapped.
+  if (!apiPath.includes(".")) {
+    return apiPath;
+  }
+  return null;
+}
+
+/**
+ * Map a failed API error into RHF field paths.
+ *
+ * ``fieldMap`` remaps OpenAPI body paths (e.g. ``banking_details.entity``) onto flat form keys.
+ * Unmapped nested locs contribute to ``root``.
+ */
+export function mapServerErrors(
+  error: unknown,
+  fieldMap: Record<string, string> = {},
+): MappedServerErrors {
+  if (!isPapitaApiError(error)) {
+    return { fields: [], root: null };
+  }
+
+  const fields: MappedFieldError[] = [];
+  const unmapped: string[] = [];
+
+  if (error.body !== null && typeof error.body === "object") {
+    const detail = (error.body as { detail?: unknown }).detail;
+    if (Array.isArray(detail)) {
+      for (const item of detail) {
+        if (!isDetailItem(item)) {
+          continue;
+        }
+        const msg = typeof item.msg === "string" ? item.msg : null;
+        if (msg === null) {
+          continue;
+        }
+        const apiPath = apiLocToPath(item.loc);
+        if (apiPath === null) {
+          unmapped.push(msg);
+          continue;
+        }
+        const target = resolveFormFieldName(apiPath, fieldMap);
+        if (target) {
+          fields.push({ name: target, message: msg });
+        } else {
+          unmapped.push(`${apiPath}: ${msg}`);
+        }
+      }
+    }
+  }
+
+  let root: string | null = null;
+  if (fields.length === 0) {
+    if (unmapped.length > 0) {
+      root = unmapped.join("; ");
+    } else if (error.code) {
+      root = `${error.message} [${error.code}]`;
+    } else {
+      root = error.message;
+    }
+  } else if (unmapped.length > 0) {
+    root = unmapped.join("; ");
+  }
+
+  return { fields, root };
+}
+
+/** True when the error should surface primarily as a toast (429 / network / 5xx). */
+export function shouldToastMutationError(error: unknown): boolean {
+  if (error instanceof TypeError) {
+    return true;
+  }
+  if (!isPapitaApiError(error)) {
+    return true;
+  }
+  if (error.status === 429 || error.status >= 500) {
+    return true;
+  }
+  // Field-mapped 422 stays inline-only; other statuses toast.
+  return error.status !== 422;
+}

--- a/modules/web/src/forms/schemas/account.test.ts
+++ b/modules/web/src/forms/schemas/account.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { emptyAccountFormState } from "@/components/accounts/accountFormState";
+import { accountFormSchema } from "@/forms/schemas/account";
+
+describe("accountFormSchema", () => {
+  it("accepts a valid checking account form", () => {
+    const result = accountFormSchema.safeParse(
+      emptyAccountFormState({
+        name: "Everyday",
+        banking_entity: "Local Bank",
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("requires banking entity for checking", () => {
+    const result = accountFormSchema.safeParse(
+      emptyAccountFormState({
+        name: "Everyday",
+        banking_entity: "",
+      }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.path[0] === "banking_entity")).toBe(true);
+    }
+  });
+
+  it("rejects empty name", () => {
+    const result = accountFormSchema.safeParse(emptyAccountFormState({ name: "  " }));
+    expect(result.success).toBe(false);
+  });
+});

--- a/modules/web/src/forms/schemas/account.ts
+++ b/modules/web/src/forms/schemas/account.ts
@@ -1,0 +1,139 @@
+import { z } from "zod";
+
+import {
+  ACCOUNT_KIND_SLUGS,
+  LEDGER_SIDE_SLUGS,
+  extensionFieldForAccountKind,
+} from "@/lib/accountKinds";
+
+const optionalNumberString = z
+  .string()
+  .refine((value) => value.trim() === "" || Number.isFinite(Number(value)), {
+    message: "Must be a valid number",
+  });
+
+const requiredNumberString = (label: string) =>
+  z
+    .string()
+    .trim()
+    .min(1, `${label} is required`)
+    .refine((value) => Number.isFinite(Number(value)), { message: `${label} must be a number` });
+
+/** UX schema for {@link AccountFormState} — OpenAPI-aligned shape checks only. */
+export const accountFormSchema = z
+  .object({
+    name: z.string().trim().min(1, "Name is required").max(255),
+    description: z.string(),
+    account_kind: z.enum(ACCOUNT_KIND_SLUGS),
+    ledger_side: z.enum(LEDGER_SIDE_SLUGS),
+    currency: z
+      .string()
+      .trim()
+      .length(3, "Currency must be a 3-letter code")
+      .regex(/^[A-Za-z]{3}$/, "Currency must be a 3-letter code"),
+    initial_value: optionalNumberString,
+    banking_entity: z.string(),
+    banking_account_number: z.string(),
+    trading_buy_value: z.string(),
+    trading_units: z.string(),
+    re_address: z.string(),
+    re_city: z.string(),
+    re_country: z.string(),
+    re_total_area: z.string(),
+    re_built_area: z.string(),
+    re_area_unit: z.string(),
+    re_ownership: z.string(),
+    re_participation: z.string(),
+    credit_limit: z.string(),
+    loan_is_paid_off: z.boolean(),
+    loan_insurance_payment: z.string(),
+    loan_extras_payment: z.string(),
+    is_active: z.boolean(),
+  })
+  .superRefine((state, ctx) => {
+    const extension = extensionFieldForAccountKind(state.account_kind);
+    if (extension === "banking_details") {
+      if (state.banking_entity.trim() === "") {
+        ctx.addIssue({
+          code: "custom",
+          path: ["banking_entity"],
+          message: "Entity is required",
+        });
+      }
+    }
+    if (extension === "trading_details") {
+      const buy = requiredNumberString("Buy value").safeParse(state.trading_buy_value);
+      if (!buy.success) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["trading_buy_value"],
+          message: buy.error.issues[0]?.message ?? "Buy value is required",
+        });
+      }
+      const units = requiredNumberString("Units").safeParse(state.trading_units);
+      if (!units.success) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["trading_units"],
+          message: units.error.issues[0]?.message ?? "Units is required",
+        });
+      }
+    }
+    if (extension === "credit_card_details") {
+      const limit = requiredNumberString("Credit limit").safeParse(state.credit_limit);
+      if (!limit.success) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["credit_limit"],
+          message: limit.error.issues[0]?.message ?? "Credit limit is required",
+        });
+      }
+    }
+    if (extension === "loan_details") {
+      const insurance = requiredNumberString("Insurance payment").safeParse(
+        state.loan_insurance_payment,
+      );
+      if (!insurance.success) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["loan_insurance_payment"],
+          message: insurance.error.issues[0]?.message ?? "Insurance payment is required",
+        });
+      }
+      const extras = requiredNumberString("Extras payment").safeParse(state.loan_extras_payment);
+      if (!extras.success) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["loan_extras_payment"],
+          message: extras.error.issues[0]?.message ?? "Extras payment is required",
+        });
+      }
+    }
+    if (extension === "real_estate_details") {
+      if (state.re_address.trim() === "") {
+        ctx.addIssue({ code: "custom", path: ["re_address"], message: "Address is required" });
+      }
+      if (state.re_city.trim() === "") {
+        ctx.addIssue({ code: "custom", path: ["re_city"], message: "City is required" });
+      }
+      if (state.re_country.trim() === "") {
+        ctx.addIssue({ code: "custom", path: ["re_country"], message: "Country is required" });
+      }
+      for (const [key, label] of [
+        ["re_total_area", "Total area"],
+        ["re_built_area", "Built area"],
+        ["re_participation", "Participation"],
+      ] as const) {
+        const parsed = requiredNumberString(label).safeParse(state[key]);
+        if (!parsed.success) {
+          ctx.addIssue({
+            code: "custom",
+            path: [key],
+            message: parsed.error.issues[0]?.message ?? `${label} is required`,
+          });
+        }
+      }
+    }
+  });
+
+export type AccountFormSchema = z.infer<typeof accountFormSchema>;

--- a/modules/web/src/forms/schemas/category.test.ts
+++ b/modules/web/src/forms/schemas/category.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { emptyCategoryFormState } from "@/components/categories/categoryFormState";
+import { categoryFormSchema } from "@/forms/schemas/category";
+
+describe("categoryFormSchema", () => {
+  it("accepts a minimal valid category", () => {
+    const result = categoryFormSchema.safeParse(emptyCategoryFormState({ name: "Food" }));
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid color when provided", () => {
+    const result = categoryFormSchema.safeParse(
+      emptyCategoryFormState({ name: "Food", color: "red" }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("allows empty color", () => {
+    const result = categoryFormSchema.safeParse(
+      emptyCategoryFormState({ name: "Food", color: "" }),
+    );
+    expect(result.success).toBe(true);
+  });
+});

--- a/modules/web/src/forms/schemas/category.ts
+++ b/modules/web/src/forms/schemas/category.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+import { CATEGORY_TYPE_SLUGS } from "@/lib/categoryTypes";
+
+/** UX schema for {@link CategoryFormState} — OpenAPI-aligned shape checks only. */
+export const categoryFormSchema = z.object({
+  name: z.string().trim().min(1, "Name is required").max(255),
+  description: z.string(),
+  category_type: z.enum(CATEGORY_TYPE_SLUGS),
+  parent_id: z.string(),
+  icon: z.string().max(64, "Icon must be at most 64 characters"),
+  color: z
+    .string()
+    .max(7, "Color must be at most 7 characters")
+    .refine((value) => value.trim() === "" || /^#[0-9A-Fa-f]{6}$/.test(value.trim()), {
+      message: "Color must be #RRGGBB",
+    }),
+  is_active: z.boolean(),
+});
+
+export type CategoryFormSchema = z.infer<typeof categoryFormSchema>;

--- a/modules/web/src/lib/formatDate.test.ts
+++ b/modules/web/src/lib/formatDate.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDate, formatDateTime } from "@/lib/formatDate";
+
+describe("formatDate", () => {
+  it("formats a valid ISO date with Intl", () => {
+    const formatted = formatDate("2026-01-15T12:00:00.000Z", "en-US");
+    expect(formatted).toMatch(/Jan/);
+    expect(formatted).toMatch(/15/);
+    expect(formatted).toMatch(/2026/);
+  });
+
+  it("returns the original string for invalid dates", () => {
+    expect(formatDate("not-a-date")).toBe("not-a-date");
+  });
+});
+
+describe("formatDateTime", () => {
+  it("includes a time component for valid values", () => {
+    const formatted = formatDateTime("2026-01-15T15:30:00.000Z", "en-US");
+    expect(formatted).toMatch(/2026/);
+    expect(formatted.length).toBeGreaterThan("Jan 15, 2026".length);
+  });
+
+  it("returns empty string for invalid non-string values", () => {
+    expect(formatDateTime(Number.NaN)).toBe("");
+  });
+});

--- a/modules/web/src/lib/formatDate.ts
+++ b/modules/web/src/lib/formatDate.ts
@@ -1,0 +1,27 @@
+/** Format a date for display (presentation only — no period math). */
+export function formatDate(value: string | number | Date, locale?: string): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return typeof value === "string" ? value : "";
+  }
+  try {
+    return new Intl.DateTimeFormat(locale, { dateStyle: "medium" }).format(date);
+  } catch {
+    return date.toISOString().slice(0, 10);
+  }
+}
+
+/** Format a date-time for display (presentation only). */
+export function formatDateTime(value: string | number | Date, locale?: string): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return typeof value === "string" ? value : "";
+  }
+  try {
+    return new Intl.DateTimeFormat(locale, { dateStyle: "medium", timeStyle: "short" }).format(
+      date,
+    );
+  } catch {
+    return date.toISOString();
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   modules/web:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.7.1
+        version: 5.7.1(@standard-schema/spec@1.1.0)(react-hook-form@7.84.0(react@19.2.8))(zod@4.4.3)
       '@radix-ui/react-dialog':
         specifier: ^1.1.23
         version: 1.1.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -43,6 +46,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.8(react@19.2.8)
+      react-hook-form:
+        specifier: ^7.84.0
+        version: 7.84.0(react@19.2.8)
       react-router-dom:
         specifier: ^7.18.2
         version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -55,6 +61,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -315,6 +324,84 @@ packages:
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
+  '@hookform/resolvers@5.7.1':
+    resolution: {integrity: sha512-8wS/P4UDr5sQDe4nFaV51TVyfDPrWgNIXweqG0Bs9Z5LSuzKLb+RQNPvkN2oHM5SRrJyWrVH/F+LOUcFjUyvwQ==}
+    peerDependencies:
+      '@sinclair/typebox': '>=0.25.24'
+      '@standard-schema/spec': ^1.0.0
+      '@typeschema/main': '>=0.13.7'
+      '@vinejs/vine': ^2.0.0 || ^3.0.0 || ^4.0.0
+      ajv: ^8.12.0
+      ajv-errors: ^3.0.0
+      ajv-formats: ^2.1.1
+      arktype: ^2.0.0
+      ata-validator: ^1.2.0
+      class-transformer: '>=0.4.0'
+      class-validator: '>=0.12.0'
+      computed-types: ^1.0.0
+      effect: ^3.10.3
+      fluentvalidation-ts: ^3.0.0
+      fp-ts: ^2.7.0
+      io-ts: ^2.0.0
+      joi: ^17.0.0
+      nope-validator: '>=0.12.0'
+      react-hook-form: ^7.55.0
+      superstruct: '>=0.12.0'
+      typanion: ^3.3.2
+      valibot: '>=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc'
+      vest: '>=3.0.0'
+      yup: ^1.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@sinclair/typebox':
+        optional: true
+      '@standard-schema/spec':
+        optional: true
+      '@typeschema/main':
+        optional: true
+      '@vinejs/vine':
+        optional: true
+      ajv:
+        optional: true
+      ajv-errors:
+        optional: true
+      ajv-formats:
+        optional: true
+      arktype:
+        optional: true
+      ata-validator:
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+      computed-types:
+        optional: true
+      effect:
+        optional: true
+      fluentvalidation-ts:
+        optional: true
+      fp-ts:
+        optional: true
+      io-ts:
+        optional: true
+      joi:
+        optional: true
+      nope-validator:
+        optional: true
+      superstruct:
+        optional: true
+      typanion:
+        optional: true
+      valibot:
+        optional: true
+      vest:
+        optional: true
+      yup:
+        optional: true
+      zod:
+        optional: true
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -759,6 +846,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@tailwindcss/node@4.3.3':
     resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
@@ -2022,6 +2112,12 @@ packages:
     peerDependencies:
       react: ^19.2.8
 
+  react-hook-form@7.84.0:
+    resolution: {integrity: sha512-+hWvQP6GLco56mDwrbU4XnHix8t1z90ltZsDIrREl+jnQFQxYLX8oAzqe/Xn8nHpmoXTY5M6oEXrAhbP1qevNQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
@@ -2711,6 +2807,14 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
+  '@hookform/resolvers@5.7.1(@standard-schema/spec@1.1.0)(react-hook-form@7.84.0(react@19.2.8))(zod@4.4.3)':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.84.0(react@19.2.8)
+    optionalDependencies:
+      '@standard-schema/spec': 1.1.0
+      zod: 4.4.3
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -3098,6 +3202,8 @@ snapshots:
   '@rolldown/pluginutils@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@tailwindcss/node@4.3.3':
     dependencies:
@@ -4420,6 +4526,10 @@ snapshots:
     dependencies:
       react: 19.2.8
       scheduler: 0.27.0
+
+  react-hook-form@7.84.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
 
   react-is@17.0.2: {}
 


### PR DESCRIPTION
**Branch:** `feat/PPT-055` · **Base:** `main` · **1 commit** · **24 files**

**Suggested title:** `feat/PPT-055: [web] Forms validation and loading UX standards`

## Summary

Closes the PPT-055 gap left after accounts/categories landed on ad-hoc controlled forms: install Zod + react-hook-form, ship a shared presentation kit under `modules/web/src/forms/`, and migrate account + category dialogs onto one validation and mutation-error pattern. OpenAPI write-model alignment stays UX-only — domain rules remain in `papita_txnsmodel`.

## Out of scope / Highlights

**Out of scope**

- New API endpoints or design-system primitives beyond PPT-051
- Migrating login/register, transactions/movements/bulk, or report filters onto the kit (follow-on)
- Dashboard/reports UI (PPT-054 / #119) — intentionally untouched

**Highlights**

- Documented UX standard in `modules/web/README.md`
- 422 field mapping from FastAPI `loc` + optional field maps; 429/network/5xx toast + root
- Custom `FormField` (no new shadcn Form dependency)
- `formatDate` / `formatDateTime` via `Intl` alongside existing `formatMoney`

## Changes

**Web forms kit**

- Add `zod`, `react-hook-form`, `@hookform/resolvers`
- `src/forms/`: schemas (account/category), `mapServerErrors`, `applyMutationError`, `FormField` / `FormRootError`, OpenAPI→flat field maps
- `src/lib/formatDate.ts`: presentation date helpers

**Feature migrations**

- `AccountFormDialog` / `AccountFormFields` and `CategoryFormDialog` use RHF + zodResolver
- Preserve global seed category 404 → read-only UX (inline + toast)
- Mutation submit disabled while pending / submitting

**Docs / agent memory**

- README Forms & UX standards section; AGENTS.md note
- Strata issue `20260803-03`, learning `web-forms-ux-kit`, project_state update

## File changes

<details>
<summary>File changes (24 files)</summary>

```
 .cursor/AGENTS.md                                  |   2 +-
 .strata/issues/20260803-03-ppt055-forms-ux-standards.md |  28 ++
 .strata/issues/ACTIVE.md                           |   1 +
 .strata/memory/MEMORY.md                           |   7 +-
 .strata/memory/learnings/web-forms-ux-kit.md       |  14 +
 .strata/memory/project_state.md                    |  22 +-
 modules/web/README.md                              |  34 +-
 modules/web/package.json                           |   5 +-
 modules/web/src/components/accounts/AccountFormDialog.tsx  |  66 ++--
 modules/web/src/components/accounts/AccountFormFields.tsx  | 382 +++++++++------------
 modules/web/src/components/categories/CategoryFormDialog.tsx | 163 ++++-----
 modules/web/src/forms/FormField.tsx                |  41 +++
 modules/web/src/forms/applyMutationError.ts        |  56 +++
 modules/web/src/forms/fieldMaps.ts                 |  37 ++
 modules/web/src/forms/index.ts                     |  12 +
 modules/web/src/forms/mapServerErrors.test.ts      | 103 ++++++
 modules/web/src/forms/mapServerErrors.ts           | 130 +++++++
 modules/web/src/forms/schemas/account.test.ts      |  34 ++
 modules/web/src/forms/schemas/account.ts           | 139 ++++++++
 modules/web/src/forms/schemas/category.test.ts     |  25 ++
 modules/web/src/forms/schemas/category.ts          |  21 ++
 modules/web/src/lib/formatDate.test.ts             |  28 ++
 modules/web/src/lib/formatDate.ts                  |  27 ++
 pnpm-lock.yaml                                     | 110 ++++++
 24 files changed, 1116 insertions(+), 371 deletions(-)
```

</details>

## Commits

- `80725c9` feat/PPT-055: [web] Standardize forms with Zod and RHF

## Checks, tests, and validation already done

- `pnpm --filter @papita/web exec tsc -b` — pass
- `pnpm --filter @papita/web test` — pass (87 tests)
- `pnpm --filter @papita/web lint` — pass
- Pre-commit on commit (`web-eslint`, `web-prettier`, `web-tsc`, `web-vitest-related`, strata validate, etc.) — pass
- GitHub Actions CI on this PR — not observed yet

## QA / test plan

- [ ] Create/edit an account (checking + one extension kind); confirm field validation and successful save
- [ ] Trigger a 422 (e.g. invalid payload) and confirm inline field/root errors without toast spam
- [ ] Confirm 429/unreachable API still toasts with retry guidance via `formatApiError`
- [ ] Edit a global seed category and confirm read-only 404 UX (inline + toast) still works
- [ ] Spot-check README Forms & UX standards section for accuracy

## Risks

> [!CAUTION]
>
> ### Risks
>
> - Account/category form behavior changes from `useState` to RHF — regression risk on extension blocks and omit-empty update payloads (mappers unchanged, but wiring did)
> - Ledger/auth forms remain on the old pattern until a follow-on; PPT-056 (#121) quality bar should treat kit adoption as incomplete outside accounts/categories

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - Zod schemas validate form state only; they do not re-encode `papita_txnsmodel` rules
> - Report/dashboard files intentionally left alone to avoid conflicting with PPT-054

## References

- Closes [#120](https://github.com/Elmorralito/save-ma-money/issues/120) (PPT-055)
- Parent epic [#112](https://github.com/Elmorralito/save-ma-money/issues/112) (PPT-046)
- Depends on closed PPT-051 [#116], PPT-048 [#114]

Made with [Cursor](https://cursor.com)