### PR TITLE
test/PPT-061: [web] E2E seed fixtures for Playwright critical path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ __pycache__/
 node_modules/
 modules/web/dist/
 modules/web/coverage/
+# Playwright E2E seed artifact + credentials (PPT-061 / #126)
+modules/web/e2e/.auth/
 .mypy_cache/
 .pytest_cache/
 .venv/

--- a/.strata/issues/20260803-05-ppt061-e2e-seed-fixtures.md
+++ b/.strata/issues/20260803-05-ppt061-e2e-seed-fixtures.md
@@ -1,0 +1,23 @@
+---
+id: 20260803-05
+type: task
+status: open
+severity: med
+area: modules/web
+created: 2026-08-03
+---
+
+**What:** PPT-061 [#126](https://github.com/Elmorralito/save-ma-money/issues/126) deterministic E2E seed fixtures for Playwright critical path (strategy A — API HTTP script).
+
+**Why:** Blocks reliable [#121](https://github.com/Elmorralito/save-ma-money/issues/121) Playwright gate. Fixture SSOT so `globalSetup` does not invent a second SQL seed.
+
+**Progress**
+
+- `bin/web_e2e_seed.py` / `bin/web_e2e_seed.sh`, `make web-e2e-seed`, `pnpm web:seed-e2e`
+- Artifact `modules/web/e2e/.auth/seed.json` (gitignored)
+- Docs in `modules/web/README.md` + `modules/web/e2e/README.md`
+
+**Still open / handoff**
+
+- Playwright `globalSetup` + Compose E2E CI owned by #121
+- Close #126 after PR merge; cite fixture SSOT from #121

--- a/.strata/memory/MEMORY.md
+++ b/.strata/memory/MEMORY.md
@@ -4,8 +4,8 @@ Pure hot index: live pointers + the generated rules-by-trigger table. Keep ≤80
 
 ## Live pointers
 
-- [Project state](project_state.md) — PPT-055 forms kit in progress; PPT-054 reports still open.
-- [Active issues](../issues/ACTIVE.md) — PPT-055 [#120] `20260803-04`; PPT-054 [#119] `20260803-02`.
+- [Project state](project_state.md) — PPT-061 E2E seed landed; PPT-055/054 still in flight; next #121.
+- [Active issues](../issues/ACTIVE.md) — PPT-061 [#126] `20260803-05`; PPT-055 [#120] `20260803-04`; PPT-054 [#119] `20260803-02`.
 - [Open backlog](../issues/OPEN.md) — PPT-040 Codecov; PPT-043 Redis; later PPT-046 children.
 - [Archived](../issues/archive/ARCHIVE.md) — PPT-060 [#125] `20260803-03`; PPT-053 [#118] `20260803-01`.
 

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -10,6 +10,10 @@ project**. Papita API verifies JWTs + links `users` by `sub` — it is not the I
 
 ### Last completed (this session)
 
+- **PPT-061 / #126:** E2E seed fixtures (strategy A — API HTTP script).
+  `make web-e2e-seed` / `pnpm web:seed-e2e` → `modules/web/e2e/.auth/seed.json`.
+  RESET soft-deletes baseline txns + E2E accounts (categories reused). Docs in
+  `modules/web/README.md`. Handoff: #121 `globalSetup` invokes seed only.
 - **PPT-060 / #125:** Auth edge-case MVP matrix — web README matrix + Playwright
   assumptions; API Auth cross-link; `formatApiError` confirm-email remap; Login/
   Register 429 page tests. Strata archived `20260803-03`. Password reset deferred;
@@ -33,8 +37,8 @@ project**. Papita API verifies JWTs + links `users` by `sub` — it is not the I
 - Finish #120: open PR, close GitHub issue after merge
 - Finish #119: cash-flow + trends tabs → export download + 501 UX → dashboard compose
   (balances from `listAccounts`; recent activity via `GET /transactions` from #118)
-- Then PPT-056 (#121) E2E (use PPT-060 confirmed-user assumptions); PPT-068 (#139)
-  check-email/resend; PPT-069 (#140)
+- PPT-056 (#121) Playwright gate — call `make web-e2e-seed` from `globalSetup`
+  (fixture SSOT #126 / PPT-061); PPT-068 (#139) check-email/resend; PPT-069 (#140)
 
 ### Uncommitted / staging notes
 

--- a/Makefile
+++ b/Makefile
@@ -125,3 +125,11 @@ check-types:
 
 # Full local contract refresh used after API OpenAPI-affecting changes.
 web-openapi: sync-openapi generate-types
+
+# E2E fixtures (PPT-061 / #126): HTTP seed against a running Compose API.
+# Requires: make api-all (AUTH_PROVIDER=local recommended for B0 CI).
+# Idempotent upsert; RESET=1 soft-deletes baseline txns + E2E accounts (categories reused).
+# Artifact: modules/web/e2e/.auth/seed.json (gitignored) for Playwright #121.
+RESET ?= 0
+web-e2e-seed:
+	RESET=$(RESET) /bin/bash ./bin/web_e2e_seed.sh

--- a/bin/web_e2e_seed.py
+++ b/bin/web_e2e_seed.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""Seed deterministic E2E fixtures for Playwright (PPT-061 / #126).
+
+Strategy A (locked): HTTP against a running Compose API using the Bearer token
+path. Playwright (#121) still exercises BFF cookie login in the browser.
+
+Requires ``make api-all`` (or equivalent). Default B0 path uses
+``AUTH_PROVIDER=local``. For Supabase, set ``E2E_SKIP_REGISTER=1`` and provide
+a pre-confirmed ``E2E_USER_EMAIL`` / ``E2E_USER_PASSWORD``.
+
+Writes ``modules/web/e2e/.auth/seed.json`` (gitignored) for #121 consumers.
+
+Reset semantics (``--reset`` / ``RESET=1``):
+  soft-delete baseline E2E transactions and E2E-prefixed accounts, then recreate.
+  Categories are **reused** (not soft-deleted) — recreating the same category name
+  after soft-delete can yield a phantom 201 against the unique tombstone.
+  Full tenant wipe: new ``E2E_USER_EMAIL`` or Compose volume reset.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUT = REPO_ROOT / "modules" / "web" / "e2e" / ".auth" / "seed.json"
+DEFAULT_API_BASE = "http://127.0.0.1:8000"
+
+NAME_PREFIX = "E2E "
+CHECKING_NAME = "E2E Checking"
+SAVINGS_NAME = "E2E Savings"
+# Short names avoid colliding with earlier soft-deleted "E2E Expense" tombstones.
+EXPENSE_CATEGORY_NAME = "E2E Exp"
+INCOME_CATEGORY_NAME = "E2E Inc"
+BASELINE_DESCRIPTION = "E2E baseline expense"
+BASELINE_DATE = "2026-03-01"
+
+
+class SeedError(RuntimeError):
+    """Raised when the seed cannot complete against the API."""
+
+
+def _parse_retry_after(headers: Any, default: float = 1.0) -> float:
+    """Parse ``Retry-After`` seconds from response headers."""
+    if headers is None:
+        return default
+    raw = headers.get("Retry-After")
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _decode_body(raw: str) -> Any:
+    """Decode response text as JSON when possible."""
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def _build_request_payload(
+    *,
+    token: str | None,
+    json_body: dict[str, Any] | None,
+    form_body: dict[str, str] | None,
+    headers: dict[str, str] | None,
+) -> tuple[bytes | None, dict[str, str]]:
+    """Build request body bytes and headers for ``_request``."""
+    req_headers = dict(headers or {})
+    data: bytes | None = None
+    if json_body is not None:
+        data = json.dumps(json_body).encode("utf-8")
+        req_headers["Content-Type"] = "application/json"
+    elif form_body is not None:
+        data = urllib.parse.urlencode(form_body).encode("utf-8")
+        req_headers["Content-Type"] = "application/x-www-form-urlencoded"
+    if token:
+        req_headers["Authorization"] = f"Bearer {token}"
+    return data, req_headers
+
+
+def _exchange(
+    method: str,
+    url: str,
+    *,
+    data: bytes | None,
+    headers: dict[str, str],
+) -> tuple[int, Any, float]:
+    """Execute one HTTP exchange; return status, body, and Retry-After seconds."""
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            raw = response.read().decode("utf-8")
+            return response.getcode(), _decode_body(raw), _parse_retry_after(response.headers)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8")
+        return exc.code, _decode_body(raw), _parse_retry_after(exc.headers)
+    except urllib.error.URLError as exc:
+        raise SeedError(f"Cannot reach API at {url}: {exc.reason}") from exc
+
+
+def _request(
+    method: str,
+    url: str,
+    *,
+    token: str | None = None,
+    json_body: dict[str, Any] | None = None,
+    form_body: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+    retries: int = 4,
+) -> tuple[int, Any]:
+    """Perform an HTTP request and return ``(status, parsed_json_or_text)``."""
+    data, req_headers = _build_request_payload(token=token, json_body=json_body, form_body=form_body, headers=headers)
+    last_status = 0
+    last_body: Any = None
+    for attempt in range(retries + 1):
+        status, body, retry_after = _exchange(method, url, data=data, headers=req_headers)
+        last_status, last_body = status, body
+        if status != 429 or attempt >= retries:
+            return status, body
+        time.sleep(min(max(retry_after, 0.5), 30.0) * (attempt + 1))
+    return last_status, last_body
+
+
+def _api(base: str, path: str) -> str:
+    return f"{base.rstrip('/')}{path}"
+
+
+def _require_ok(status: int, body: Any, *, expected: set[int], action: str) -> Any:
+    if status not in expected:
+        raise SeedError(f"{action} failed HTTP {status}: {body}")
+    return body
+
+
+def _list_items(base: str, token: str, path: str, *, limit: int = 100) -> list[dict[str, Any]]:
+    status, body = _request("GET", _api(base, f"{path}?limit={limit}"), token=token)
+    payload = _require_ok(status, body, expected={200}, action=f"GET {path}")
+    if not isinstance(payload, dict):
+        raise SeedError(f"Unexpected list payload for {path}: {payload}")
+    items = payload.get("items") or []
+    if not isinstance(items, list):
+        raise SeedError(f"Unexpected items for {path}: {items}")
+    return [item for item in items if isinstance(item, dict)]
+
+
+def _find_by_name(items: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    for item in items:
+        if item.get("name") != name:
+            continue
+        if item.get("active") is False or item.get("is_active") is False:
+            continue
+        if item.get("deleted_at") is not None:
+            continue
+        return item
+    return None
+
+
+def _entity_exists(base: str, token: str, path: str, entity_id: str) -> bool:
+    """Return True when GET ``path/{id}`` is 200 (guards phantom create IDs)."""
+    status, _body = _request("GET", _api(base, f"{path}/{entity_id}"), token=token)
+    return status == 200
+
+
+def _register_or_login(
+    base: str,
+    *,
+    email: str,
+    password: str,
+    username: str,
+    skip_register: bool,
+) -> tuple[str, str]:
+    """Return ``(access_token, owner_id)`` for the fixture user."""
+    if not skip_register:
+        status, body = _request(
+            "POST",
+            _api(base, "/api/v1/auth/register"),
+            json_body={
+                "email": email,
+                "password": password,
+                "username": username,
+                "display_name": "E2E Owner",
+            },
+        )
+        if status not in {201, 409, 422}:
+            raise SeedError(f"Register failed HTTP {status}: {body}")
+
+    status, body = _request(
+        "POST",
+        _api(base, "/api/v1/auth/login"),
+        form_body={"username": email, "password": password},
+    )
+    login = _require_ok(status, body, expected={200}, action="Login")
+    if not isinstance(login, dict) or "access_token" not in login:
+        raise SeedError(f"Login response missing access_token: {login}")
+    token = str(login["access_token"])
+
+    status, me = _request("GET", _api(base, "/api/v1/auth/me"), token=token)
+    me_body = _require_ok(status, me, expected={200}, action="GET /auth/me")
+    if not isinstance(me_body, dict) or "id" not in me_body:
+        raise SeedError(f"/auth/me missing id: {me_body}")
+    return token, str(me_body["id"])
+
+
+def _ensure_account(
+    base: str,
+    token: str,
+    *,
+    name: str,
+    initial_value: float,
+    force_create: bool = False,
+) -> str:
+    if not force_create:
+        accounts = _list_items(base, token, "/api/v1/accounts")
+        existing = _find_by_name(accounts, name)
+        existing_id = str(existing["id"]) if existing and existing.get("id") else None
+        if existing_id and _entity_exists(base, token, "/api/v1/accounts", existing_id):
+            return existing_id
+
+    status, body = _request(
+        "POST",
+        _api(base, "/api/v1/accounts"),
+        token=token,
+        json_body={
+            "name": name,
+            "account_kind": "other_asset",
+            "ledger_side": "asset",
+            "currency": "USD",
+            "initial_value": initial_value,
+        },
+    )
+    created = _require_ok(status, body, expected={201}, action=f"Create account {name}")
+    if not isinstance(created, dict) or "id" not in created:
+        raise SeedError(f"Create account missing id: {created}")
+    account_id = str(created["id"])
+    if not _entity_exists(base, token, "/api/v1/accounts", account_id):
+        raise SeedError(
+            f"Create account {name!r} returned id {account_id} but GET is 404 "
+            "(soft-delete unique tombstone?). Use a fresh E2E_USER_EMAIL or wipe Compose volumes."
+        )
+    return account_id
+
+
+def _ensure_category(
+    base: str,
+    token: str,
+    *,
+    name: str,
+    category_type: str,
+) -> str:
+    """Reuse an active category by name, or create one and verify GET."""
+    categories = _list_items(base, token, "/api/v1/categories")
+    existing = _find_by_name(categories, name)
+    existing_id = str(existing["id"]) if existing and existing.get("id") else None
+    if existing_id and _entity_exists(base, token, "/api/v1/categories", existing_id):
+        return existing_id
+
+    status, body = _request(
+        "POST",
+        _api(base, "/api/v1/categories"),
+        token=token,
+        json_body={"name": name, "category_type": category_type},
+    )
+    created = _require_ok(status, body, expected={201}, action=f"Create category {name}")
+    if not isinstance(created, dict) or "id" not in created:
+        raise SeedError(f"Create category missing id: {created}")
+    category_id = str(created["id"])
+    if not _entity_exists(base, token, "/api/v1/categories", category_id):
+        raise SeedError(
+            f"Create category {name!r} returned id {category_id} but GET is 404 "
+            "(likely unique constraint vs soft-deleted row). "
+            "Do not soft-delete fixture categories; use a fresh E2E_USER_EMAIL or wipe volumes."
+        )
+    return category_id
+
+
+def _ensure_baseline_expense(
+    base: str,
+    token: str,
+    *,
+    account_id: str,
+    category_id: str,
+    force_create: bool = False,
+) -> str:
+    if not force_create:
+        txns = _list_items(base, token, "/api/v1/transactions")
+        for item in txns:
+            txn_id = item.get("id")
+            if item.get("description") != BASELINE_DESCRIPTION or not txn_id:
+                continue
+            if _entity_exists(base, token, "/api/v1/transactions", str(txn_id)):
+                return str(txn_id)
+
+    idem_key = f"e2e-baseline-{account_id}-{uuid.uuid4().hex[:8]}"
+    status, body = _request(
+        "POST",
+        _api(base, "/api/v1/transactions"),
+        token=token,
+        headers={"Idempotency-Key": idem_key},
+        json_body={
+            "account_id": account_id,
+            "category_id": category_id,
+            "transaction_type": "expense",
+            "amount": 12.34,
+            "currency": "USD",
+            "description": BASELINE_DESCRIPTION,
+            "transaction_date": BASELINE_DATE,
+        },
+    )
+    created = _require_ok(status, body, expected={201}, action="Create baseline expense")
+    if not isinstance(created, dict) or "id" not in created:
+        raise SeedError(f"Baseline txn missing id: {created}")
+    return str(created["id"])
+
+
+def _soft_delete_prefixed_accounts(base: str, token: str) -> int:
+    deleted = 0
+    for item in _list_items(base, token, "/api/v1/accounts"):
+        name = item.get("name")
+        item_id = item.get("id")
+        if not isinstance(name, str) or not name.startswith(NAME_PREFIX) or not item_id:
+            continue
+        status, body = _request("DELETE", _api(base, f"/api/v1/accounts/{item_id}"), token=token)
+        if status not in {204, 404}:
+            raise SeedError(f"DELETE account {item_id} failed HTTP {status}: {body}")
+        deleted += 1
+        time.sleep(0.15)
+    return deleted
+
+
+def _soft_delete_baseline_txns(base: str, token: str) -> int:
+    deleted = 0
+    for item in _list_items(base, token, "/api/v1/transactions"):
+        if item.get("description") != BASELINE_DESCRIPTION or not item.get("id"):
+            continue
+        status, body = _request(
+            "DELETE",
+            _api(base, f"/api/v1/transactions/{item['id']}"),
+            token=token,
+        )
+        if status not in {204, 404}:
+            raise SeedError(f"DELETE transaction failed HTTP {status}: {body}")
+        deleted += 1
+        time.sleep(0.15)
+    return deleted
+
+
+def _probe_live(base: str) -> None:
+    status, body = _request("GET", _api(base, "/api/v1/health/live"))
+    if status != 200:
+        raise SeedError(f"API not healthy at {base} (HTTP {status}: {body}). Run: make api-all")
+
+
+def seed(*, api_base: str, out_path: Path, reset: bool) -> dict[str, Any]:
+    """Create or refresh fixture data and return the seed artifact dict."""
+    email = os.environ.get("E2E_USER_EMAIL", "e2e.owner@example.local")
+    password = os.environ.get("E2E_USER_PASSWORD", "SecurePass1!")
+    username = os.environ.get("E2E_USER_USERNAME", "e2e_owner")
+    skip_register = os.environ.get("E2E_SKIP_REGISTER", "").lower() in {"1", "true", "yes"}
+
+    _probe_live(api_base)
+    token, owner_id = _register_or_login(
+        api_base,
+        email=email,
+        password=password,
+        username=username,
+        skip_register=skip_register,
+    )
+
+    if reset:
+        _soft_delete_baseline_txns(api_base, token)
+        _soft_delete_prefixed_accounts(api_base, token)
+        # Categories intentionally kept — soft-delete + same-name create is unsafe.
+
+    checking_id = _ensure_account(api_base, token, name=CHECKING_NAME, initial_value=1_000.0, force_create=reset)
+    savings_id = _ensure_account(api_base, token, name=SAVINGS_NAME, initial_value=500.0, force_create=reset)
+    expense_category_id = _ensure_category(api_base, token, name=EXPENSE_CATEGORY_NAME, category_type="expense")
+    income_category_id = _ensure_category(api_base, token, name=INCOME_CATEGORY_NAME, category_type="income")
+    baseline_txn_id = _ensure_baseline_expense(
+        api_base,
+        token,
+        account_id=checking_id,
+        category_id=expense_category_id,
+        force_create=reset,
+    )
+
+    artifact = {
+        "apiBase": api_base,
+        "email": email,
+        "password": password,
+        "username": username,
+        "ownerId": owner_id,
+        "accountIds": {
+            "checking": checking_id,
+            "savings": savings_id,
+        },
+        "accountNames": {
+            "checking": CHECKING_NAME,
+            "savings": SAVINGS_NAME,
+        },
+        "categoryIds": {
+            "expense": expense_category_id,
+            "income": income_category_id,
+        },
+        "categoryNames": {
+            "expense": EXPENSE_CATEGORY_NAME,
+            "income": INCOME_CATEGORY_NAME,
+        },
+        "baselineTxnId": baseline_txn_id,
+        "baselineDescription": BASELINE_DESCRIPTION,
+        "namePrefix": NAME_PREFIX.strip(),
+        "seedId": uuid.uuid4().hex,
+    }
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(artifact, indent=2) + "\n", encoding="utf-8")
+    return artifact
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(description="Seed Playwright E2E fixtures (PPT-061).")
+    parser.add_argument(
+        "--api-base",
+        default=os.environ.get("E2E_API_BASE", DEFAULT_API_BASE),
+        help="Running API origin (default E2E_API_BASE or http://127.0.0.1:8000)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path(os.environ.get("E2E_SEED_OUT", str(DEFAULT_OUT))),
+        help="Path for seed.json artifact",
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Soft-delete baseline txns + E2E accounts, then recreate (categories reused)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        artifact = seed(api_base=args.api_base, out_path=args.out, reset=args.reset)
+    except SeedError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"E2E seed OK → {args.out}")
+    print(
+        json.dumps(
+            {
+                "ownerId": artifact["ownerId"],
+                "email": artifact["email"],
+                "accountIds": artifact["accountIds"],
+                "categoryIds": artifact["categoryIds"],
+                "categoryNames": artifact["categoryNames"],
+                "baselineTxnId": artifact["baselineTxnId"],
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/web_e2e_seed.sh
+++ b/bin/web_e2e_seed.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090,SC1091
+# PPT-061 / #126: deterministic E2E seed against a running B0 Compose API.
+#
+# Usage:
+#   make api-all
+#   make web-e2e-seed              # idempotent upsert
+#   make web-e2e-seed RESET=1      # soft-delete baseline txns + E2E accounts; categories reused
+#
+# Env (optional):
+#   E2E_API_BASE, E2E_USER_EMAIL, E2E_USER_PASSWORD, E2E_USER_USERNAME
+#   E2E_SEED_OUT, E2E_SKIP_REGISTER=1 (pre-provisioned Supabase user)
+
+set -euo pipefail
+
+PROJECT_PATH="$(dirname "$(dirname "$(realpath "$0")")")"
+cd "${PROJECT_PATH}"
+
+PAPITA_ENV_NAME="${PAPITA_ENV:-local}"
+RESET_FLAG="${RESET:-0}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env)
+      PAPITA_ENV_NAME="$2"
+      shift 2
+      ;;
+    --reset)
+      RESET_FLAG="1"
+      shift
+      ;;
+    --api-base)
+      export E2E_API_BASE="$2"
+      shift 2
+      ;;
+    --out)
+      export E2E_SEED_OUT="$2"
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+# shellcheck source=bin/utils.sh
+source "${PROJECT_PATH}/bin/utils.sh"
+
+export PAPITA_ENV="${PAPITA_ENV_NAME}"
+ENV_FILE="$(resolve_papita_env_file "${PAPITA_ENV}")" || exit 1
+
+if [[ -f "${ENV_FILE}" ]]; then
+  log INFO "Loading env from ${ENV_FILE} (PAPITA_ENV=${PAPITA_ENV})"
+  set -a
+  # shellcheck disable=SC1090
+  source "${ENV_FILE}"
+  set +a
+fi
+
+# Prefer Compose publish port when E2E_API_BASE is unset.
+if [[ -z "${E2E_API_BASE:-}" ]]; then
+  API_PORT="$(grep -E '^API_PORT=' "${ENV_FILE}" 2>/dev/null | cut -d= -f2 || true)"
+  API_PORT="${API_PORT:-8000}"
+  export E2E_API_BASE="http://127.0.0.1:${API_PORT}"
+fi
+
+ARGS=(python3 "${PROJECT_PATH}/bin/web_e2e_seed.py" --api-base "${E2E_API_BASE}")
+if [[ "${RESET_FLAG}" == "1" ]]; then
+  ARGS+=(--reset)
+  log INFO "RESET=1 — soft-deleting baseline txns + E2E accounts (categories reused)"
+fi
+if [[ -n "${E2E_SEED_OUT:-}" ]]; then
+  ARGS+=(--out "${E2E_SEED_OUT}")
+fi
+
+log INFO "Seeding E2E fixtures against ${E2E_API_BASE}"
+"${ARGS[@]}"

--- a/modules/web/README.md
+++ b/modules/web/README.md
@@ -37,6 +37,7 @@ make web-dev      # Vite on :5173
 | `make sync-openapi`   | —                         | Refresh `openapi/openapi.json` from the FastAPI app (offline)       |
 | `make check-openapi`  | —                         | Fail if the committed artifact drifts from a fresh offline dump     |
 | `make web-openapi`    | —                         | `sync-openapi` + `generate-types` (after API schema changes)        |
+| `make web-e2e-seed`   | `pnpm web:seed-e2e`       | Seed Playwright fixtures against a running API (PPT-061 / #126)     |
 
 Package-local: `pnpm --filter @papita/web <script>`.
 
@@ -122,6 +123,46 @@ MVP vs deferred for Supabase Auth behind the BFF. Cookie posture above is unchan
 - Default E2E / B0 path uses a **confirmed** (or confirm-N/A) user: CI `AUTH_PROVIDER=local`, or local Supabase with Confirm email OFF / Admin auto-confirm so register → login succeeds without inbox access.
 - Unconfirmed-user journeys (pending screen, resend, SMTP) are **out of Playwright MVP until #139** — do not write e2e that depends on confirmation email delivery.
 - Auth **429** is covered at unit level (mapper + login/register pages); e2e rate-limit is optional later.
+- **Fixture SSOT:** [#126](https://github.com/Elmorralito/save-ma-money/issues/126) / PPT-061 — see [E2E fixtures](#e2e-fixtures-ppt-061--126) below. `globalSetup` must call `make web-e2e-seed` (do not invent a second SQL seed).
+
+## E2E fixtures (PPT-061 / #126)
+
+**Locked strategy: A — API seed script** (HTTP against running Compose API). Playwright `globalSetup` (#121) only invokes the seed; SQL dumps are out of scope.
+
+| Piece       | Location                                           | Notes                                                                 |
+| ----------- | -------------------------------------------------- | --------------------------------------------------------------------- |
+| Runner      | [`bin/web_e2e_seed.py`](../../bin/web_e2e_seed.py) | Bearer register/login → accounts → categories → optional baseline txn |
+| Wrapper     | [`bin/web_e2e_seed.sh`](../../bin/web_e2e_seed.sh) | Loads `environments/<env>/.env`; supports `RESET=1`                   |
+| Artifact    | `modules/web/e2e/.auth/seed.json`                  | **Gitignored** — email/password + IDs for #121                        |
+| Make / pnpm | `make web-e2e-seed` / `pnpm web:seed-e2e`          | Requires healthy API (`make api-all`)                                 |
+
+**Why not B/C:** Seed logic must not live only inside Playwright (harder to run standalone). SQL fixtures bypass API validation and do not create auth users correctly for local/Supabase.
+
+**Seed contract (owner-scoped, `E2E ` name prefix):**
+
+| Entity       | Stable name                                          | Purpose                                          |
+| ------------ | ---------------------------------------------------- | ------------------------------------------------ |
+| User         | `E2E_USER_EMAIL` (default `e2e.owner@example.local`) | Fixture tenant                                   |
+| Accounts     | `E2E Checking`, `E2E Savings`                        | Expense source + transfer destination            |
+| Categories   | `E2E Exp`, `E2E Inc`                                 | Ledger + report UX                               |
+| Baseline txn | description `E2E baseline expense`                   | Non-empty spending report before UI creates more |
+
+**Commands:**
+
+```bash
+make api-all
+make web-e2e-seed              # idempotent: create missing rows only
+make web-e2e-seed RESET=1      # soft-delete baseline txns + E2E accounts; recreate; categories reused
+pnpm web:seed-e2e              # same as make (honors RESET=1 env)
+```
+
+`RESET=1` does **not** soft-delete categories — same-name create after soft-delete can return a phantom 201 against the unique tombstone. Full wipe: new `E2E_USER_EMAIL` or Compose volume reset.
+
+**Env (optional):** `E2E_API_BASE`, `E2E_USER_EMAIL`, `E2E_USER_PASSWORD`, `E2E_USER_USERNAME`, `E2E_SEED_OUT`, `E2E_SKIP_REGISTER=1` (pre-provisioned Supabase user — skip register, login only).
+
+**Auth modes:** Prefer `AUTH_PROVIDER=local` for B0 / CI E2E (no Supabase secrets). Bearer path seeds domain data; Playwright still logs in via BFF cookies in the browser. Token clients (`make auth-smoke`) coexist unchanged.
+
+**CI placement:** Keep PR [`web-ci.yml`](../../.github/workflows/web-ci.yml) Node-only. Compose seed + Playwright belong in a separate / nightly `web-e2e` gate under [#121](https://github.com/Elmorralito/save-ma-money/issues/121) — not on every path-filtered web PR.
 
 ## Vite `/api` proxy
 

--- a/modules/web/e2e/.gitignore
+++ b/modules/web/e2e/.gitignore
@@ -1,0 +1,3 @@
+# Seed credentials / IDs written by `make web-e2e-seed` (PPT-061 / #126).
+# Never commit passwords or seed.json.
+.auth/

--- a/modules/web/e2e/README.md
+++ b/modules/web/e2e/README.md
@@ -1,0 +1,12 @@
+# E2E fixtures (PPT-061 / #126)
+
+Fixture SSOT for Playwright critical-path data. Seed strategy is **API HTTP script**
+(option A) — see [`../README.md`](../README.md#e2e-fixtures-ppt-061--126).
+
+```bash
+make api-all
+make web-e2e-seed              # or: pnpm web:seed-e2e
+make web-e2e-seed RESET=1      # baseline txns + E2E accounts; categories reused
+```
+
+Artifact (gitignored): `.auth/seed.json`. Playwright wiring lives in [#121](https://github.com/Elmorralito/save-ma-money/issues/121) (`globalSetup` should invoke this command only — do not invent a second SQL seed).

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "web:test": "pnpm --filter @papita/web test",
     "web:build": "pnpm --filter @papita/web build",
     "web:generate-types": "pnpm --filter @papita/web generate-types",
-    "web:check-types": "pnpm --filter @papita/web check-types"
+    "web:check-types": "pnpm --filter @papita/web check-types",
+    "web:seed-e2e": "bash ./bin/web_e2e_seed.sh"
   }
 }


### PR DESCRIPTION
**Branch:** `test/PPT-061` · **Base:** `main` · **1 commit** · **11 files**

**Suggested title:** `test/PPT-061: [web] E2E seed fixtures for Playwright critical path`

## Summary

Adds a deterministic B0 HTTP seed so Playwright critical journeys (auth → account → expense → transfer → report) can start from clean Compose without manual UI setup. Locks **strategy A** (API seed script): `make web-e2e-seed` / `pnpm web:seed-e2e` provision an owner-scoped fixture user, two accounts, expense/income categories, and a baseline expense, writing gitignored `modules/web/e2e/.auth/seed.json` for [#121](https://github.com/Elmorralito/save-ma-money/issues/121).

## Out of scope / Highlights

**Out of scope**

- Playwright config / `globalSetup` / critical-path specs ([#121](https://github.com/Elmorralito/save-ma-money/issues/121))
- Compose E2E CI workflow (documentedly separate/nightly under #121 — keep PR `web-ci` Node-only)
- Extracting shared helpers from `modules/api/tests` live-DB suites
- Fixing category soft-delete + same-name recreate API tombstone behavior

**Highlights**

- Idempotent upsert + documented `RESET=1` (baseline txns + E2E accounts; categories reused)
- Create responses GET-verified; HTTP 429 retried with `Retry-After`
- README locks strategy A vs Playwright-only / SQL fixtures; cites #126 as fixture SSOT for #121

## Changes

**Ops / seed**

- `bin/web_e2e_seed.py` + `bin/web_e2e_seed.sh`: Bearer register/login against running API; stable `E2E ` names; artifact under `modules/web/e2e/.auth/`
- `Makefile` `web-e2e-seed`; root `pnpm web:seed-e2e`
- `.gitignore` + `modules/web/e2e/.gitignore`: never commit seed credentials/artifact

**Docs / memory**

- `modules/web/README.md` + `modules/web/e2e/README.md`: strategy, contract, env knobs (`E2E_*`), CI placement
- `.strata` issue `20260803-05` + project_state / MEMORY pointers for PPT-061 → #121 handoff

## File changes

<details>
<summary>File changes (~11 files)</summary>

```
 .gitignore                                         |   2 +
 .../issues/20260803-05-ppt061-e2e-seed-fixtures.md |  23 +
 .strata/memory/MEMORY.md                           |   4 +-
 .strata/memory/project_state.md                    |   8 +-
 Makefile                                           |   8 +
 bin/web_e2e_seed.py                                | 478 +++++++++++++++++++++
 bin/web_e2e_seed.sh                                |  77 ++++
 modules/web/README.md                              |  41 ++
 modules/web/e2e/.gitignore                         |   3 +
 modules/web/e2e/README.md                          |  12 +
 package.json                                       |   3 +-
 11 files changed, 654 insertions(+), 5 deletions(-)
```

</details>

## Commits

- `a31cf1b` test/PPT-061: [web] Add E2E seed fixtures for Playwright critical path

## Checks, tests, and validation already done

- Pre-commit on commit: black, isort, flake8, pylint, mypy, ShellCheck, strata validate, web prettier — **pass**
- Local against Compose API (`make api-all` already healthy): `make web-e2e-seed` (idempotent re-run) and `make web-e2e-seed RESET=1` — **pass**
- GitHub Actions / full CI on this PR — **not observed yet**

## QA / test plan

- [ ] Fresh clone path: `make api-all` → `make web-e2e-seed` → confirm `modules/web/e2e/.auth/seed.json` exists and is gitignored
- [ ] Re-run `make web-e2e-seed` without `RESET` keeps stable account/category IDs
- [ ] `make web-e2e-seed RESET=1` recreates accounts + baseline txn; categories reused
- [ ] With `AUTH_PROVIDER=local`, register/login path succeeds without Supabase secrets
- [ ] Confirm PR `web-ci` still Node-only (no Compose seed job introduced here)
- [ ] After merge: update [#121](https://github.com/Elmorralito/save-ma-money/issues/121) to cite #126 as fixture SSOT; close [#126](https://github.com/Elmorralito/save-ma-money/issues/126)

## Risks

> [!CAUTION]
>
> ### Risks
>
> - Seed defaults assume a reachable API (`E2E_API_BASE` / Compose publish port). Operators must run `make api-all` first.
> - Prefer `AUTH_PROVIDER=local` for B0/CI E2E. Supabase path needs a pre-confirmed user and `E2E_SKIP_REGISTER=1` (or Confirm email OFF / auto-confirm).
> - Override `E2E_USER_PASSWORD` via env in shared CI; do not commit `seed.json`.

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - `RESET=1` does **not** soft-delete fixture categories — same-name recreate after soft-delete can return a phantom 201 against unique tombstones. Full wipe: new `E2E_USER_EMAIL` or Compose volume reset.
> - Heavy RESET churn can hit API rate limits; the seed retries 429s but is not a load tool.
> - Playwright wiring is intentionally deferred to #121 (`globalSetup` should only invoke this command).

## References

- Closes [#126](https://github.com/Elmorralito/save-ma-money/issues/126) (PPT-061)
- Parent epic: [#112](https://github.com/Elmorralito/save-ma-money/issues/112) (PPT-046)
- Downstream: [#121](https://github.com/Elmorralito/save-ma-money/issues/121) (PPT-056 Playwright gate — fixture SSOT)
- Related auth assumptions: [#125](https://github.com/Elmorralito/save-ma-money/issues/125) (PPT-060)

Made with [Cursor](https://cursor.com)