### PR TITLE
feat/PPT-064: [web] Client guard for Papita breaking-changes contract

### DIFF
--- a/.strata/issues/20260803-07-ppt064-breaking-changes-guard.md
+++ b/.strata/issues/20260803-07-ppt064-breaking-changes-guard.md
@@ -1,0 +1,21 @@
+---
+id: 20260803-07
+type: feature
+status: in-progress
+severity: med
+area: modules/web
+created: 2026-08-03
+---
+
+# PPT-064 / #129 Client guard for Papita breaking-changes contract
+
+**What:** Shared SPA guard that compares `VITE_PAPITA_BREAKING_CHANGES_ID` (default
+`ppt-044`) against `GET /api/v1/meta/client-contract` / `X-Papita-Breaking-Changes`,
+with DEV console.error + prod console.warn and a non-blocking banner on mismatch.
+
+**Why:** Epic #112 child — fail loudly (dev) / degrade safely (prod) when PPT-044
+discovery drifts; features must not ad-hoc-read discovery headers.
+
+**Acceptance pointers:** `modules/web/src/api/contract.ts` helpers + unit tests;
+`BreakingChangesGuard` at app root; README § Breaking-changes guard; public
+`VITE_PAPITA_BREAKING_CHANGES_ID` only.

--- a/.strata/issues/ACTIVE.md
+++ b/.strata/issues/ACTIVE.md
@@ -3,8 +3,9 @@
 Everything `status: in-progress`. Loaded at `/strata:load`.
 
 <!-- GENERATED at /strata:save from issue frontmatter — do not hand-edit; edit item files instead -->
