### PR TITLE
docs/PPT-058: [web] Document modules/web in monorepo indexes

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -25,14 +25,15 @@ Code-style enforcement stays in [`.cursor/rules/gen-custom/`](rules/gen-custom/)
 
 ## What this repo is
 
-**save-ma-money** (also referred to as _save-ma-finances_ in README copy) is a Poetry monorepo for Papita financial transaction data: type-safe persistence, migrations, and a FastAPI REST surface.
+**save-ma-money** (also referred to as _save-ma-finances_ in README copy) is a Poetry + pnpm monorepo for Papita financial transaction data: type-safe persistence, migrations, a FastAPI REST surface, and a presentation-only React SPA.
 
 | Goal            | Detail                                                                                                                                                                                                                                                                                                                                                                                                              |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Primary outcome | Auditable PostgreSQL-backed financial data with tested model layer and shippable API ([#25](https://github.com/Elmorralito/save-ma-money/issues/25))                                                                                                                                                                                                                                                                |
-| Active packages | `papita-transactions-model` → import `papita_txnsmodel` (`modules/model`, PyPI); `papita-transactions-api` → import `papita_txnsapi` (`modules/api`)                                                                                                                                                                                                                                                                |
+| Primary outcome | Auditable PostgreSQL-backed financial data with tested model layer, shippable API ([#25](https://github.com/Elmorralito/save-ma-money/issues/25)), and web client ([#112](https://github.com/Elmorralito/save-ma-money/issues/112))                                                                                                                                                                                 |
+| Active packages | `papita-transactions-model` → import `papita_txnsmodel` (`modules/model`, PyPI); `papita-transactions-api` → import `papita_txnsapi` (`modules/api`); `@papita/web` (`modules/web`, pnpm — **no JS domain logic**)                                                                                                                                                                                                  |
 | Database        | **PostgreSQL only** ([#31](https://github.com/Elmorralito/save-ma-money/issues/31)). Do not add DuckDB URLs or dialect work.                                                                                                                                                                                                                                                                                        |
 | Auth direction  | **Supabase project owns user management + Auth** (PPT-039 / [#49](https://github.com/Elmorralito/save-ma-money/issues/49)): register/login via Supabase Auth; API verifies JWKS and maps `sub` → `users.id`. Local HS256 is **tests only** (`AUTH_PROVIDER=local`). Compose must inject `SUPABASE_*`. See `docs/issues/README.md#part-iv--ppt-039-supabase-auth-reissue-49` and learning `supabase-auth-ownership`. |
+| Web epic        | PPT-046 / [#112](https://github.com/Elmorralito/save-ma-money/issues/112) — index in [`docs/issues/README.md` Part VII](../docs/issues/README.md#part-vii--ppt-046-web-spa-epic-112); setup SSOT [`modules/web/README.md`](../modules/web/README.md)                                                                                                                                                                |
 
 ---
 
@@ -40,7 +41,8 @@ Code-style enforcement stays in [`.cursor/rules/gen-custom/`](rules/gen-custom/)
 
 ```
 save-ma-money/
-├── pyproject.toml              # workspace root (package-mode = false)
+├── pyproject.toml              # Poetry workspace root (package-mode = false)
+├── pnpm-workspace.yaml         # Node workspace → modules/web
 ├── modules/
 │   ├── model/                  # papita_txnsmodel — domain + Alembic
 │   │   ├── src/papita_txnsmodel/
@@ -51,26 +53,32 @@ save-ma-money/
 │   │   │   └── database/       # SQLDatabaseConnector, upsert helpers
 │   │   ├── alembic/            # migrations (alembic.ini in module root)
 │   │   └── tests/
-│   └── api/                    # papita_txnsapi — FastAPI MVP (PPT-032 epic)
-│       └── src/papita_txnsapi/
-│           ├── main.py         # create_app, lifespan, ASGI app
-│           ├── config/         # settings, environment, logger
-│           ├── core/           # security, redis, rate_limit, db_health, …
-│           ├── dependencies/   # auth, pagination, services, redis
-│           ├── routers/v1/     # health, auth, accounts, categories, txns, movements, reports, budgets
-│           ├── schemas/        # request/response, query_params, converters
-│           └── middleware/
+│   ├── api/                    # papita_txnsapi — FastAPI MVP (PPT-032 epic)
+│   │   └── src/papita_txnsapi/
+│   │       ├── main.py         # create_app, lifespan, ASGI app
+│   │       ├── config/         # settings, environment, logger
+│   │       ├── core/           # security, redis, rate_limit, db_health, …
+│   │       ├── dependencies/   # auth, pagination, services, redis
+│   │       ├── routers/v1/     # health, auth, accounts, categories, txns, movements, reports, budgets
+│   │       ├── schemas/        # request/response, query_params, converters
+│   │       └── middleware/
+│   └── web/                    # @papita/web — Vite + React SPA (PPT-046 / #112)
+│       ├── README.md           # Node 22 + pnpm setup SSOT
+│       ├── openapi/            # committed OpenAPI artifact (strategy B)
+│       └── src/                # presentation only — no domain logic
 ├── environments/               # PAPITA_ENV profiles (local|staging|production)
-├── bin/                        # alembic.sh, test.sh, smokes, utils.sh
+├── bin/                        # alembic.sh, test.sh, smokes, utils.sh, web_e2e_seed.*
 ├── docker/                     # database/, api/, redis/, docker-compose.yml
-├── docs/design/ · docs/issues/ # human design program (PPT-031)
+├── docs/design/ · docs/issues/ # human design program (PPT-031) + web epic Part VII
 ├── .cursor/                    # adapters, gen-custom rules, skills
 ├── .agents/                    # symlinks to .cursor/ adapters (Codex)
 ├── .strata/                    # agent memory (hot/warm/cold tiers)
-└── .github/workflows/          # CI (quality, security, migrations, strata, publish)
+└── .github/workflows/          # CI (quality, security, migrations, strata, web-ci, publish)
 ```
 
 Domain entities in the model layer include **accounts**, **transactions**, **categories**, **users**, and account extension tables. Canonical B0 API start: `make api-up` (uvicorn in-container; see ARCHITECTURE Part IX). Full local stack + health wait: `make api-all` (preferred before `make web-dev`).
+
+**Web setup (pnpm ≠ Poetry):** Node **22** + pnpm **9** via root `pnpm-workspace.yaml` / `packageManager`. Install with `pnpm install` (not `poetry install`). Day-to-day: `make web-dev` / `web-lint` / `web-test` / `web-build`. Do **not** port `papita_txnsmodel` rules into TypeScript — UI + TanStack Query + BFF session only. SSOT: [`modules/web/README.md`](../modules/web/README.md). Field RUM / Sentry deferred post-MVP; lab Lighthouse/CWV only in PPT-056 / [#121](https://github.com/Elmorralito/save-ma-money/issues/121).
 
 **Web OpenAPI types (PPT-065):** strategy **B** — committed `modules/web/openapi/openapi.json` + `openapi-typescript` → `modules/web/src/types/api.d.ts`. After API/model OpenAPI-affecting changes run `make web-openapi`. CI: `web-ci.yml` (`check-types`) + `openapi-contract.yml` (artifact vs offline `app.openapi()`; paths include API src + model `model/`/`access/`). Exporter normalizes `info.version`. See `modules/web/README.md`.
 
@@ -130,16 +138,20 @@ Always set `DATABASE_URL` to a PostgreSQL URL.
 
 ## Setup, test, and quality
 
-Python **3.12** recommended. Poetry **2.1.3** (matches CI).
+Python **3.12** recommended. Poetry **2.1.3** (matches CI). Web: Node **22** + pnpm **9** (separate toolchain; see above).
 
 ```bash
-# Install workspace (path deps: model + api)
+# Install Python workspace (path deps: model + api)
 poetry install --no-interaction
+
+# Install web workspace (modules/web) — does not replace Poetry
+pnpm install
 
 # Full local gate (mirrors CI quality-control)
 pre-commit run --all-files
 poetry run pytest
 /bin/bash ./bin/test.sh
+make web-lint && make web-test   # Node gate locally; web-ci.yml in Actions
 
 # Supply chain (poetry check, version metadata, pip-audit)
 /bin/bash .github/scripts/supply_chain_check.sh
@@ -150,7 +162,7 @@ poetry run pytest
 
 Coverage output: `docs/coverage.xml` from `--cov=modules/{model,api}/src` (Codecov-aligned). B0 CI uses `AUTH_PROVIDER=local` against Docker Postgres. **Supabase is Auth-only** (users/tokens) — validate with `make auth-smoke`; do not treat Supabase PG/pooler as an epic or PPT-040 gate. Pre-commit: [`.pre-commit-config.yaml`](../.pre-commit-config.yaml).
 
-**Note:** `poetry.lock` is gitignored — CI resolves deps via `poetry install` at run time.
+**Note:** `poetry.lock` is gitignored — CI resolves deps via `poetry install` at run time. Web `pnpm-lock.yaml` **is** committed.
 
 **Local pre-commit hooks (not CI):** `strata-validate` and `mcp-config-validate` run on `git commit`; staging `modules/web/**` also runs `web-eslint` / `web-prettier` / `web-tsc` / `web-vitest-related` (requires `pnpm install`). GitHub Actions skips those local hooks (`strata-check.yml` / `web-ci.yml` are the CI gates).
 
@@ -211,7 +223,8 @@ Use the right tier for the question:
 | Auth contract                | [`docs/design/ARCHITECTURE.md#part-vi--auth-contract-ppt-031-track-e`](../docs/design/ARCHITECTURE.md#part-vi--auth-contract-ppt-031-track-e)                                                        |
 | API ↔ model mapping          | [`docs/design/ARCHITECTURE.md#part-iv--api--model-mapping-ppt-031-c-33`](../docs/design/ARCHITECTURE.md#part-iv--api--model-mapping-ppt-031-c-33)                                                    |
 | Target REST contract         | [`modules/api/README.md`](../modules/api/README.md)                                                                                                                                                  |
-| Issue briefs                 | [`docs/issues/README.md`](../docs/issues/README.md) (merged SSOT; Parts I–VI)                                                                                                                        |
+| Issue briefs                 | [`docs/issues/README.md`](../docs/issues/README.md) (merged SSOT; Parts I–VII incl. PPT-046 web epic)                                                                                                |
+| Web SPA setup / no domain JS | [`modules/web/README.md`](../modules/web/README.md) · epic [#112](https://github.com/Elmorralito/save-ma-money/issues/112)                                                                           |
 | Post-MVP hardening / uvicorn | [`ARCHITECTURE.md` Part VIII](../docs/design/ARCHITECTURE.md#part-viii--post-mvp-api-hardening-ppt-044-89) · [Part IX](../docs/design/ARCHITECTURE.md#part-ix--uvicorn-process-packaging-ppt-045-93) |
 | Human README                 | [`README.md`](../README.md)                                                                                                                                                                          |
 | CI workflows & scripts       | [`.github/CI.md`](../.github/CI.md)                                                                                                                                                                  |

--- a/.cursor/CLAUDE.md
+++ b/.cursor/CLAUDE.md
@@ -10,16 +10,17 @@ Project memory is repo-owned under `.strata/` (strata format, `layout_version: 3
 
 ## Claude Code quick context
 
-| Topic        | Summary                                                                                                                                                                                                            |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Repo         | Python 3.12 Poetry monorepo — financial transaction data                                                                                                                                                           |
-| Packages     | `papita-transactions-model` / `papita_txnsmodel`; `papita-transactions-api` / `papita_txnsapi` (MVP routers wired)                                                                                                 |
-| DB           | PostgreSQL / schema `papita_transactions` only                                                                                                                                                                     |
-| API status   | Runnable app: health, auth, accounts, categories, transactions, movements, reports (+ budgets 501) ([#42](https://github.com/Elmorralito/save-ma-money/issues/42))                                                 |
-| Active work  | PPT-032 epic [#42](https://github.com/Elmorralito/save-ma-money/issues/42) close-out; open post-MVP PPT-043 Redis [#83](https://github.com/Elmorralito/save-ma-money/issues/83) (PPT-044/#89 + PPT-045/#93 closed) |
-| Design docs  | `docs/design/` (PPT-031 program), `docs/issues/` (briefs)                                                                                                                                                          |
-| Agent memory | `.strata/` — use strata plugin commands below                                                                                                                                                                      |
-| Adapters     | Canonical: `.cursor/AGENTS.md` + `.cursor/CLAUDE.md`; Strata validates `.agents/` symlinks                                                                                                                         |
+| Topic        | Summary                                                                                                                                                                                                                            |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Repo         | Python 3.12 Poetry + Node 22/pnpm monorepo — financial transaction data                                                                                                                                                            |
+| Packages     | `papita_txnsmodel`; `papita_txnsapi` (MVP routers); `@papita/web` (`modules/web` — presentation only, **no JS domain logic**)                                                                                                      |
+| DB           | PostgreSQL / schema `papita_transactions` only                                                                                                                                                                                     |
+| API status   | Runnable app: health, auth, accounts, categories, transactions, movements, reports (+ budgets 501) ([#42](https://github.com/Elmorralito/save-ma-money/issues/42))                                                                 |
+| Web epic     | PPT-046 / [#112](https://github.com/Elmorralito/save-ma-money/issues/112) — setup [`modules/web/README.md`](../modules/web/README.md); index [`docs/issues` Part VII](../docs/issues/README.md#part-vii--ppt-046-web-spa-epic-112) |
+| Active work  | PPT-032 epic [#42](https://github.com/Elmorralito/save-ma-money/issues/42) close-out; open post-MVP PPT-043 Redis [#83](https://github.com/Elmorralito/save-ma-money/issues/83) (PPT-044/#89 + PPT-045/#93 closed)                 |
+| Design docs  | `docs/design/` (PPT-031 program), `docs/issues/` (briefs incl. PPT-046 Part VII)                                                                                                                                                   |
+| Agent memory | `.strata/` — use strata plugin commands below                                                                                                                                                                                      |
+| Adapters     | Canonical: `.cursor/AGENTS.md` + `.cursor/CLAUDE.md`; Strata validates `.agents/` symlinks                                                                                                                                         |
 
 ---
 

--- a/.cursor/rules/gen-custom/project_structure.mdc
+++ b/.cursor/rules/gen-custom/project_structure.mdc
@@ -13,14 +13,17 @@ NOTE: This rule file was generated or updated by the `/rules-architect` command.
 
 ### Monorepo Organization
 
-Poetry workspace (`package-mode = false` at root) with active packages:
+Poetry workspace (`package-mode = false` at root) for Python packages, plus a pnpm workspace for the web SPA:
 
 | Tree path | Distribution name | Import root | Status |
 | --------- | ----------------- | ----------- | ------ |
 | `modules/model/` | `papita-transactions-model` | `papita_txnsmodel` | Active; published to PyPI / TestPyPI |
 | `modules/api/` | `papita-transactions-api` | `papita_txnsapi` | Active FastAPI MVP (PPT-032) |
+| `modules/web/` | `@papita/web` | (Vite/React app; `@/*` alias) | Active SPA (PPT-046 / #112); presentation only — **no JS domain logic** |
 
 **Database:** PostgreSQL only. Schema: `papita_transactions`.
+
+**Web toolchain:** Node 22 + pnpm 9 (`pnpm-workspace.yaml` at repo root). Separate from Poetry — `pnpm install` / `make web-dev`. Setup SSOT: `modules/web/README.md`.
 
 ### Model module layout
 
@@ -55,6 +58,19 @@ modules/api/
 ```
 
 **API layer rule:** routers validate auth, map schemas, and delegate to `papita_txnsmodel` services — no business logic in routers.
+
+### Web module layout
+
+```
+modules/web/
+├── src/                 # React app (pages, components, api/, forms/)
+├── openapi/             # committed openapi.json (typegen strategy B)
+├── e2e/                 # Playwright + seed helpers
+├── package.json         # @papita/web
+└── README.md            # Node/pnpm setup, BFF, quality
+```
+
+**Web layer rule:** UI + TanStack Query + BFF cookie session only. Do not reimplement `papita_txnsmodel` services in TypeScript. nginx Compose packaging is PPT-057 / #122.
 
 ### Import Paths
 
@@ -93,6 +109,7 @@ Canonical B0 API start: `make api-up` (uvicorn in-container). See `ARCHITECTURE.
 | ---- | ----- |
 | Human front door | Root `README.md` |
 | API reference | `modules/api/README.md` |
+| Web SPA | `modules/web/README.md` (epic PPT-046 / #112; issues index Part VII) |
 | Design program | `docs/design/` (`ARCHITECTURE.md`, `README.md`) |
 | Issue briefs | `docs/issues/README.md` (merged SSOT; no separate PPT-044/045 brief files) |
 | Agent ops | `.cursor/AGENTS.md` |

--- a/.cursor/skills/pr-description/SKILL.md
+++ b/.cursor/skills/pr-description/SKILL.md
@@ -72,11 +72,11 @@ do not quote the secret in the PR text.
 **Structure SSOT:** [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md).
 Fill that template (do not invent alternate section orders or drop required headings).
 
-| Source                 | Path / pattern                                                                                                                                                                                            |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| GitHub PR template     | [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md) — **required structure**                                                                                                  |
-| Issue / PR body drafts | [`docs/issues/README.md`](../../../docs/issues/README.md) Parts I–VI; packaging design in [`ARCHITECTURE.md` Part IX](../../../docs/design/ARCHITECTURE.md#part-ix--uvicorn-process-packaging-ppt-045-93) |
-| Title notation         | `.cursor/rules/gen-custom/github_issue_conventions.mdc` → `{semantic}/PPT-{NNN}: [{domain}] {sentence case}`                                                                                              |
+| Source                 | Path / pattern                                                                                                                                                                                                                 |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| GitHub PR template     | [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md) — **required structure**                                                                                                                       |
+| Issue / PR body drafts | [`docs/issues/README.md`](../../../docs/issues/README.md) Parts I–VII (incl. PPT-046 web); packaging design in [`ARCHITECTURE.md` Part IX](../../../docs/design/ARCHITECTURE.md#part-ix--uvicorn-process-packaging-ppt-045-93) |
+| Title notation         | `.cursor/rules/gen-custom/github_issue_conventions.mdc` → `{semantic}/PPT-{NNN}: [{domain}] {sentence case}`                                                                                                                   |
 
 ## Output format
 

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -43,9 +43,19 @@ Capture with `/strata:capture` only for work in flight.
 _Nothing open in strata._ Capture next epic children from
 [#112](https://github.com/Elmorralito/save-ma-money/issues/112) when starting work.
 
+### Docs hygiene (PPT-058 / #123)
+
+Monorepo indexes now point at `modules/web` + PPT-046: root `README.md` (package
+table, architecture mermaid/layer, quick-start §4), `docs/issues/README.md`
+Part VII, `.cursor/AGENTS.md` + thin `CLAUDE.md`,
+`.cursor/rules/gen-custom/project_structure.mdc`. RUM/Sentry marked deferred in
+`modules/web/README.md` (lab Lighthouse stays #121). Local patches ready — PR
+not opened until asked.
+
 ### Next action
 
 - Open PR for PPT-056 (#121); close after `web-ci` + agreed `web-e2e` gate green
+- Open/land PR for PPT-058 (#123) docs indexes (local patches ready)
 - PPT-054 carry-forward: cash-flow + trends → export + 501 UX → dashboard
 - PPT-068 (#139); PPT-057 (#122) CSP/nginx
 - Do not re-add closed GH issues into `.strata/issues/`

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@
 [<img src="./docs/share1.png" width="23" style="border-radius: 50%; border: 1px solid #e1e4e8;" alt="Donated to the PSF."/>](https://www.python.org/psf/donations/)
 [<img src="./docs/share2.png" width="23" style="border-radius: 50%; border: 1px solid #e1e4e8;" alt="Donated to the PSF."/>](https://www.python.org/psf/donations/)
 
-I'm just trying to **save-ma-money** (also _save-ma-finances_) from my own **ignorance**. This project is a Python monorepo for personal and (hopefully in the future) professional financial data: type-safe PostgreSQL persistence, Alembic migrations, and a FastAPI REST surface. The goal is auditable, tenant-isolated finance data with a tested model layer and a shippable API.
+I'm just trying to **save-ma-money** (also _save-ma-finances_) from my own **ignorance**. This project is a Poetry + pnpm monorepo for personal and (hopefully in the future) professional financial data: type-safe PostgreSQL persistence, Alembic migrations, a FastAPI REST surface, and a React SPA. The goal is auditable, tenant-isolated finance data with a tested model layer, a shippable API, and a presentation-only web client.
 
 | Package              | README                                                 | Role                                                                                                                                                                      |
 | :------------------- | :----------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **papita-txnsmodel** | [`modules/model/README.md`](./modules/model/README.md) | SQLModel schemas, repositories, services, handlers, migrations — PyPI: `papita-transactions-model` ([PPT-024](https://github.com/Elmorralito/save-ma-money/issues/11))    |
 | **papita-txnsapi**   | [`modules/api/README.md`](./modules/api/README.md)     | FastAPI REST surface; **unified API reference** (architecture, integration, 32 MVP endpoints) — routers via [#42](https://github.com/Elmorralito/save-ma-money/issues/42) |
+| **@papita/web**      | [`modules/web/README.md`](./modules/web/README.md)     | Vite + React + TypeScript SPA (epic [PPT-046 / #112](https://github.com/Elmorralito/save-ma-money/issues/112)) — presentation + BFF cookies; **no JS domain logic**       |
 
 ---
 
@@ -38,17 +39,20 @@ The architecture separates **how data is stored** from **how it is exposed**:
 
 - **`papita-txnsmodel`** — The system of record: migrations, handlers for ingestion, and business logic API routers will call — not reimplement.
 - **`papita-txnsapi`** — A thin FastAPI layer: request/response schemas, auth, and routing over existing services. The full REST contract lives in endpoint catalog, integration guide, and target package layout in one place.
+- **`@papita/web`** — Presentation-only React SPA ([PPT-046 / #112](https://github.com/Elmorralito/save-ma-money/issues/112)): TanStack Query + BFF cookies; **no JS domain logic**. Setup: [`modules/web/README.md`](./modules/web/README.md).
 
-That split keeps ingestion pipelines and REST endpoints aligned on one tested model, makes balances and reports derivable from the same ledger, and lets the API ship incrementally without forking financial rules into duplicate code paths.
+That split keeps ingestion pipelines, REST endpoints, and the SPA aligned on one tested model, makes balances and reports derivable from the same ledger, and lets the API and UI ship without forking financial rules into TypeScript.
 
 ```mermaid
 flowchart TB
   subgraph clients [Clients]
+    SPA["@papita/web SPA"]
     HTTP[HTTP / SDK]
     ETL[Ingestion handlers]
   end
 
   subgraph api [papita-txnsapi]
+    BFF[BFF session]
     R[Routers]
     S[API schemas]
   end
@@ -62,18 +66,20 @@ flowchart TB
 
   DB[(PostgreSQL)]
 
+  SPA --> BFF --> R
   HTTP --> R --> S --> SV
   ETL --> SV
   SV --> RP --> DTO --> SM --> DB
 ```
 
-| Layer   | Location                     | Responsibility                                                                                                                                                                     |
-| :------ | :--------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Model   | `papita_txnsmodel/model/`    | Tables, relationships, soft delete (`active`, `deleted_at`) — see [`modules/model/README.md`](./modules/model/README.md)                                                           |
-| Access  | `papita_txnsmodel/access/`   | DTO validation, repository CRUD, pandas DataFrames                                                                                                                                 |
-| Service | `papita_txnsmodel/services/` | Business rules, transfers, reports, account extensions                                                                                                                             |
-| Handler | `papita_txnsmodel/handlers/` | Load/dump pipelines for bulk ingest                                                                                                                                                |
-| API     | `papita_txnsapi/`            | Settings, auth helpers, unified REST reference — see [`modules/api/README.md`](./modules/api/README.md); routers via [#42](https://github.com/Elmorralito/save-ma-money/issues/42) |
+| Layer   | Location                       | Responsibility                                                                                                                                                                     |
+| :------ | :----------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Model   | `papita_txnsmodel/model/`      | Tables, relationships, soft delete (`active`, `deleted_at`) — see [`modules/model/README.md`](./modules/model/README.md)                                                           |
+| Access  | `papita_txnsmodel/access/`     | DTO validation, repository CRUD, pandas DataFrames                                                                                                                                 |
+| Service | `papita_txnsmodel/services/`   | Business rules, transfers, reports, account extensions                                                                                                                             |
+| Handler | `papita_txnsmodel/handlers/`   | Load/dump pipelines for bulk ingest                                                                                                                                                |
+| API     | `papita_txnsapi/`              | Settings, auth helpers, unified REST reference — see [`modules/api/README.md`](./modules/api/README.md); routers via [#42](https://github.com/Elmorralito/save-ma-money/issues/42) |
+| Web     | `modules/web/` (`@papita/web`) | Vite + React SPA — UI + BFF cookie session only; see [`modules/web/README.md`](./modules/web/README.md) · epic [#112](https://github.com/Elmorralito/save-ma-money/issues/112)     |
 
 **Platform:** PostgreSQL only — Docker Postgres locally (B0), Supabase for hosted environments (B1). DuckDB is deprecated ([#31](https://github.com/Elmorralito/save-ma-money/issues/31)).
 
@@ -81,15 +87,16 @@ flowchart TB
 
 ## Current status and roadmap
 
-| Area                          | Status                                                                                                                                                                                                                            |
-| :---------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **v3 schema & migrations**    | Delivered ([#32](https://github.com/Elmorralito/save-ma-money/issues/32), [#34](https://github.com/Elmorralito/save-ma-money/issues/34)); Alembic upgrade/downgrade validated in CI                                               |
-| **Model layer**               | Production-ready core: accounts, categories, transactions, users, materialized balance views; **351** unit/integration tests in `modules/model/tests`                                                                             |
-| **Model hardening (PPT-041)** | **Closed** ([#51](https://github.com/Elmorralito/save-ma-money/issues/51)) — transfers, reports, account extensions, tenancy guards, live-DB integration tests                                                                    |
-| **Design program (PPT-031)**  | **Closed** ([#28](https://github.com/Elmorralito/save-ma-money/issues/28)) — unified in [`docs/design/ARCHITECTURE.md`](./docs/design/ARCHITECTURE.md) (v0 audit, v3 schema, API mapping, coverage matrix, auth, migrations)      |
-| **API documentation**         | Consolidated in [`modules/api/README.md`](./modules/api/README.md) (replaces legacy `API_*.md.md` specs). Issue briefs: [`docs/issues/README.md`](./docs/issues/README.md)                                                        |
-| **API implementation**        | Runnable FastAPI MVP — health, auth, accounts, categories, transactions, movements, reports; OpenAPI at `/api/openapi.json`                                                                                                       |
-| **API epic (PPT-032)**        | Children **#43–#50 closed**; epic [#42](https://github.com/Elmorralito/save-ma-money/issues/42) open for formal close-out. Auth = Supabase only ([#49](https://github.com/Elmorralito/save-ma-money/issues/49)); B0 Postgres gate |
+| Area                          | Status                                                                                                                                                                                                                                                                                          |
+| :---------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **v3 schema & migrations**    | Delivered ([#32](https://github.com/Elmorralito/save-ma-money/issues/32), [#34](https://github.com/Elmorralito/save-ma-money/issues/34)); Alembic upgrade/downgrade validated in CI                                                                                                             |
+| **Model layer**               | Production-ready core: accounts, categories, transactions, users, materialized balance views; **351** unit/integration tests in `modules/model/tests`                                                                                                                                           |
+| **Model hardening (PPT-041)** | **Closed** ([#51](https://github.com/Elmorralito/save-ma-money/issues/51)) — transfers, reports, account extensions, tenancy guards, live-DB integration tests                                                                                                                                  |
+| **Design program (PPT-031)**  | **Closed** ([#28](https://github.com/Elmorralito/save-ma-money/issues/28)) — unified in [`docs/design/ARCHITECTURE.md`](./docs/design/ARCHITECTURE.md) (v0 audit, v3 schema, API mapping, coverage matrix, auth, migrations)                                                                    |
+| **API documentation**         | Consolidated in [`modules/api/README.md`](./modules/api/README.md) (replaces legacy `API_*.md.md` specs). Issue briefs: [`docs/issues/README.md`](./docs/issues/README.md)                                                                                                                      |
+| **API implementation**        | Runnable FastAPI MVP — health, auth, accounts, categories, transactions, movements, reports; OpenAPI at `/api/openapi.json`                                                                                                                                                                     |
+| **API epic (PPT-032)**        | Children **#43–#50 closed**; epic [#42](https://github.com/Elmorralito/save-ma-money/issues/42) open for formal close-out. Auth = Supabase only ([#49](https://github.com/Elmorralito/save-ma-money/issues/49)); B0 Postgres gate                                                               |
+| **Web SPA (PPT-046)**         | `modules/web` epic [#112](https://github.com/Elmorralito/save-ma-money/issues/112) — Vite/React client on FastAPI v1 + BFF cookies; setup in [`modules/web/README.md`](./modules/web/README.md); index brief [docs/issues Part VII](./docs/issues/README.md#part-vii--ppt-046-web-spa-epic-112) |
 
 Post-MVP items (budgets, splits, recurrence) are documented in [`docs/design/ARCHITECTURE.md#part-iii--post-mvp-v4-extensions-ppt-031-track-a`](./docs/design/ARCHITECTURE.md#part-iii--post-mvp-v4-extensions-ppt-031-track-a) and intentionally out of the v3 MVP scope.
 
@@ -99,23 +106,27 @@ Post-MVP items (budgets, splits, recurrence) are documented in [`docs/design/ARC
 
 ```
 save-ma-money/
-├── pyproject.toml              # workspace root (package-mode = false)
+├── pyproject.toml              # Poetry workspace root (package-mode = false)
+├── pnpm-workspace.yaml         # Node workspace → modules/web
 ├── modules/
 │   ├── model/                  # papita-txnsmodel — primary implementation
 │   │   ├── README.md           # schema, services, handlers, migrations, testing
 │   │   ├── src/papita_txnsmodel/
 │   │   ├── alembic/            # migrations
 │   │   └── tests/
-│   └── api/                    # papita-txnsapi — FastAPI REST surface
-│       ├── README.md           # REST contract, integration guide, endpoint catalog
-│       ├── tests/              # unit + B0 live-DB + Auth smoke helpers
-│       └── src/papita_txnsapi/ # main.py, routers/v1, schemas, deps
-├── bin/                     # alembic.sh, test.sh, utils.sh
+│   ├── api/                    # papita-txnsapi — FastAPI REST surface
+│   │   ├── README.md           # REST contract, integration guide, endpoint catalog
+│   │   ├── tests/              # unit + B0 live-DB + Auth smoke helpers
+│   │   └── src/papita_txnsapi/ # main.py, routers/v1, schemas, deps
+│   └── web/                    # @papita/web — Vite + React SPA (PPT-046)
+│       ├── README.md           # Node 22 + pnpm setup, BFF, OpenAPI types, quality
+│       └── src/
+├── bin/                        # alembic.sh, test.sh, utils.sh, web_e2e_seed.*
 ├── docker/database/            # local Postgres 15 Compose
 ├── docs/design/                # ARCHITECTURE.md (PPT-031) + README gates index
-├── docs/issues/                # consolidated issue briefs (README Parts I–V) + PPT-044/045
+├── docs/issues/                # consolidated issue briefs (incl. PPT-046 Part VII)
 ├── .strata/                    # agent memory (hot/warm/cold tiers)
-└── .github/workflows/          # CI (quality, security, migrations, strata)
+└── .github/workflows/          # CI (quality, security, migrations, strata, web-ci)
 ```
 
 ---
@@ -168,18 +179,32 @@ make api-all     # Full stack (Postgres/Redis/migrate/api) + wait until healthy
 
 See [`modules/api/README.md`](./modules/api/README.md) for env setup, auth flows, v3 data shapes, and the full endpoint catalog.
 
+### 4. Web SPA (`modules/web`)
+
+Node **22 LTS** + pnpm **9** (separate from Poetry). Full setup: [`modules/web/README.md`](./modules/web/README.md). Epic: [PPT-046 / #112](https://github.com/Elmorralito/save-ma-money/issues/112).
+
+```bash
+corepack enable   # or: npm install -g pnpm@9
+pnpm install
+make api-all      # preferred before web-dev (Compose API on :8000)
+make web-dev      # Vite on :5173; /api proxied to the API
+```
+
+Production nginx static packaging is **[#122](https://github.com/Elmorralito/save-ma-money/issues/122)** (PPT-057) — not a day-to-day local target yet. Field RUM / Sentry are deferred post-MVP; lab Lighthouse/CWV lives under [#121](https://github.com/Elmorralito/save-ma-money/issues/121) only.
+
 ---
 
 ## Documentation hub
 
 ### Module READMEs
 
-Each Poetry package has its own README with layer-specific setup, architecture, and reference material:
+Each package has its own README with layer-specific setup, architecture, and reference material:
 
-| Module README                                          | Scope                                                                           |
-| :----------------------------------------------------- | :------------------------------------------------------------------------------ |
-| [`modules/model/README.md`](./modules/model/README.md) | **papita-txnsmodel** — v3 schema, services, handlers, migrations, testing       |
-| [`modules/api/README.md`](./modules/api/README.md)     | **papita-txnsapi** — unified API reference, integration guide, 32 MVP endpoints |
+| Module README                                          | Scope                                                                                            |
+| :----------------------------------------------------- | :----------------------------------------------------------------------------------------------- |
+| [`modules/model/README.md`](./modules/model/README.md) | **papita-txnsmodel** — v3 schema, services, handlers, migrations, testing                        |
+| [`modules/api/README.md`](./modules/api/README.md)     | **papita-txnsapi** — unified API reference, integration guide, 32 MVP endpoints                  |
+| [`modules/web/README.md`](./modules/web/README.md)     | **@papita/web** — Vite/React SPA setup, BFF cookies, OpenAPI types, quality (no JS domain logic) |
 
 ### Design and operations
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -1,6 +1,6 @@
-# Issue briefs — PPT-031 / PPT-032 program
+# Issue briefs — PPT-031 / PPT-032 / PPT-046 program
 
-Canonical in-repo copies of GitHub issue bodies and decision briefs for the Papita simplify + API MVP program.
+Canonical in-repo copies of GitHub issue bodies and decision briefs for the Papita simplify + API MVP program, plus the web SPA epic index (PPT-046).
 
 **New GitHub issues:** use the chooser templates under [`.github/ISSUE_TEMPLATE/`](../../.github/ISSUE_TEMPLATE/) — epic (`01-epic.md`), program issue (`02-program-issue.md`), child under epic (`03-child-issue.md`), bug (`04-bug-report.md`). Shape references: [#42](https://github.com/Elmorralito/save-ma-money/issues/42), [#52](https://github.com/Elmorralito/save-ma-money/issues/52), [#89](https://github.com/Elmorralito/save-ma-money/issues/89), [#93](https://github.com/Elmorralito/save-ma-money/issues/93), children of #42.
 
@@ -11,20 +11,22 @@ Live issue status (open/closed, closing PR summaries) is mirrored in the root [C
 | Doc                                                        | Role                                                   |
 | ---------------------------------------------------------- | ------------------------------------------------------ |
 | [`modules/api/README.md`](../../modules/api/README.md)     | API reference, setup, endpoint catalog                 |
+| [`modules/web/README.md`](../../modules/web/README.md)     | Web SPA setup (Node 22 + pnpm; no JS domain logic)     |
 | [`docs/design/ARCHITECTURE.md`](../design/ARCHITECTURE.md) | Design body (schema, mapping, auth Part VI, migration) |
 | [`docs/design/README.md`](../design/README.md)             | Design program index + gates                           |
 | [`environments/README.md`](../../environments/README.md)   | `PAPITA_ENV` / secrets layout                          |
 
 ## Table of contents
 
-| Part                                                    | Topic                                       | Issue                                                         | Status                         |
-| ------------------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------- | ------------------------------ |
-| [I](#part-i--ppt-031-simplify-requirements-28)          | PPT-031 simplify requirements               | [#28](https://github.com/Elmorralito/save-ma-money/issues/28) | Closed                         |
-| [II](#part-ii--ppt-031-c-supabase--fastapi-decision-31) | Supabase × FastAPI decision (G7 Auth-first) | [#31](https://github.com/Elmorralito/save-ma-money/issues/31) | Complete (G7 superseded)       |
-| [III](#part-iii--ppt-032-api-epic-42)                   | FastAPI MVP epic body                       | [#42](https://github.com/Elmorralito/save-ma-money/issues/42) | Open (children #43–#50 closed) |
-| [IV](#part-iv--ppt-039-supabase-auth-reissue-49)        | Supabase Auth reissue                       | [#49](https://github.com/Elmorralito/save-ma-money/issues/49) | Closed                         |
-| [V](#part-v--ppt-043-redis-integration-83)              | Redis integration brief                     | [#83](https://github.com/Elmorralito/save-ma-money/issues/83) | Open (post-MVP)                |
-| [VI](#part-vi--ppt-045-uvicorn-process-packaging-93)    | Uvicorn process packaging                   | [#93](https://github.com/Elmorralito/save-ma-money/issues/93) | Closed                         |
+| Part                                                    | Topic                                       | Issue                                                           | Status                         |
+| ------------------------------------------------------- | ------------------------------------------- | --------------------------------------------------------------- | ------------------------------ |
+| [I](#part-i--ppt-031-simplify-requirements-28)          | PPT-031 simplify requirements               | [#28](https://github.com/Elmorralito/save-ma-money/issues/28)   | Closed                         |
+| [II](#part-ii--ppt-031-c-supabase--fastapi-decision-31) | Supabase × FastAPI decision (G7 Auth-first) | [#31](https://github.com/Elmorralito/save-ma-money/issues/31)   | Complete (G7 superseded)       |
+| [III](#part-iii--ppt-032-api-epic-42)                   | FastAPI MVP epic body                       | [#42](https://github.com/Elmorralito/save-ma-money/issues/42)   | Open (children #43–#50 closed) |
+| [IV](#part-iv--ppt-039-supabase-auth-reissue-49)        | Supabase Auth reissue                       | [#49](https://github.com/Elmorralito/save-ma-money/issues/49)   | Closed                         |
+| [V](#part-v--ppt-043-redis-integration-83)              | Redis integration brief                     | [#83](https://github.com/Elmorralito/save-ma-money/issues/83)   | Open (post-MVP)                |
+| [VI](#part-vi--ppt-045-uvicorn-process-packaging-93)    | Uvicorn process packaging                   | [#93](https://github.com/Elmorralito/save-ma-money/issues/93)   | Closed                         |
+| [VII](#part-vii--ppt-046-web-spa-epic-112)              | React SPA epic (modules/web)                | [#112](https://github.com/Elmorralito/save-ma-money/issues/112) | Open (post-MVP web)            |
 
 **Merged sources (removed):** `PPT-031-simplify-requirements.md`, `PPT-031-C-supabase-decision-brief.md`, `_gh_body_PPT-032-epic.md`, `_gh_body_PPT-039.md`, `PPT-039-supabase-auth-reissue.md`, `PPT-043-redis-integration-brief.md`, `PPT-045-uvicorn-process-packaging-brief.md` — content lives in this README only.
 
@@ -2007,3 +2009,56 @@ Validate process packaging on **B0 Docker Postgres** (and Compose Redis when ena
 - [#83](https://github.com/Elmorralito/save-ma-money/issues/83) PPT-043 Redis
 - [#89](https://github.com/Elmorralito/save-ma-money/issues/89) PPT-044 hardening
 - Epic [#42](https://github.com/Elmorralito/save-ma-money/issues/42) PPT-032
+
+---
+
+## Part VII — PPT-046 web SPA epic (#112)
+
+> Post-MVP React SPA epic. Live body: [#112](https://github.com/Elmorralito/save-ma-money/issues/112) (PPT-046).
+> Operator SSOT: [`modules/web/README.md`](../../modules/web/README.md) · agent ops: [`.cursor/AGENTS.md`](../../.cursor/AGENTS.md).
+> Docs index hygiene for this epic: [#123](https://github.com/Elmorralito/save-ma-money/issues/123) (PPT-058).
+
+**Parent program:** [#28](https://github.com/Elmorralito/save-ma-money/issues/28) (PPT-031) · **PPT-046** · **Step:** Post-MVP web client (after PPT-032 API MVP)
+
+### Summary
+
+Ship a **React + TypeScript SPA** under `modules/web/` that consumes the existing FastAPI surface (`papita_txnsapi` v1). The frontend must **not** reimplement domain/business logic in JavaScript — accounts, categories, transactions, movements, reports, and tenancy stay in `papita_txnsmodel`.
+
+**Locked decisions (cite epic; do not re-litigate):**
+
+- Deploy: Compose + nginx static hosting (`docker/web/`) — packaging owned by [#122](https://github.com/Elmorralito/save-ma-money/issues/122)
+- UI: Tailwind CSS + shadcn/ui
+- Auth: BFF + HttpOnly session cookies from day one (SPA never holds JWTs in JS storage) — [#115](https://github.com/Elmorralito/save-ma-money/issues/115)
+- Stack: Vite, React 19, TypeScript strict, TanStack Query v5, `openapi-typescript`, Vitest + Playwright
+
+### Where to start
+
+| Need                         | Where                                                                                                |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Setup (Node 22 + pnpm 9)     | [`modules/web/README.md`](../../modules/web/README.md)                                               |
+| Local run                    | `make api-all` then `make web-dev`                                                                   |
+| Epic + children              | [#112](https://github.com/Elmorralito/save-ma-money/issues/112)                                      |
+| OpenAPI typegen (strategy B) | PPT-065 / [#130](https://github.com/Elmorralito/save-ma-money/issues/130) — committed `openapi.json` |
+| Quality / a11y / lab CWV     | PPT-056 / [#121](https://github.com/Elmorralito/save-ma-money/issues/121)                            |
+| Field RUM / Sentry           | **Deferred post-MVP** — lab Lighthouse/CWV only in #121; no production RUM in MVP                    |
+
+### Child-issue map (selected)
+
+| Step | PPT         | Issue                                                                                                                           | Topic                                    |
+| ---- | ----------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| 0    | PPT-047     | [#113](https://github.com/Elmorralito/save-ma-money/issues/113)                                                                 | Scaffold + pnpm + Web CI                 |
+| 0d   | PPT-058     | [#123](https://github.com/Elmorralito/save-ma-money/issues/123)                                                                 | Document modules/web in monorepo indexes |
+| 1a   | PPT-048     | [#114](https://github.com/Elmorralito/save-ma-money/issues/114)                                                                 | OpenAPI types + thin client              |
+| 1b   | PPT-049     | [#115](https://github.com/Elmorralito/save-ma-money/issues/115)                                                                 | BFF cookie auth                          |
+| 1c   | PPT-051     | [#116](https://github.com/Elmorralito/save-ma-money/issues/116)                                                                 | Design system + AppLayout                |
+| 2a–c | PPT-052…054 | [#117](https://github.com/Elmorralito/save-ma-money/issues/117)–[#119](https://github.com/Elmorralito/save-ma-money/issues/119) | Feature screens                          |
+| 3    | PPT-056     | [#121](https://github.com/Elmorralito/save-ma-money/issues/121)                                                                 | Vitest + Playwright + a11y + security    |
+| 4    | PPT-057     | [#122](https://github.com/Elmorralito/save-ma-money/issues/122)                                                                 | nginx Compose + prod origins             |
+
+Full dependency graph and deferred scope (budgets, splits, browser JWTs, Vercel) live on the GitHub epic body — this Part is an **index**, not a second epic SSOT.
+
+### Out of scope (epic-level)
+
+- Reimplementing `papita_txnsmodel` services in TypeScript
+- Field RUM / Sentry / production error reporting (post-MVP)
+- Mobile native apps, public marketing SSR

--- a/modules/web/README.md
+++ b/modules/web/README.md
@@ -223,6 +223,10 @@ Documented as **met for MVP flows** when:
 
 Deferred polish (not blockers): full screen-reader scripted journeys, mobile native a11y.
 
+### RUM / Sentry (deferred)
+
+**Field RUM, Sentry, and production error-reporting SDKs are deferred post-MVP.** Do not add browser observability vendors for the PPT-046 MVP. Lab-only Lighthouse / Core Web Vitals budgets live under [PPT-056 / #121](https://github.com/Elmorralito/save-ma-money/issues/121) (`make web-lhci` / `web-e2e.yml`) — not a substitute for field RUM.
+
 ### Lighthouse / Core Web Vitals (lab)
 
 `make web-lhci` after build — config `lighthouserc.cjs`:


### PR DESCRIPTION
**Branch:** `docs/PPT-058` · **Base:** `main` · **1 commit** · **8 files**

**Suggested title:** `docs/PPT-058: [web] Document modules/web in monorepo indexes`

## Summary

Closes the PPT-058 discoverability gap for epic PPT-046: monorepo human/agent indexes now surface `modules/web`, Node 22 + pnpm, `make web-dev`, and the **no JS domain logic** rule without duplicating `modules/web/README.md`. Also marks field RUM / Sentry as deferred post-MVP (lab Lighthouse/CWV stays with #121).

## Out of scope / Highlights

**Out of scope**

- Product features, budgets/splits, Vercel, browser JWTs, CODEOWNERS, SSO UI
- nginx Compose packaging (owned by [#122](https://github.com/Elmorralito/save-ma-money/issues/122))
- Full strata memory rewrite; field RUM/Sentry product work
- Closing epic [#112](https://github.com/Elmorralito/save-ma-money/issues/112)

**Highlights**

- New `docs/issues` **Part VII** epic index for PPT-046 / #112
- Root README architecture mermaid now includes SPA → BFF
- Explicit RUM/Sentry deferred note in `modules/web/README.md`

## Changes

**Docs / indexes**

- Root `README.md`: `@papita/web` package row, roadmap, repo map, quick-start §4, docs hub
- `docs/issues/README.md`: TOC + Part VII (selected child map; link to live epic)
- `modules/web/README.md`: RUM/Sentry deferred section (lab CWV = #121 only)

**Agent ops**

- `.cursor/AGENTS.md`: repo map + pnpm ≠ Poetry setup; docs sources Parts I–VII
- `.cursor/CLAUDE.md`: thin adapter updated for Node/pnpm + web epic
- `.cursor/rules/gen-custom/project_structure.mdc`: `modules/web` row + layout
- `.cursor/skills/pr-description/SKILL.md`: issues index Parts I–VII
- `.strata/memory/project_state.md`: PPT-058 hygiene note

## File changes

<details>
<summary>File changes (8 files)</summary>

```
 .cursor/AGENTS.md                              | 53 ++++++++++------
 .cursor/CLAUDE.md                              | 21 ++++---
 .cursor/rules/gen-custom/project_structure.mdc | 19 +++++-
 .cursor/skills/pr-description/SKILL.md         | 10 +--
 .strata/memory/project_state.md                | 10 +++
 README.md                                      | 87 +++++++++++++++++---------
 docs/issues/README.md                          | 75 +++++++++++++++++++---
 modules/web/README.md                          |  4 ++
 8 files changed, 202 insertions(+), 77 deletions(-)
```

</details>

## Commits

- `3d00128` docs/PPT-058: [web] Document modules/web in monorepo indexes

## Checks, tests, and validation already done

- Local `pre-commit` on commit — **pass** (prettier auto-fix on first attempt, then clean)
- Product/unit/e2e suites — **not run** (docs-only)
- GitHub Actions on this PR — **not observed yet**

## QA / test plan

- [ ] Spot-check anchors: root README → `docs/issues` Part VII; AGENTS → `modules/web/README.md`
- [ ] Confirm a new contributor can find epic #112, Node 22 + pnpm + `make web-dev`, and “no JS domain logic” from README / AGENTS / issues index
- [ ] Confirm RUM/Sentry deferred wording appears in `modules/web/README.md` (and root quick-start note)
- [ ] Confirm no secrets / credentialed URLs in the diff

## Risks

> [!CAUTION]
>
> ### Risks
>
> - None identified (docs/agent-index only; no runtime or migration changes)

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - Part VII is an **index**, not a full copy of epic #112 (selected children only)
> - nginx day-to-day Make target still deferred to #122; README points there explicitly

## References

- Closes [#123](https://github.com/Elmorralito/save-ma-money/issues/123) (docs/PPT-058)
- Parent epic [#112](https://github.com/Elmorralito/save-ma-money/issues/112) (feat/PPT-046)
- Related: [#121](https://github.com/Elmorralito/save-ma-money/issues/121) (lab Lighthouse/CWV), [#122](https://github.com/Elmorralito/save-ma-money/issues/122) (nginx packaging)

Made with [Cursor](https://cursor.com)