-<!-- Hand-refreshed 2026-08-03: rebase PPT-056 onto main (PPT-062 #152 + PPT-059 #153 merged); id 20260803-06 → PPT-056. -->
+<!-- Hand-refreshed 2026-08-03: add PPT-064 #129 (20260803-07); PPT-056 remains active. -->
 
 | Id          | Type    | Sev  | Area        | What                                                                     |
 | ----------- | ------- | ---- | ----------- | ------------------------------------------------------------------------ |
 | 20260803-06 | feature | high | modules/web | PPT-056 [#121] Vitest/Playwright/a11y/security gate (wired to #125/#126) |
+| 20260803-07 | feature | med  | modules/web | PPT-064 [#129] Breaking-changes client guard (banner + shared helper)    |

--- a/.strata/memory/MEMORY.md
+++ b/.strata/memory/MEMORY.md
@@ -5,7 +5,7 @@ Pure hot index: live pointers + the generated rules-by-trigger table. Keep ≤80
 ## Live pointers
 
 - [Project state](project_state.md) — ACTIVE = PPT-056 on `test/PPT-056`; PPT-062/059/061/060 merged; PPT-054 carry-forward.
-- [Active issues](../issues/ACTIVE.md) — PPT-056 [#121] `20260803-06`.
+- [Active issues](../issues/ACTIVE.md) — PPT-056 [#121] `20260803-06`; PPT-064 [#129] `20260803-07`.
 - [Open backlog](../issues/OPEN.md) — empty (capture from GitHub epic #112 when starting work).
 - Closed work — GitHub issues + `git log` (no `.strata/issues/archive/`).
 

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -32,6 +32,9 @@ Capture with `/strata:capture` only for work in flight.
 
 ### In progress (ACTIVE)
 
+- **PPT-064 / #129** (`20260803-07` on `feat/PPT-064`): Breaking-changes client
+  guard — shared `evaluateBreakingChangesGuard`, app-root banner, public
+  `VITE_PAPITA_BREAKING_CHANGES_ID` (default `ppt-044`).
 - **PPT-056 / #121** (`20260803-06` on `test/PPT-056`): Vitest coverage gate in
   `web-ci`; Playwright critical path + axe (`globalSetup` → `make web-e2e-seed`);
   Lighthouse lab budgets (`lighthouserc.cjs`); `web-e2e.yml` nightly/dispatch;
@@ -54,8 +57,8 @@ not opened until asked.
 
 ### Next action
 
+- Land PPT-064 (#129) PR on `feat/PPT-064` (guard + tests + README)
 - Open PR for PPT-056 (#121); close after `web-ci` + agreed `web-e2e` gate green
-- Open/land PR for PPT-058 (#123) docs indexes (local patches ready)
 - PPT-054 carry-forward: cash-flow + trends → export + 501 UX → dashboard
 - PPT-068 (#139); PPT-057 (#122) CSP/nginx
 - Do not re-add closed GH issues into `.strata/issues/`

--- a/modules/web/.env.example
+++ b/modules/web/.env.example
@@ -7,3 +7,8 @@
 
 # App display name (placeholder for shell work in PPT-051).
 VITE_APP_TITLE=Papita
+
+# Expected PPT-044 breaking-changes discovery id (PPT-064 / #129).
+# Mismatch with GET /api/v1/meta/client-contract or X-Papita-Breaking-Changes
+# surfaces a non-blocking banner + console error (dev) / warn (prod).
+VITE_PAPITA_BREAKING_CHANGES_ID=ppt-044

--- a/modules/web/README.md
+++ b/modules/web/README.md
@@ -80,16 +80,32 @@ Thin schema aliases live in `src/types/domain.ts`.
 
 Presentation-only client under `src/api/`. **No** `papita_txnsmodel` business logic in TypeScript — typed HTTP + Query wiring only.
 
-| Piece            | Location                                       | Notes                                                                        |
-| ---------------- | ---------------------------------------------- | ---------------------------------------------------------------------------- |
-| `apiFetch`       | `src/api/http.ts`                              | `credentials: 'include'`; `AbortSignal`; no `Authorization` header           |
-| Base URL         | `src/api/config.ts`                            | Default same-origin (`""`) → Vite `/api` proxy; optional `VITE_API_BASE_URL` |
-| Errors           | `src/api/errors.ts`                            | `PapitaApiError` maps `X-Papita-Error-Code` + discovery headers              |
-| Contract helpers | `src/api/contract.ts`                          | `bulkMaxTransactions` / `reportWindowMaxDays` from body (prefer) or headers  |
-| Probes           | `src/api/meta.ts`, `health.ts`                 | Unauthenticated health + `GET /api/v1/meta/client-contract`                  |
-| Query            | `queryKeys.ts`, `queries.ts`, `queryClient.ts` | `queryOptions()`; `staleTime` 60s; **no 4xx retries**                        |
+| Piece            | Location                                       | Notes                                                                                                       |
+| ---------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `apiFetch`       | `src/api/http.ts`                              | `credentials: 'include'`; `AbortSignal`; no `Authorization` header                                          |
+| Base URL         | `src/api/config.ts`                            | Default same-origin (`""`) → Vite `/api` proxy; optional `VITE_API_BASE_URL`                                |
+| Errors           | `src/api/errors.ts`                            | `PapitaApiError` maps `X-Papita-Error-Code` + discovery headers                                             |
+| Contract helpers | `src/api/contract.ts`                          | `bulkMaxTransactions` / `reportWindowMaxDays` from body (prefer) or headers; breaking-changes guard helpers |
+| Probes           | `src/api/meta.ts`, `health.ts`                 | Unauthenticated health + `GET /api/v1/meta/client-contract`                                                 |
+| Query            | `queryKeys.ts`, `queries.ts`, `queryClient.ts` | `queryOptions()`; `staleTime` 60s; **no 4xx retries**                                                       |
+| Breaking guard   | `BreakingChangesGuard` (app root)              | PPT-064 / #129 — see § Breaking-changes guard below                                                         |
 
 **Credentials policy:** always send cookies (`credentials: 'include'`) for BFF HttpOnly sessions (PPT-049 / #115). Do **not** store JWTs in `localStorage` / JS-readable storage or attach Bearer tokens from the SPA (PDF Axios interceptor pattern is superseded).
+
+### Breaking-changes guard (PPT-064 / #129)
+
+The SPA expects a stable PPT-044 discovery id (default `ppt-044`) via public env `VITE_PAPITA_BREAKING_CHANGES_ID`. On bootstrap, `BreakingChangesGuard` loads `GET /api/v1/meta/client-contract` (shared `clientContractQueryOptions`) and compares:
+
+1. Body `breaking_changes` (preferred), else
+2. Response header `X-Papita-Breaking-Changes` (via shared helpers — **do not** parse that header in feature pages).
+
+| Result       | Behavior                                                                                           |
+| ------------ | -------------------------------------------------------------------------------------------------- |
+| **match**    | Silent                                                                                             |
+| **mismatch** | Non-blocking banner for all routes; `console.error` once in DEV, `console.warn` once in production |
+| **unknown**  | No banner (probe missing / offline) — avoids false alarms                                          |
+
+Helpers: `evaluateBreakingChangesGuard`, `resolveExpectedBreakingChangesId`, `observedBreakingChangesId` in `src/api/contract.ts`. Feature code must use these instead of ad-hoc header reads.
 
 ## BFF cookie auth (PPT-049 / #115)
 

--- a/modules/web/src/App.tsx
+++ b/modules/web/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
 import { AuthRedirectBridge } from "@/auth/AuthRedirectBridge";
 import { RequireAuth } from "@/auth/RequireAuth";
+import { BreakingChangesGuard } from "@/components/contract/BreakingChangesGuard";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { PublicLayout } from "@/components/layout/PublicLayout";
 
@@ -54,6 +55,7 @@ function RouteFallback() {
 function App() {
   return (
     <BrowserRouter>
+      <BreakingChangesGuard />
       <AuthRedirectBridge />
       <Suspense fallback={<RouteFallback />}>
         <Routes>

--- a/modules/web/src/api/contract.test.ts
+++ b/modules/web/src/api/contract.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   bulkMaxTransactions,
+  DEFAULT_BREAKING_CHANGES_ID,
+  evaluateBreakingChangesGuard,
+  observedBreakingChangesId,
   reportWindowMaxDays,
   reportsForeignAccountStatus,
+  resolveExpectedBreakingChangesId,
 } from "@/api/contract";
 import type { DiscoveryHeaders } from "@/api/headers";
 import type { ClientContract } from "@/types/domain";
@@ -61,5 +65,66 @@ describe("contract helpers", () => {
   it("returns null when neither body nor headers provide a value", () => {
     expect(bulkMaxTransactions(null, null)).toBeNull();
     expect(reportWindowMaxDays(null, null)).toBeNull();
+  });
+});
+
+describe("breaking-changes guard", () => {
+  it("defaults expected id to ppt-044 when env is unset or blank", () => {
+    expect(resolveExpectedBreakingChangesId(undefined)).toBe(DEFAULT_BREAKING_CHANGES_ID);
+    expect(resolveExpectedBreakingChangesId("")).toBe(DEFAULT_BREAKING_CHANGES_ID);
+    expect(resolveExpectedBreakingChangesId("  ")).toBe(DEFAULT_BREAKING_CHANGES_ID);
+  });
+
+  it("trims a configured expected id", () => {
+    expect(resolveExpectedBreakingChangesId(" ppt-099 ")).toBe("ppt-099");
+  });
+
+  it("prefers body breaking_changes over discovery header", () => {
+    const discovery: DiscoveryHeaders = { ...sampleDiscovery, breakingChanges: "ppt-header" };
+    expect(observedBreakingChangesId(sampleContract, discovery)).toBe("ppt-044");
+  });
+
+  it("falls back to discovery header when body is absent", () => {
+    expect(observedBreakingChangesId(null, sampleDiscovery)).toBe("ppt-044");
+  });
+
+  it("returns unknown when neither body nor header provides an id", () => {
+    expect(
+      evaluateBreakingChangesGuard({ contract: null, discovery: null, expected: "ppt-044" }),
+    ).toEqual({
+      status: "unknown",
+      expected: "ppt-044",
+      observed: null,
+    });
+  });
+
+  it("matches when expected equals observed body id", () => {
+    expect(
+      evaluateBreakingChangesGuard({
+        contract: sampleContract,
+        discovery: sampleDiscovery,
+        expected: "ppt-044",
+      }),
+    ).toEqual({ status: "match", expected: "ppt-044", observed: "ppt-044" });
+  });
+
+  it("mismatches when expected differs from observed", () => {
+    expect(
+      evaluateBreakingChangesGuard({
+        contract: sampleContract,
+        discovery: sampleDiscovery,
+        expected: "ppt-099",
+      }),
+    ).toEqual({ status: "mismatch", expected: "ppt-099", observed: "ppt-044" });
+  });
+
+  it("uses header when evaluating without a contract body", () => {
+    expect(
+      evaluateBreakingChangesGuard({
+        contract: null,
+        discovery: { ...sampleDiscovery, breakingChanges: "ppt-header" },
+        expected: "ppt-044",
+      }),
+    ).toEqual({ status: "mismatch", expected: "ppt-044", observed: "ppt-header" });
   });
 });

--- a/modules/web/src/api/contract.ts
+++ b/modules/web/src/api/contract.ts
@@ -1,6 +1,79 @@
 import type { DiscoveryHeaders } from "@/api/headers";
 import type { ClientContract } from "@/types/domain";
 
+/** Default expected PPT-044 discovery id when `VITE_PAPITA_BREAKING_CHANGES_ID` is unset. */
+export const DEFAULT_BREAKING_CHANGES_ID = "ppt-044";
+
+export type BreakingChangesGuardStatus = "match" | "mismatch" | "unknown";
+
+export type BreakingChangesGuardResult = {
+  status: BreakingChangesGuardStatus;
+  expected: string;
+  observed: string | null;
+};
+
+/**
+ * Resolve the SPA-expected breaking-changes id from public Vite env.
+ *
+ * Args:
+ *   envValue: Optional override (defaults to `import.meta.env.VITE_PAPITA_BREAKING_CHANGES_ID`).
+ *
+ * Returns:
+ *   Trimmed env value, or {@link DEFAULT_BREAKING_CHANGES_ID} when unset/empty.
+ */
+export function resolveExpectedBreakingChangesId(
+  envValue: string | undefined = import.meta.env.VITE_PAPITA_BREAKING_CHANGES_ID,
+): string {
+  const trimmed = envValue?.trim();
+  if (trimmed === undefined || trimmed === "") {
+    return DEFAULT_BREAKING_CHANGES_ID;
+  }
+  return trimmed;
+}
+
+/**
+ * Observed breaking-changes id from contract body (preferred) or discovery header.
+ *
+ * Returns:
+ *   Non-empty id string, or `null` when neither source provides a value.
+ */
+export function observedBreakingChangesId(
+  contract?: ClientContract | null,
+  discovery?: DiscoveryHeaders | null,
+): string | null {
+  const fromBody = contract?.breaking_changes?.trim();
+  if (fromBody !== undefined && fromBody !== "") {
+    return fromBody;
+  }
+  const fromHeader = discovery?.breakingChanges?.trim();
+  if (fromHeader !== undefined && fromHeader !== "") {
+    return fromHeader;
+  }
+  return null;
+}
+
+/**
+ * Compare expected SPA breaking-changes id against PPT-044 discovery signals.
+ *
+ * Prefer `contract.breaking_changes` over `X-Papita-Breaking-Changes`. When neither
+ * is present, status is `unknown` (no banner — avoids false alarms when offline).
+ */
+export function evaluateBreakingChangesGuard(input: {
+  contract?: ClientContract | null;
+  discovery?: DiscoveryHeaders | null;
+  expected?: string;
+}): BreakingChangesGuardResult {
+  const expected = input.expected ?? resolveExpectedBreakingChangesId();
+  const observed = observedBreakingChangesId(input.contract, input.discovery);
+  if (observed === null) {
+    return { status: "unknown", expected, observed: null };
+  }
+  if (observed === expected) {
+    return { status: "match", expected, observed };
+  }
+  return { status: "mismatch", expected, observed };
+}
+
 /** Bulk create cap from contract JSON body (preferred) or discovery headers. */
 export function bulkMaxTransactions(
   contract: ClientContract | null | undefined,

--- a/modules/web/src/api/index.ts
+++ b/modules/web/src/api/index.ts
@@ -1,7 +1,13 @@
 export {
   bulkMaxTransactions,
+  DEFAULT_BREAKING_CHANGES_ID,
+  evaluateBreakingChangesGuard,
+  observedBreakingChangesId,
   reportWindowMaxDays,
   reportsForeignAccountStatus,
+  resolveExpectedBreakingChangesId,
+  type BreakingChangesGuardResult,
+  type BreakingChangesGuardStatus,
 } from "@/api/contract";
 export { buildApiUrl, resolveApiBaseUrl } from "@/api/config";
 export { isClientHttpError, isPapitaApiError, PapitaApiError } from "@/api/errors";

--- a/modules/web/src/components/contract/BreakingChangesBanner.tsx
+++ b/modules/web/src/components/contract/BreakingChangesBanner.tsx
@@ -1,0 +1,18 @@
+type BreakingChangesBannerProps = {
+  expected: string;
+  observed: string;
+};
+
+/** Non-blocking banner when SPA expected breaking-changes id drifts from the API. */
+export function BreakingChangesBanner({ expected, observed }: BreakingChangesBannerProps) {
+  return (
+    <div
+      role="alert"
+      className="border-b border-destructive/40 bg-destructive/10 px-4 py-2 text-sm text-destructive"
+    >
+      API contract drift: expected breaking-changes id <code className="font-mono">{expected}</code>
+      , API reports <code className="font-mono">{observed}</code>. Update the SPA or{" "}
+      <code className="font-mono">VITE_PAPITA_BREAKING_CHANGES_ID</code>.
+    </div>
+  );
+}

--- a/modules/web/src/components/contract/BreakingChangesGuard.test.tsx
+++ b/modules/web/src/components/contract/BreakingChangesGuard.test.tsx
@@ -1,0 +1,104 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as metaApi from "@/api/meta";
+import { resetBreakingChangesMismatchLogForTests } from "@/components/contract/breakingChangesLog";
+import { BreakingChangesGuard } from "@/components/contract/BreakingChangesGuard";
+import { QueryTestProvider } from "@/test/queryWrapper";
+import type { ClientContract } from "@/types/domain";
+
+vi.mock("@/api/meta", () => ({
+  getClientContract: vi.fn(),
+}));
+
+const baseContract = {
+  breaking_changes: "ppt-044",
+  api_version: "0.0.0-test",
+  secure_defaults: {
+    reports_foreign_account_status: 404,
+    cash_flow_refresh_balances_default: false,
+    bulk_max_transactions: 100,
+    report_window_max_days: 366,
+    docs_require_debug_or_docs_enabled: true,
+    cors_wildcard_forbidden_when_not_debug: true,
+  },
+  effective: {
+    reports_foreign_account_status: 404,
+    cash_flow_refresh_balances_default: false,
+    bulk_max_transactions: 100,
+    report_window_max_days: 366,
+    docs_enabled: true,
+  },
+  compat: { active: [], sunset: null, flags: {} },
+  error_codes: {},
+  migration: {
+    probe: "GET /api/v1/meta/client-contract",
+    prefer_headers: [],
+    client_checklist: [],
+  },
+} satisfies ClientContract;
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  resetBreakingChangesMismatchLogForTests();
+});
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+describe("BreakingChangesGuard", () => {
+  it("renders no banner when contract matches expected id", async () => {
+    vi.mocked(metaApi.getClientContract).mockResolvedValue({
+      contract: baseContract,
+      discovery: {
+        breakingChanges: "ppt-044",
+        bulkMax: 100,
+        reportWindowMaxDays: 366,
+        cashFlowRefreshDefault: false,
+        reportsForeignAccountStatus: 404,
+        errorCode: null,
+        compatActive: [],
+      },
+    });
+
+    render(
+      <QueryTestProvider>
+        <BreakingChangesGuard />
+      </QueryTestProvider>,
+    );
+
+    await waitFor(() => {
+      expect(metaApi.getClientContract).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("renders banner and logs on mismatch", async () => {
+    vi.mocked(metaApi.getClientContract).mockResolvedValue({
+      contract: { ...baseContract, breaking_changes: "ppt-099" },
+      discovery: {
+        breakingChanges: "ppt-099",
+        bulkMax: 100,
+        reportWindowMaxDays: 366,
+        cashFlowRefreshDefault: false,
+        reportsForeignAccountStatus: 404,
+        errorCode: null,
+        compatActive: [],
+      },
+    });
+
+    render(
+      <QueryTestProvider>
+        <BreakingChangesGuard />
+      </QueryTestProvider>,
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("ppt-099");
+    await waitFor(() => {
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/modules/web/src/components/contract/BreakingChangesGuard.tsx
+++ b/modules/web/src/components/contract/BreakingChangesGuard.tsx
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+import { evaluateBreakingChangesGuard } from "@/api/contract";
+import { clientContractQueryOptions } from "@/api/queries";
+import { BreakingChangesBanner } from "@/components/contract/BreakingChangesBanner";
+import { logBreakingChangesMismatch } from "@/components/contract/breakingChangesLog";
+
+/**
+ * Probe client-contract once at app root; surface PPT-064 mismatch via console + banner.
+ *
+ * Features should use {@link evaluateBreakingChangesGuard} — do not read discovery headers ad hoc.
+ */
+export function BreakingChangesGuard() {
+  const contractQuery = useQuery(clientContractQueryOptions());
+  const result = evaluateBreakingChangesGuard({ contract: contractQuery.data });
+  const { status, expected, observed } = result;
+
+  useEffect(() => {
+    logBreakingChangesMismatch({ status, expected, observed });
+  }, [status, expected, observed]);
+
+  if (status !== "mismatch" || observed === null) {
+    return null;
+  }
+
+  return <BreakingChangesBanner expected={expected} observed={observed} />;
+}

--- a/modules/web/src/components/contract/breakingChangesLog.ts
+++ b/modules/web/src/components/contract/breakingChangesLog.ts
@@ -1,0 +1,29 @@
+import type { BreakingChangesGuardResult } from "@/api/contract";
+
+const loggedMismatchKeys = new Set<string>();
+
+/** Log a breaking-changes mismatch once per expected|observed pair (dev error / prod warn). */
+export function logBreakingChangesMismatch(result: BreakingChangesGuardResult): void {
+  if (result.status !== "mismatch" || result.observed === null) {
+    return;
+  }
+  const key = `${result.expected}|${result.observed}`;
+  if (loggedMismatchKeys.has(key)) {
+    return;
+  }
+  loggedMismatchKeys.add(key);
+  const message =
+    `Papita API breaking-changes id mismatch: expected "${result.expected}", ` +
+    `observed "${result.observed}". Sync the SPA / VITE_PAPITA_BREAKING_CHANGES_ID with ` +
+    `GET /api/v1/meta/client-contract.`;
+  if (import.meta.env.DEV) {
+    console.error(message);
+  } else {
+    console.warn(message);
+  }
+}
+
+/** Test helper to clear once-per-session log dedupe. */
+export function resetBreakingChangesMismatchLogForTests(): void {
+  loggedMismatchKeys.clear();
+}

--- a/modules/web/src/vite-env.d.ts
+++ b/modules/web/src/vite-env.d.ts
@@ -3,6 +3,8 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_APP_TITLE?: string;
+  /** Expected PPT-044 breaking-changes id (default `ppt-044`). */
+  readonly VITE_PAPITA_BREAKING_CHANGES_ID?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
**Branch:** `feat/PPT-064` · **Base:** `main` · **1 commit** · **15 files**

## Summary

Adds a shared SPA guard for PPT-044 discovery drift (`#129` / PPT-064 under epic `#112`). Compares public `VITE_PAPITA_BREAKING_CHANGES_ID` (default `ppt-044`) against `GET /api/v1/meta/client-contract` / `X-Papita-Breaking-Changes`, logging once and showing a non-blocking banner on mismatch so silent API contract skew is visible without blocking CRUD.

## Out of scope / Highlights

**Out of scope**

- Auto-migrating UI for future breaking-change ids
- Reimplementing server contract logic
- E2E coverage (unit tests only per issue AC)

**Highlights**

- Body `breaking_changes` preferred over header (same pattern as bulk/window helpers)
- `unknown` (probe missing) stays silent to avoid false alarms offline

## Changes

**Web**

- Shared helpers: `evaluateBreakingChangesGuard`, `resolveExpectedBreakingChangesId`, `observedBreakingChangesId`
- App-root `BreakingChangesGuard` + banner; DEV `console.error` / prod `console.warn` (once per pair)
- `.env.example` + `vite-env.d.ts` for `VITE_PAPITA_BREAKING_CHANGES_ID`
- README § Breaking-changes guard

**Strata**

- In-flight item `20260803-07` + ACTIVE / project_state pointers

## File changes

<details>
<summary>File changes (~15 files)</summary>

```
 .strata/issues/20260803-07-ppt064-breaking-changes-guard.md
 .strata/issues/ACTIVE.md
 .strata/memory/MEMORY.md
 .strata/memory/project_state.md
 modules/web/.env.example
 modules/web/README.md
 modules/web/src/App.tsx
 modules/web/src/api/contract.test.ts
 modules/web/src/api/contract.ts
 modules/web/src/api/index.ts
 modules/web/src/components/contract/BreakingChangesBanner.tsx
 modules/web/src/components/contract/BreakingChangesGuard.test.tsx
 modules/web/src/components/contract/BreakingChangesGuard.tsx
 modules/web/src/components/contract/breakingChangesLog.ts
 modules/web/src/vite-env.d.ts
```

</details>

## Commits

- `87cbb79` feat/PPT-064: [web] Client guard for Papita breaking-changes contract

## Checks, tests, and validation already done

- `make web-test` — pass (113)
- `make web-lint` — pass
- Pre-commit (eslint, prettier, tsc, vitest related, strata validate) — pass on commit

## QA / test plan

- [ ] Confirm match path: local API with `breaking_changes: ppt-044` shows no banner
- [ ] Confirm mismatch: temporarily set `VITE_PAPITA_BREAKING_CHANGES_ID=ppt-099` → banner + console
- [ ] Confirm feature pages still do not parse `X-Papita-Breaking-Changes` ad hoc
- [ ] Web CI green on this PR

## Risks

> [!CAUTION]
>
> ### Risks
>
> - Prod shows a non-blocking banner on mismatch (intentional degrade; not log-only)
> - Guard probes client-contract on all routes (unauthenticated); failed probe stays silent (`unknown`)

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - Expected id is public `VITE_*` only — no secrets added
> - Does not auto-update UI behavior when the server bumps the discovery id

## Web security checklist (PPT-056 / #121)

- [x] No JWTs / access tokens in `localStorage` / `sessionStorage` (BFF HttpOnly `papita_sid` only)
- [x] Cookie flags reviewed for the touched path (`HttpOnly` / `Secure` when not DEBUG / `SameSite`) — N/A (no cookie changes)
- [x] CSRF: mutations send `X-Papita-CSRF`; token stays in memory (not WebStorage) — N/A (no auth mutations)
- [x] No secrets in `VITE_*` (public bundle only); gitleaks-aware for accidental embeds
- [ ] `pnpm web:audit` considered (or Dependabot `npm-web`); no known high prod vulns left untracked — not run this PR
- [x] CSP: documented posture OK for this PR (full CSP headers owned by launch packaging / #122)

## References

- Closes #129
- Parent epic #112
- Depends on PPT-048 client-contract probe (#114)

Made with [Cursor](https://cursor.com)