### PR TITLE
ops/PPT-067: [infra] Publish versioned Docker images for API

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -68,7 +68,7 @@ save-ma-money/
 │       └── src/                # presentation only — no domain logic
 ├── environments/               # PAPITA_ENV profiles (local|staging|production)
 ├── bin/                        # alembic.sh, test.sh, smokes, utils.sh, web_e2e_seed.*
-├── docker/                     # database/, api/, redis/, web/ (nginx SPA), docker-compose.yml
+├── docker/                     # README (GHCR SSOT PPT-067), database/, api/, redis/, web/, docker-compose.yml
 ├── docs/design/ · docs/issues/ # human design program (PPT-031) + web epic Part VII
 ├── .cursor/                    # adapters, gen-custom rules, skills
 ├── .agents/                    # symlinks to .cursor/ adapters (Codex)
@@ -228,6 +228,7 @@ Use the right tier for the question:
 | Post-MVP hardening / uvicorn | [`ARCHITECTURE.md` Part VIII](../docs/design/ARCHITECTURE.md#part-viii--post-mvp-api-hardening-ppt-044-89) · [Part IX](../docs/design/ARCHITECTURE.md#part-ix--uvicorn-process-packaging-ppt-045-93) |
 | Human README                 | [`README.md`](../README.md)                                                                                                                                                                          |
 | CI workflows & scripts       | [`.github/CI.md`](../.github/CI.md)                                                                                                                                                                  |
+| Docker / GHCR image publish  | [`docker/README.md`](../docker/README.md) (PPT-067 / [#132](https://github.com/Elmorralito/save-ma-money/issues/132))                                                                                |
 
 Promote durable decisions to `.strata/docs/decisions/` (ADR-NNNN) via `/strata:save`; do not duplicate routing rules here.
 

--- a/.cursor/rules/gen-custom/github_issue_conventions.mdc
+++ b/.cursor/rules/gen-custom/github_issue_conventions.mdc
@@ -63,6 +63,7 @@ Apply durable domain labels (`API`, `frontend`, `CI/CD`, `documentation`, `enhan
 | Label | CI reaction |
 | ----- | ----------- |
 | `skip-dev-release` | Skip Publish model (dev) |
+| `skip-api-image-dev` | Skip Publish API image (PR dev GHCR) |
 | `skip-strata` | Skip Strata Check |
 | `skip-web-ci` | Skip Web CI |
 | `skip-web-e2e` | Skip Web E2E |

--- a/.cursor/rules/gen-custom/project_structure.mdc
+++ b/.cursor/rules/gen-custom/project_structure.mdc
@@ -96,15 +96,16 @@ Developer/ops entrypoints (CI wrappers stay under `.github/scripts/`):
 
 | Path | Role |
 | ---- | ---- |
+| `docker/README.md` | GHCR naming + publish SSOT (PPT-067 / #132); model = PyPI, API = container |
 | `docker/database/docker-compose.yml` | Local Postgres 15 (B0) |
 | `docker/docker-compose.yml` | API + Postgres + Redis + nginx SPA stack |
-| `docker/api/Dockerfile` | uvicorn `CMD` SSOT (`papita_txnsapi.main:app`) |
+| `docker/api/Dockerfile` | uvicorn `CMD` SSOT (`papita_txnsapi.main:app`); base digest pinned |
 | `docker/web/Dockerfile` | multi-stage pnpm → nginx:alpine (PPT-057 / #122); SPA CSP snippet PPT-063 / #128 |
 | `docker/web/nginx.conf` | SPA fallback + `/api` proxy (BFF cookie Path=/api) |
 | `docker/web/spa-security-headers.conf` | CSP + baseline headers for static SPA locations (PPT-063 / #128) |
 | `docker/redis/` | Redis config for Compose |
 
-Canonical B0 API start: `make api-up` (uvicorn in-container). nginx SPA: `make web-up`. See `ARCHITECTURE.md` Part IX (PPT-045). Do not promote host `poetry run uvicorn` as the day-to-day path.
+Canonical B0 API start: `make api-up` (uvicorn in-container). nginx SPA: `make web-up`. See `ARCHITECTURE.md` Part IX (PPT-045). API image registry publish: `publish-api-image.yml` → `ghcr.io/.../save-ma-money-api` (PPT-067). Do not promote host `poetry run uvicorn` as the day-to-day path.
 
 ### Documentation
 

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -20,7 +20,7 @@ GitHub Actions workflows, validation scripts, and local pre-commit hooks for **s
 - [PR skip labels](#pr-skip-labels)
 - [Workflow overview](#workflow-overview)
 - [Run checks locally](#run-checks-locally)
-- [Workflows in detail](#workflows-in-detail) (includes [Publish model package](#publish-model-package-ppt-024) + [dev TestPyPI](#publish-model-dev--testpypi))
+- [Workflows in detail](#workflows-in-detail) (includes [Publish model package](#publish-model-package-ppt-024) + [dev TestPyPI](#publish-model-dev--testpypi) + [Publish API image](#publish-api-image-ppt-067))
 - [CI Adoption Badge](#ci-adoption-badge)
 - [Pre-commit hooks](#pre-commit-hooks)
 - [Strata validation](#strata-validation)
@@ -58,6 +58,7 @@ flowchart TB
         AU[Auto Updates]
         REL[Release model PSR]
         PYPI[Publish model PyPI]
+        APIIMG[Publish API image edge]
     end
 
     QC --> |pre-commit + pytest + Codecov| Pass1[Gate]
@@ -78,6 +79,7 @@ flowchart TB
     Merge --> AU
     Merge --> |modules/model paths + releasable commits| REL
     REL --> |workflow_call on released=true| PYPI
+    Merge --> APIIMG
     AU --> |CHANGELOG + badges| Push[Push to main]
 ```
 
@@ -121,15 +123,16 @@ Use this matrix to predict required checks before opening a PR.
 
 Durable **functional** labels (not `PPT-*`). Apply on a **PR** to skip the matching workflow job. Adding/removing the label re-triggers the workflow (`labeled` / `unlabeled`). **Push to `main`, schedules, and `workflow_dispatch` ignore these labels.**
 
-| Label              | Skips workflow                       | File                                                         |
-| ------------------ | ------------------------------------ | ------------------------------------------------------------ |
-| `skip-dev-release` | Publish model (dev) TestPyPI preview | [`publish-model-dev.yml`](./workflows/publish-model-dev.yml) |
-| `skip-strata`      | Strata Check                         | [`strata-check.yml`](./workflows/strata-check.yml)           |
-| `skip-web-ci`      | Web CI (lint / Vitest / build)       | [`web-ci.yml`](./workflows/web-ci.yml)                       |
-| `skip-web-e2e`     | Web E2E (Playwright / axe / LHCI)    | [`web-e2e.yml`](./workflows/web-e2e.yml)                     |
-| `skip-quality`     | Code Quality Control (Python gate)   | [`quality-control.yml`](./workflows/quality-control.yml)     |
-| `skip-migrations`  | Migration Check                      | [`migration-check.yml`](./workflows/migration-check.yml)     |
-| `skip-openapi`     | OpenAPI Web Contract                 | [`openapi-contract.yml`](./workflows/openapi-contract.yml)   |
+| Label                | Skips workflow                       | File                                                         |
+| -------------------- | ------------------------------------ | ------------------------------------------------------------ |
+| `skip-dev-release`   | Publish model (dev) TestPyPI preview | [`publish-model-dev.yml`](./workflows/publish-model-dev.yml) |
+| `skip-api-image-dev` | Publish API image (PR dev GHCR)      | [`publish-api-image.yml`](./workflows/publish-api-image.yml) |
+| `skip-strata`        | Strata Check                         | [`strata-check.yml`](./workflows/strata-check.yml)           |
+| `skip-web-ci`        | Web CI (lint / Vitest / build)       | [`web-ci.yml`](./workflows/web-ci.yml)                       |
+| `skip-web-e2e`       | Web E2E (Playwright / axe / LHCI)    | [`web-e2e.yml`](./workflows/web-e2e.yml)                     |
+| `skip-quality`       | Code Quality Control (Python gate)   | [`quality-control.yml`](./workflows/quality-control.yml)     |
+| `skip-migrations`    | Migration Check                      | [`migration-check.yml`](./workflows/migration-check.yml)     |
+| `skip-openapi`       | OpenAPI Web Contract                 | [`openapi-contract.yml`](./workflows/openapi-contract.yml)   |
 
 **Not skippable via label (by design):** Gitleaks, CodeQL, Trivy, Bash Security, Supply Chain, Branch sync — keep security and merge-hygiene gates honest.
 
@@ -144,26 +147,27 @@ gh pr edit 123 --add-label skip-dev-release
 
 ## Workflow overview
 
-| Workflow             | File                                                                     | Triggers                                                                     | Purpose                                                                                                                                           |
-| :------------------- | :----------------------------------------------------------------------- | :--------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Code Quality Control | [`workflows/quality-control.yml`](./workflows/quality-control.yml)       | PR + push to `main`; Mon 07:00 UTC; skips `docs/**` + web                    | pre-commit, pytest, Postgres live tests (B0), Codecov                                                                                             |
-| Web CI               | [`workflows/web-ci.yml`](./workflows/web-ci.yml)                         | PR + push to `main` (`modules/web/**`, `docker/web/**`, pnpm lock/workspace) | pnpm lint / Vitest+coverage / audit (soft) / build + OpenAPI `check-types` + nginx image (tar export→load) + SPA header smoke (PPT-057 / PPT-063) |
-| Web E2E              | [`workflows/web-e2e.yml`](./workflows/web-e2e.yml)                       | Nightly Mon 07:30 UTC; `workflow_dispatch`; PRs touching e2e/seed            | Compose API (`AUTH_PROVIDER=local`) + Playwright/axe + Lighthouse lab (PPT-056 / #121)                                                            |
-| OpenAPI Web Contract | [`workflows/openapi-contract.yml`](./workflows/openapi-contract.yml)     | PR + push (API src, model model/access, web OpenAPI artifact)                | Offline OpenAPI dump vs committed `modules/web/openapi/openapi.json` (PPT-065)                                                                    |
-| Migration Check      | [`workflows/migration-check.yml`](./workflows/migration-check.yml)       | PR + push to `main` (model/migration/integration paths)                      | PostgreSQL Alembic round-trip + drift check                                                                                                       |
-| Supply Chain Check   | [`workflows/supply-chain-check.yml`](./workflows/supply-chain-check.yml) | PR + push (deps/workflow paths); Mon 08:00 UTC                               | `poetry check`, version metadata, `pip-audit`                                                                                                     |
-| Secret Scan          | [`workflows/gitleaks.yml`](./workflows/gitleaks.yml)                     | **All PRs**; push to `main`; Mon 05:00 UTC                                   | Full-history secret detection                                                                                                                     |
-| CodeQL Python        | [`workflows/codeql.yml`](./workflows/codeql.yml)                         | PR → `main` + push (`modules/{model,api}/**`); Mon 06:00 UTC                 | Python SAST (`security-extended`) — independent of JS/TS                                                                                          |
-| CodeQL JS/TS         | [`workflows/codeql-javascript.yml`](./workflows/codeql-javascript.yml)   | PR → `main` + push (`modules/web/**`, pnpm); Mon 06:30 UTC                   | JavaScript/TypeScript SAST — runs when web/JS/TS paths change; independent of Python                                                              |
-| Trivy Security Scan  | [`workflows/trivy.yml`](./workflows/trivy.yml)                           | PR + push (manifest/docker paths); Mon 07:00 UTC                             | Filesystem CVE + IaC misconfig (SARIF)                                                                                                            |
-| Bash Security        | [`workflows/bash-security.yml`](./workflows/bash-security.yml)           | **PR only** (shell/script paths)                                             | ShellCheck security codes + Semgrep bash rules                                                                                                    |
-| Strata Check         | [`workflows/strata-check.yml`](./workflows/strata-check.yml)             | PR + push to `main` (code/bin paths)                                         | `.strata/` layout + strict code/memory pairing                                                                                                    |
-| Branch sync          | [`workflows/branch-sync.yml`](./workflows/branch-sync.yml)               | **All PRs**; `workflow_dispatch`                                             | Fail if branch is behind `origin/main` (needs merge/rebase)                                                                                       |
-| Auto Updates         | [`workflows/auto-updates.yml`](./workflows/auto-updates.yml)             | Push or merged PR to `main`                                                  | Regenerate [`CHANGELOG.md`](../CHANGELOG.md) and badges                                                                                           |
-| CI Adoption Badge    | [`workflows/ci-badge.yml`](./workflows/ci-badge.yml)                     | PR + push to `main`; Mon 06:00 UTC; `workflow_dispatch`                      | Score CI maturity and update README adoption badge                                                                                                |
-| Release model (PSR)  | [`workflows/release-model.yml`](./workflows/release-model.yml)           | Push `main` (model paths); `workflow_dispatch`                               | python-semantic-release → `model-v*` + `modules/model/CHANGELOG.md`; calls publish on release                                                     |
-| Publish model (PyPI) | [`workflows/publish-model.yml`](./workflows/publish-model.yml)           | `workflow_call`; tag `model-v*`; `workflow_dispatch`                         | Build + OIDC publish `papita-transactions-model` (PPT-024)                                                                                        |
-| Publish model (dev)  | [`workflows/publish-model-dev.yml`](./workflows/publish-model-dev.yml)   | PR (model paths) after other checks pass                                     | Stamp `{version}.dev{run_id}` → TestPyPI (same-repo, non-draft)                                                                                   |
+| Workflow             | File                                                                     | Triggers                                                                            | Purpose                                                                                                                                           |
+| :------------------- | :----------------------------------------------------------------------- | :---------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Code Quality Control | [`workflows/quality-control.yml`](./workflows/quality-control.yml)       | PR + push to `main`; Mon 07:00 UTC; skips `docs/**` + web                           | pre-commit, pytest, Postgres live tests (B0), Codecov                                                                                             |
+| Web CI               | [`workflows/web-ci.yml`](./workflows/web-ci.yml)                         | PR + push to `main` (`modules/web/**`, `docker/web/**`, pnpm lock/workspace)        | pnpm lint / Vitest+coverage / audit (soft) / build + OpenAPI `check-types` + nginx image (tar export→load) + SPA header smoke (PPT-057 / PPT-063) |
+| Web E2E              | [`workflows/web-e2e.yml`](./workflows/web-e2e.yml)                       | Nightly Mon 07:30 UTC; `workflow_dispatch`; PRs touching e2e/seed                   | Compose API (`AUTH_PROVIDER=local`) + Playwright/axe + Lighthouse lab (PPT-056 / #121)                                                            |
+| OpenAPI Web Contract | [`workflows/openapi-contract.yml`](./workflows/openapi-contract.yml)     | PR + push (API src, model model/access, web OpenAPI artifact)                       | Offline OpenAPI dump vs committed `modules/web/openapi/openapi.json` (PPT-065)                                                                    |
+| Migration Check      | [`workflows/migration-check.yml`](./workflows/migration-check.yml)       | PR + push to `main` (model/migration/integration paths)                             | PostgreSQL Alembic round-trip + drift check                                                                                                       |
+| Supply Chain Check   | [`workflows/supply-chain-check.yml`](./workflows/supply-chain-check.yml) | PR + push (deps/workflow paths); Mon 08:00 UTC                                      | `poetry check`, version metadata, `pip-audit`                                                                                                     |
+| Secret Scan          | [`workflows/gitleaks.yml`](./workflows/gitleaks.yml)                     | **All PRs**; push to `main`; Mon 05:00 UTC                                          | Full-history secret detection                                                                                                                     |
+| CodeQL Python        | [`workflows/codeql.yml`](./workflows/codeql.yml)                         | PR → `main` + push (`modules/{model,api}/**`); Mon 06:00 UTC                        | Python SAST (`security-extended`) — independent of JS/TS                                                                                          |
+| CodeQL JS/TS         | [`workflows/codeql-javascript.yml`](./workflows/codeql-javascript.yml)   | PR → `main` + push (`modules/web/**`, pnpm); Mon 06:30 UTC                          | JavaScript/TypeScript SAST — runs when web/JS/TS paths change; independent of Python                                                              |
+| Trivy Security Scan  | [`workflows/trivy.yml`](./workflows/trivy.yml)                           | PR + push (manifest/docker paths); Mon 07:00 UTC                                    | Filesystem CVE + IaC misconfig (SARIF)                                                                                                            |
+| Bash Security        | [`workflows/bash-security.yml`](./workflows/bash-security.yml)           | **PR only** (shell/script paths)                                                    | ShellCheck security codes + Semgrep bash rules                                                                                                    |
+| Strata Check         | [`workflows/strata-check.yml`](./workflows/strata-check.yml)             | PR + push to `main` (code/bin paths)                                                | `.strata/` layout + strict code/memory pairing                                                                                                    |
+| Branch sync          | [`workflows/branch-sync.yml`](./workflows/branch-sync.yml)               | **All PRs**; `workflow_dispatch`                                                    | Fail if branch is behind `origin/main` (needs merge/rebase)                                                                                       |
+| Auto Updates         | [`workflows/auto-updates.yml`](./workflows/auto-updates.yml)             | Push or merged PR to `main`                                                         | Regenerate [`CHANGELOG.md`](../CHANGELOG.md) and badges                                                                                           |
+| CI Adoption Badge    | [`workflows/ci-badge.yml`](./workflows/ci-badge.yml)                     | PR + push to `main`; Mon 06:00 UTC; `workflow_dispatch`                             | Score CI maturity and update README adoption badge                                                                                                |
+| Release model (PSR)  | [`workflows/release-model.yml`](./workflows/release-model.yml)           | Push `main` (model paths); `workflow_dispatch`                                      | python-semantic-release → `model-v*` + `modules/model/CHANGELOG.md`; calls publish on release                                                     |
+| Publish model (PyPI) | [`workflows/publish-model.yml`](./workflows/publish-model.yml)           | `workflow_call`; tag `model-v*`; `workflow_dispatch`                                | Build + OIDC publish `papita-transactions-model` (PPT-024)                                                                                        |
+| Publish model (dev)  | [`workflows/publish-model-dev.yml`](./workflows/publish-model-dev.yml)   | PR (model paths) after other checks pass                                            | Stamp `{version}.dev{run_id}` → TestPyPI (same-repo, non-draft)                                                                                   |
+| Publish API image    | [`workflows/publish-api-image.yml`](./workflows/publish-api-image.yml)   | Path-relevant `main` → stable GHCR; PR → `pr-*`/`dev-*` (skip `skip-api-image-dev`) | PPT-067 / #132 — Environments `ghcr` + `ghcr-dev`                                                                                                 |
 
 ---
 
@@ -281,6 +285,29 @@ pip install \
 **Operator setup (once):** on [TestPyPI](https://test.pypi.org/) / [PyPI](https://pypi.org/), add a Trusted Publisher for this repository, workflow **`publish-model.yml`** (the reusable file that performs OIDC), and the matching environment. For PR → TestPyPI, the `testpypi` GitHub Environment must allow deployments from PR head branches (not only `main`). Prefer environment protection on `pypi`. Do not store long-lived tokens in git.
 
 **Local:** `make package-model` · docs: [`modules/model/README.md`](../modules/model/README.md) § Install.
+
+### Publish API image (PPT-067)
+
+|                 |                                                                                                                                                                           |
+| :-------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Trigger**     | Path-relevant push to **`main`** → stable GHCR; path-filtered **PR** → dev GHCR (unless `skip-api-image-dev`); dispatch `smoke-only` \| `publish` (publish requires main) |
+| **Jobs**        | `publish` (Environment **`ghcr`**) · `publish-dev` (Environment **`ghcr-dev`**) · `changes` · `build-smoke` (dispatch only)                                               |
+| **Image**       | `ghcr.io/<owner>/save-ma-money-api`                                                                                                                                       |
+| **Stable tags** | `main` only: `:edge`, `:{semver}`, `:py-api-v{semver}`, `:sha-<12>` — **not** triggered by git tag events                                                                 |
+| **Dev tags**    | PR only: `:pr-<N>`, `:pr-<N>-<sha>`, `:dev-<run_id>` (never overwrites stable tags)                                                                                       |
+| **Vuln gate**   | Pre-push [Trivy image gate](./actions/trivy-api-image-gate/action.yml) (CRITICAL/HIGH, ignore-unfixed) + SARIF → Security tab — Environment reviewers cannot be scanners  |
+| **Smoke**       | Pre-push [`api_image_smoke.sh`](./scripts/api_image_smoke.sh) on the scanned local image                                                                                  |
+| **Auth**        | Ephemeral `GITHUB_TOKEN` + `packages: write` on publish jobs; same-repo non-draft PRs for `publish-dev`; forks/drafts skipped                                             |
+| **Platforms**   | Stable: `linux/amd64,linux/arm64`; PR dev: `linux/amd64`                                                                                                                  |
+| **Model**       | Decision **A** — no model runtime image; PyPI remains SSOT                                                                                                                |
+
+**Not a merge gate.** Opt out of PR images: `gh pr edit <n> --add-label skip-api-image-dev`.
+
+**Operator setup (once):** Environments **`ghcr`** / **`ghcr-dev`**; set GHCR package visibility for `save-ma-money-api`.
+
+**Local:** `make api-image-build` · `make api-up` · `./.github/scripts/api_image_smoke.sh papita-api:local` · SSOT: [`docker/README.md`](../docker/README.md).
+
+**Coverage:** PPT-045 (#93) owns Dockerfile CMD only; PPT-057 (#122) owns web nginx Compose image; PPT-066 (#131) owns git tag prefixes — **this workflow owns API registry publish**.
 
 ---
 

--- a/.github/actions/trivy-api-image-gate/action.yml
+++ b/.github/actions/trivy-api-image-gate/action.yml
@@ -1,0 +1,40 @@
+# Composite gate: fail the job on CRITICAL/HIGH image vulns (PPT-067).
+# GitHub Environment "required reviewers" cannot be scanners — this is the automated gate.
+# Aligns severity/ignore-unfixed with .github/workflows/trivy.yml filesystem scan.
+
+name: Trivy API image gate
+description: Scan a local Docker image with Trivy; fail on CRITICAL/HIGH; upload SARIF
+
+inputs:
+  image-ref:
+    description: Local image reference to scan (must already be loaded)
+    required: true
+  sarif-category:
+    description: Code scanning category for the Security tab
+    required: true
+  sarif-file:
+    description: SARIF output path
+    required: false
+    default: trivy-api-image.sarif
+
+runs:
+  using: composite
+  steps:
+    - name: Trivy image scan (CRITICAL/HIGH gate)
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        scan-type: image
+        image-ref: ${{ inputs.image-ref }}
+        scanners: vuln
+        severity: CRITICAL,HIGH
+        ignore-unfixed: true
+        format: sarif
+        output: ${{ inputs.sarif-file }}
+        exit-code: "1"
+
+    - name: Upload Trivy image SARIF
+      uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+      if: ${{ always() && hashFiles(inputs.sarif-file) != '' }}
+      with:
+        sarif_file: ${{ inputs.sarif-file }}
+        category: ${{ inputs.sarif-category }}

--- a/.github/actions/trivy-api-image-gate/action.yml
+++ b/.github/actions/trivy-api-image-gate/action.yml
@@ -1,6 +1,10 @@
 # Composite gate: fail the job on CRITICAL/HIGH image vulns (PPT-067).
 # GitHub Environment "required reviewers" cannot be scanners — this is the automated gate.
 # Aligns severity/ignore-unfixed with .github/workflows/trivy.yml filesystem scan.
+#
+# Gate uses `docker run aquasec/trivy` (table + exit-code) so severity filtering is
+# reliable. SARIF upload is separate and non-gating (trivy-action SARIF mode can
+# unset severity unless limit-severities-for-sarif is set).
 
 name: Trivy API image gate
 description: Scan a local Docker image with Trivy; fail on CRITICAL/HIGH; upload SARIF
@@ -20,19 +24,40 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Trivy image scan (CRITICAL/HIGH gate)
+    - name: Assert image is visible to Docker
+      shell: bash
+      run: |
+        set -euo pipefail
+        docker image inspect "${{ inputs.image-ref }}" --format 'id={{.Id}} created={{.Created}}'
+
+    - name: Trivy image scan (CRITICAL/HIGH table gate)
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "${HOME}/.cache/trivy"
+        docker run --rm \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          -v "${HOME}/.cache/trivy:/root/.cache/trivy" \
+          aquasec/trivy:0.70.0 image \
+          --scanners vuln \
+          --severity CRITICAL,HIGH \
+          --ignore-unfixed \
+          --exit-code 1 \
+          --format table \
+          "${{ inputs.image-ref }}"
+
+    - name: Trivy image SARIF (report only)
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         scan-type: image
         image-ref: ${{ inputs.image-ref }}
         scanners: vuln
         severity: CRITICAL,HIGH
-        # Without this, SARIF mode unsets TRIVY_SEVERITY and exit-code fails on MEDIUM/LOW too.
         limit-severities-for-sarif: true
         ignore-unfixed: true
         format: sarif
         output: ${{ inputs.sarif-file }}
-        exit-code: "1"
+        exit-code: "0"
 
     - name: Upload Trivy image SARIF
       uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4

--- a/.github/actions/trivy-api-image-gate/action.yml
+++ b/.github/actions/trivy-api-image-gate/action.yml
@@ -2,9 +2,9 @@
 # GitHub Environment "required reviewers" cannot be scanners — this is the automated gate.
 # Aligns severity/ignore-unfixed with .github/workflows/trivy.yml filesystem scan.
 #
-# Gate uses `docker run aquasec/trivy` (table + exit-code) so severity filtering is
-# reliable. SARIF upload is separate and non-gating (trivy-action SARIF mode can
-# unset severity unless limit-severities-for-sarif is set).
+# Gate exports the image and runs `trivy rootfs` so BuildKit/third-party SBOM
+# attestations (which can list stale Python package versions) cannot fail the gate
+# when the real site-packages are already patched. SARIF upload remains non-gating.
 
 name: Trivy API image gate
 description: Scan a local Docker image with Trivy; fail on CRITICAL/HIGH; upload SARIF
@@ -30,23 +30,37 @@ runs:
         set -euo pipefail
         docker image inspect "${{ inputs.image-ref }}" --format 'id={{.Id}} created={{.Created}}'
 
-    - name: Trivy image scan (CRITICAL/HIGH table gate)
+    - name: Export image rootfs for Trivy
+      id: rootfs
+      shell: bash
+      run: |
+        set -euo pipefail
+        ROOTFS="${RUNNER_TEMP}/papita-api-rootfs"
+        rm -rf "${ROOTFS}"
+        mkdir -p "${ROOTFS}"
+        cid="$(docker create "${{ inputs.image-ref }}")"
+        docker export "${cid}" | tar -C "${ROOTFS}" -xf -
+        docker rm -f "${cid}" >/dev/null
+        echo "dir=${ROOTFS}" >>"${GITHUB_OUTPUT}"
+
+    - name: Trivy rootfs scan (CRITICAL/HIGH table gate)
       shell: bash
       run: |
         set -euo pipefail
         mkdir -p "${HOME}/.cache/trivy"
         docker run --rm \
-          -v /var/run/docker.sock:/var/run/docker.sock \
           -v "${HOME}/.cache/trivy:/root/.cache/trivy" \
-          aquasec/trivy:0.70.0 image \
+          -v "${{ steps.rootfs.outputs.dir }}:/rootfs:ro" \
+          aquasec/trivy:0.70.0 rootfs \
           --scanners vuln \
           --severity CRITICAL,HIGH \
           --ignore-unfixed \
           --exit-code 1 \
           --format table \
-          "${{ inputs.image-ref }}"
+          /rootfs
 
     - name: Trivy image SARIF (report only)
+      if: ${{ always() }}
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         scan-type: image

--- a/.github/actions/trivy-api-image-gate/action.yml
+++ b/.github/actions/trivy-api-image-gate/action.yml
@@ -27,6 +27,8 @@ runs:
         image-ref: ${{ inputs.image-ref }}
         scanners: vuln
         severity: CRITICAL,HIGH
+        # Without this, SARIF mode unsets TRIVY_SEVERITY and exit-code fails on MEDIUM/LOW too.
+        limit-severities-for-sarif: true
         ignore-unfixed: true
         format: sarif
         output: ${{ inputs.sarif-file }}

--- a/.github/actions/trivy-api-image-gate/action.yml
+++ b/.github/actions/trivy-api-image-gate/action.yml
@@ -41,6 +41,34 @@ runs:
         cid="$(docker create "${{ inputs.image-ref }}")"
         docker export "${cid}" | tar -C "${ROOTFS}" -xf -
         docker rm -f "${cid}" >/dev/null
+        # Third-party SBOMs embedded in the image can list stale Python versions
+        # (e.g. msgpack 1.1.2) while site-packages are already patched. Drop them
+        # so the gate reflects the real filesystem packages Trivy also enumerates.
+        while IFS= read -r -d '' f; do
+          echo "Removing embedded SBOM candidate: ${f#"${ROOTFS}/"}"
+          rm -f "${f}"
+        done < <(
+          find "${ROOTFS}" \( \
+            -iname '*sbom*' -o \
+            -iname '*.spdx*' -o \
+            -iname '*cyclonedx*' -o \
+            -iname 'bom.json' -o \
+            -iname '*.cdx.json' \
+          \) -type f -print0 2>/dev/null || true
+        )
+        # Also drop JSON/XML docs that still claim the stale msgpack pin.
+        while IFS= read -r -d '' f; do
+          echo "Removing stale-msgpack document: ${f#"${ROOTFS}/"}"
+          rm -f "${f}"
+        done < <(
+          grep -RIlZ --include='*.json' --include='*.xml' --include='*.spdx' \
+            -e 'msgpack' "${ROOTFS}" 2>/dev/null \
+            | while IFS= read -r -d '' f; do
+                if grep -Eq '1\.1\.2' "${f}"; then
+                  printf '%s\0' "${f}"
+                fi
+              done || true
+        )
         echo "dir=${ROOTFS}" >>"${GITHUB_OUTPUT}"
 
     - name: Trivy rootfs scan (CRITICAL/HIGH table gate)
@@ -57,6 +85,7 @@ runs:
           --ignore-unfixed \
           --exit-code 1 \
           --format table \
+          --skip-files "**/*sbom*,**/*.spdx*,**/*cyclonedx*,**/bom.json,**/*.cdx.json" \
           /rootfs
 
     - name: Trivy image SARIF (report only)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -121,6 +121,27 @@ updates:
         patterns:
           - "*"
 
+  # PPT-067 / #132 — API runtime base (python:*-slim) digest bumps
+  - package-ecosystem: docker
+    directory: /docker/api
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Bogota
+    open-pull-requests-limit: 2
+    labels:
+      - dependencies
+      - CI/CD
+      - API
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      docker-api:
+        patterns:
+          - "*"
+
   - package-ecosystem: pre-commit
     directory: /
     schedule:

--- a/.github/scripts/api_image_smoke.sh
+++ b/.github/scripts/api_image_smoke.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Smoke-test a papita API image: GET /api/v1/health/live must return alive=true.
+# Usage: api_image_smoke.sh <image:tag> [host_port]
+# PPT-067 / #132 — used by publish-api-image.yml (PR build-smoke + post-publish).
+
+set -euo pipefail
+
+IMAGE_TAG="${1:-}"
+HOST_PORT="${2:-18000}"
+CONTAINER_NAME="${API_IMAGE_SMOKE_NAME:-papita-api-ci}"
+
+if [[ -z "${IMAGE_TAG}" ]]; then
+  echo "usage: $0 <image:tag> [host_port]" >&2
+  exit 2
+fi
+
+docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+
+docker run -d --name "${CONTAINER_NAME}" -p "${HOST_PORT}:8000" \
+  -e AUTH_PROVIDER=local \
+  -e REDIS_ENABLED=false \
+  -e DEBUG=true \
+  -e DOCS_ENABLED=false \
+  -e JWT_SECRET_KEY="ci-smoke-only-replace-me-min-32-chars" \
+  "${IMAGE_TAG}"
+
+cleanup() {
+  docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 60); do
+  if curl -sf "http://127.0.0.1:${HOST_PORT}/api/v1/health/live" >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+curl -sf "http://127.0.0.1:${HOST_PORT}/api/v1/health/live" | tee /tmp/papita-api-live.json
+grep -q '"alive"[[:space:]]*:[[:space:]]*true' /tmp/papita-api-live.json
+echo "API liveness smoke OK (${IMAGE_TAG})"

--- a/.github/workflows/publish-api-image.yml
+++ b/.github/workflows/publish-api-image.yml
@@ -291,6 +291,24 @@ jobs:
             org.opencontainers.image.version=${{ steps.pkg_ver.outputs.version }}
             com.github.papita.image.channel=stable
 
+      - name: Assert patched Python packages in scan image
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint python papita-api:scan - <<'PY'
+          import importlib.metadata as m
+
+          def ver(name: str) -> tuple[int, ...]:
+              return tuple(int(p) for p in m.version(name).split(".")[:3])
+
+          setuptools_v = ver("setuptools")
+          msgpack_v = ver("msgpack")
+          pip_v = ver("pip")
+          print(f"pip={m.version('pip')} setuptools={m.version('setuptools')} msgpack={m.version('msgpack')}")
+          assert pip_v >= (26, 1, 2), pip_v
+          assert setuptools_v >= (78, 1, 1), setuptools_v
+          assert msgpack_v >= (1, 2, 1), msgpack_v
+          PY
+
       - name: Trivy image vulnerability gate
         uses: ./.github/actions/trivy-api-image-gate
         with:
@@ -482,8 +500,9 @@ jobs:
           push: false
           load: true
           tags: papita-api:scan
-          cache-from: type=gha,scope=papita-api-dev
-          cache-to: type=gha,mode=max,scope=papita-api-dev
+          # Bust stale GHA build cache from earlier PPT-067 iterations.
+          cache-from: type=gha,scope=papita-api-dev-v2
+          cache-to: type=gha,mode=max,scope=papita-api-dev-v2
           labels: |
             org.opencontainers.image.title=save-ma-money-api
             org.opencontainers.image.description=Papita transactions API (papita_txnsapi) PR preview
@@ -491,6 +510,24 @@ jobs:
             org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
             org.opencontainers.image.version=${{ steps.meta.outputs.dev_version }}
             com.github.papita.image.channel=dev
+
+      - name: Assert patched Python packages in scan image
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint python papita-api:scan - <<'PY'
+          import importlib.metadata as m
+
+          def ver(name: str) -> tuple[int, ...]:
+              return tuple(int(p) for p in m.version(name).split(".")[:3])
+
+          setuptools_v = ver("setuptools")
+          msgpack_v = ver("msgpack")
+          pip_v = ver("pip")
+          print(f"pip={m.version('pip')} setuptools={m.version('setuptools')} msgpack={m.version('msgpack')}")
+          assert pip_v >= (26, 1, 2), pip_v
+          assert setuptools_v >= (78, 1, 1), setuptools_v
+          assert msgpack_v >= (1, 2, 1), msgpack_v
+          PY
 
       - name: Trivy image vulnerability gate
         uses: ./.github/actions/trivy-api-image-gate
@@ -517,8 +554,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha,scope=papita-api-dev
-          cache-to: type=gha,mode=max,scope=papita-api-dev
+          cache-from: type=gha,scope=papita-api-dev-v2
+          cache-to: type=gha,mode=max,scope=papita-api-dev-v2
           labels: |
             org.opencontainers.image.title=save-ma-money-api
             org.opencontainers.image.description=Papita transactions API (papita_txnsapi) PR preview

--- a/.github/workflows/publish-api-image.yml
+++ b/.github/workflows/publish-api-image.yml
@@ -281,6 +281,9 @@ jobs:
           push: false
           load: true
           tags: papita-api:scan
+          # Attested/third-party SBOMs can report stale Python package versions to Trivy.
+          provenance: false
+          sbom: false
           cache-from: type=gha,scope=papita-api
           cache-to: type=gha,mode=max,scope=papita-api
           labels: |
@@ -333,6 +336,8 @@ jobs:
           platforms: ${{ steps.meta.outputs.platforms }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          provenance: false
+          sbom: false
           cache-from: type=gha,scope=papita-api
           cache-to: type=gha,mode=max,scope=papita-api
           labels: |
@@ -500,9 +505,13 @@ jobs:
           push: false
           load: true
           tags: papita-api:scan
-          # Bust stale GHA build cache from earlier PPT-067 iterations.
-          cache-from: type=gha,scope=papita-api-dev-v2
-          cache-to: type=gha,mode=max,scope=papita-api-dev-v2
+          # Attested/third-party SBOMs can report stale Python package versions to Trivy
+          # (filesystem packages were already patched; SBOM still listed msgpack 1.1.2 /
+          # setuptools 70.3.0). Keep scan images attestation-free.
+          provenance: false
+          sbom: false
+          cache-from: type=gha,scope=papita-api-dev-v3
+          cache-to: type=gha,mode=max,scope=papita-api-dev-v3
           labels: |
             org.opencontainers.image.title=save-ma-money-api
             org.opencontainers.image.description=Papita transactions API (papita_txnsapi) PR preview
@@ -554,8 +563,10 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha,scope=papita-api-dev-v2
-          cache-to: type=gha,mode=max,scope=papita-api-dev-v2
+          provenance: false
+          sbom: false
+          cache-from: type=gha,scope=papita-api-dev-v3
+          cache-to: type=gha,mode=max,scope=papita-api-dev-v3
           labels: |
             org.opencontainers.image.title=save-ma-money-api
             org.opencontainers.image.description=Papita transactions API (papita_txnsapi) PR preview

--- a/.github/workflows/publish-api-image.yml
+++ b/.github/workflows/publish-api-image.yml
@@ -1,0 +1,559 @@
+# Publish papita_txnsapi runtime image to GHCR (PPT-067 / #132).
+# Dockerfile SSOT: docker/api/Dockerfile (PPT-045 uvicorn CMD).
+# Naming SSOT: docker/README.md
+#
+# Policy:
+#   - Stable/release tags publish ONLY from main (never from git tag events or PR heads)
+#   - PRs publish a non-release "dev" image (pr-* / dev-*) unless skip-api-image-dev
+#   - Automated vuln gate: Trivy CRITICAL/HIGH before any GHCR push (Environment
+#     required reviewers cannot be scanners — see .github/actions/trivy-api-image-gate)
+#
+# Jobs:
+#   build-smoke  — dispatch smoke-only: contents:read (no packages:write)
+#   changes      — main path detect
+#   publish      — main only → build → Trivy → smoke → multi-arch push
+#   publish-dev  — PR → build → Trivy → smoke → amd64 push (never release tags)
+#
+# Auth: GITHUB_TOKEN packages:write on publish jobs only. No long-lived registry secrets.
+
+name: Publish API image
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    paths:
+      - "docker/api/**"
+      - "modules/api/**"
+      - "modules/model/pyproject.toml"
+      - "modules/model/src/**"
+      - "modules/model/alembic/**"
+      - "modules/model/alembic.ini"
+      - "modules/model/README.md"
+      - "modules/model/LICENSE"
+      - ".dockerignore"
+      - ".github/workflows/publish-api-image.yml"
+      - ".github/scripts/api_image_smoke.sh"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "smoke-only (no push) | publish (main → stable GHCR tags)"
+        type: choice
+        options:
+          - smoke-only
+          - publish
+        default: smoke-only
+
+concurrency:
+  group: >-
+    publish-api-image-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: save-ma-money-api
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Detect API-relevant path changes on main pushes.
+  # ---------------------------------------------------------------------------
+  changes:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      api: ${{ steps.check.outputs.api }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect API image paths vs push before
+        id: check
+        env:
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${BEFORE}" || "${BEFORE}" =~ ^0+$ ]]; then
+            echo "api=true" >>"${GITHUB_OUTPUT}"
+            echo "No usable before SHA — treating as api-relevant"
+            exit 0
+          fi
+          api=false
+          count=0
+          while IFS= read -r f; do
+            count=$((count + 1))
+            case "${f}" in
+              docker/api/* | \
+              modules/api/* | \
+              modules/model/pyproject.toml | \
+              modules/model/src/* | \
+              modules/model/alembic/* | \
+              modules/model/alembic.ini | \
+              modules/model/README.md | \
+              modules/model/LICENSE | \
+              .dockerignore | \
+              .github/workflows/publish-api-image.yml | \
+              .github/scripts/api_image_smoke.sh)
+                api=true
+                ;;
+            esac
+          done < <(git diff --name-only "${BEFORE}" "${SHA}" || true)
+          echo "api=${api}" >>"${GITHUB_OUTPUT}"
+          echo "api=${api} (changed_files=${count})"
+
+  # ---------------------------------------------------------------------------
+  # Manual smoke — never packages:write.
+  # ---------------------------------------------------------------------------
+  build-smoke:
+    if: github.event_name == 'workflow_dispatch' && inputs.mode == 'smoke-only'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Read API package version
+        id: pkg_ver
+        run: |
+          set -euo pipefail
+          PKG_VER="$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+          data = tomllib.loads(Path("modules/api/pyproject.toml").read_text())
+          print(data["project"]["version"])
+          PY
+          )"
+          echo "version=${PKG_VER}" >>"${GITHUB_OUTPUT}"
+
+      - name: Image coordinates
+        id: meta
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          OWNER="$(echo "${REPO_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          IMAGE="ghcr.io/${OWNER}/${IMAGE_NAME}"
+          echo "image=${IMAGE}" >>"${GITHUB_OUTPUT}"
+          echo "tags=${IMAGE}:ci" >>"${GITHUB_OUTPUT}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
+      - name: Build API image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/api/Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha,scope=papita-api
+          cache-to: type=gha,mode=max,scope=papita-api
+          labels: |
+            org.opencontainers.image.title=save-ma-money-api
+            org.opencontainers.image.description=Papita transactions API (papita_txnsapi)
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.pkg_ver.outputs.version }}
+
+      - name: Smoke GET /api/v1/health/live
+        run: /bin/bash .github/scripts/api_image_smoke.sh "${{ steps.meta.outputs.tags }}"
+
+      - name: Summary
+        env:
+          PKG_VER: ${{ steps.pkg_ver.outputs.version }}
+          IMAGE: ${{ steps.meta.outputs.image }}
+        run: |
+          {
+            echo "## API image build-smoke (PPT-067)"
+            echo ""
+            echo "- Package version: \`${PKG_VER}\`"
+            echo "- Image (local): \`${IMAGE}:ci\`"
+            echo "- Push: \`false\`"
+            echo "- SSOT: \`docker/README.md\`"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+  # ---------------------------------------------------------------------------
+  # Stable publish — main only (path-relevant push or dispatch mode=publish).
+  # ---------------------------------------------------------------------------
+  publish:
+    needs: [changes]
+    if: >-
+      always() &&
+      needs.changes.result != 'failure' &&
+      (
+        (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.api == 'true') ||
+        (github.event_name == 'workflow_dispatch' && inputs.mode == 'publish')
+      )
+    runs-on: ubuntu-latest
+    environment: ghcr
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    steps:
+      - name: Guard main-only publish
+        env:
+          REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [[ "${REF}" != "refs/heads/main" ]]; then
+            echo "Stable API images publish only from main (got ${REF} event=${EVENT_NAME})" >&2
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Read API package version
+        id: pkg_ver
+        run: |
+          set -euo pipefail
+          PKG_VER="$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+          data = tomllib.loads(Path("modules/api/pyproject.toml").read_text())
+          print(data["project"]["version"])
+          PY
+          )"
+          echo "version=${PKG_VER}" >>"${GITHUB_OUTPUT}"
+
+      - name: Decide platforms / tags (stable)
+        id: meta
+        env:
+          SHA: ${{ github.sha }}
+          PKG_VER: ${{ steps.pkg_ver.outputs.version }}
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          OWNER="$(echo "${REPO_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          IMAGE="ghcr.io/${OWNER}/${IMAGE_NAME}"
+          SHORT_SHA="$(echo "${SHA}" | cut -c1-12)"
+          PLATFORMS="linux/amd64,linux/arm64"
+          TAGS=(
+            "${IMAGE}:edge"
+            "${IMAGE}:${PKG_VER}"
+            "${IMAGE}:py-api-v${PKG_VER}"
+            "${IMAGE}:sha-${SHORT_SHA}"
+          )
+          TAGS_CSV="$(IFS=,; echo "${TAGS[*]}")"
+          {
+            echo "image=${IMAGE}"
+            echo "kind=stable"
+            echo "platforms=${PLATFORMS}"
+            echo "short_sha=${SHORT_SHA}"
+            echo "scan_tag=papita-api:scan"
+            echo "tags=${TAGS_CSV}"
+            echo "tags_list<<EOF"
+            printf '%s\n' "${TAGS[@]}"
+            echo "EOF"
+          } >>"${GITHUB_OUTPUT}"
+          printf 'tags:\n'
+          printf '  %s\n' "${TAGS[@]}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
+      - name: Build amd64 for Trivy gate + smoke
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/api/Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: papita-api:scan
+          cache-from: type=gha,scope=papita-api
+          cache-to: type=gha,mode=max,scope=papita-api
+          labels: |
+            org.opencontainers.image.title=save-ma-money-api
+            org.opencontainers.image.description=Papita transactions API (papita_txnsapi)
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.pkg_ver.outputs.version }}
+            com.github.papita.image.channel=stable
+
+      - name: Trivy image vulnerability gate
+        uses: ./.github/actions/trivy-api-image-gate
+        with:
+          image-ref: papita-api:scan
+          sarif-category: trivy-api-image-stable
+
+      - name: Smoke GET /api/v1/health/live (pre-push)
+        run: /bin/bash .github/scripts/api_image_smoke.sh papita-api:scan
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (multi-arch stable)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/api/Dockerfile
+          platforms: ${{ steps.meta.outputs.platforms }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha,scope=papita-api
+          cache-to: type=gha,mode=max,scope=papita-api
+          labels: |
+            org.opencontainers.image.title=save-ma-money-api
+            org.opencontainers.image.description=Papita transactions API (papita_txnsapi)
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.pkg_ver.outputs.version }}
+            org.opencontainers.image.licenses=MIT
+            com.github.papita.module=api
+            com.github.papita.package=papita-transactions-api
+            com.github.papita.image.channel=stable
+
+      - name: Resolve image digests (pin guidance)
+        id: digests
+        env:
+          TAGS_LIST: ${{ steps.meta.outputs.tags_list }}
+        run: |
+          set -euo pipefail
+          {
+            echo "digests_md<<EOF"
+            while IFS= read -r tag; do
+              [[ -z "${tag}" ]] && continue
+              DIGEST="$(docker buildx imagetools inspect "${tag}" 2>/dev/null | awk '/^Digest:/ {print $2; exit}' || true)"
+              if [[ -n "${DIGEST}" ]]; then
+                echo "- \`${tag}@${DIGEST}\`"
+              else
+                echo "- \`${tag}\` (digest lookup unavailable)"
+              fi
+            done <<< "${TAGS_LIST}"
+            echo "EOF"
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Summary
+        env:
+          PKG_VER: ${{ steps.pkg_ver.outputs.version }}
+          IMAGE: ${{ steps.meta.outputs.image }}
+          PLATFORMS: ${{ steps.meta.outputs.platforms }}
+          TAGS_LIST: ${{ steps.meta.outputs.tags_list }}
+          DIGESTS_MD: ${{ steps.digests.outputs.digests_md }}
+          SHORT_SHA: ${{ steps.meta.outputs.short_sha }}
+        run: |
+          {
+            echo "## API image publish — stable (main)"
+            echo ""
+            echo "- Package version: \`${PKG_VER}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- Platforms: \`${PLATFORMS}\`"
+            echo "- Gates: Trivy CRITICAL/HIGH (pre-push) · /health/live smoke"
+            echo "- Tags:"
+            while IFS= read -r tag; do
+              [[ -z "${tag}" ]] && continue
+              echo "  - \`${tag}\`"
+            done <<< "${TAGS_LIST}"
+            echo ""
+            echo "### Prefer digest pins for staging/prod"
+            echo ""
+            echo "${DIGESTS_MD}"
+            echo ""
+            echo "Immutable alternative: \`${IMAGE}:sha-${SHORT_SHA}\`"
+            echo ""
+            echo "SSOT: \`docker/README.md\` · environment: \`ghcr\`"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+  # ---------------------------------------------------------------------------
+  # PR dev preview — never writes :edge / semver / py-api-v* tags.
+  # ---------------------------------------------------------------------------
+  publish-dev:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-api-image-dev')
+    runs-on: ubuntu-latest
+    environment: ghcr-dev
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Read API package version
+        id: pkg_ver
+        run: |
+          set -euo pipefail
+          PKG_VER="$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+          data = tomllib.loads(Path("modules/api/pyproject.toml").read_text())
+          print(data["project"]["version"])
+          PY
+          )"
+          echo "version=${PKG_VER}" >>"${GITHUB_OUTPUT}"
+
+      - name: Decide platforms / tags (dev only)
+        id: meta
+        env:
+          SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
+          PKG_VER: ${{ steps.pkg_ver.outputs.version }}
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          # PR number and SHA come from trusted GitHub event context (not PR body).
+          if [[ ! "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number: ${PR_NUMBER}" >&2
+            exit 1
+          fi
+          OWNER="$(echo "${REPO_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          IMAGE="ghcr.io/${OWNER}/${IMAGE_NAME}"
+          SHORT_SHA="$(echo "${SHA}" | cut -c1-12)"
+          # Dev channel only — never :edge, bare semver, or py-api-v*
+          TAGS=(
+            "${IMAGE}:pr-${PR_NUMBER}"
+            "${IMAGE}:pr-${PR_NUMBER}-${SHORT_SHA}"
+            "${IMAGE}:dev-${RUN_ID}"
+          )
+          for tag in "${TAGS[@]}"; do
+            case "${tag}" in
+              *:edge | *:py-api-v* )
+                echo "Refusing forbidden release tag: ${tag}" >&2
+                exit 1
+                ;;
+            esac
+            # Block bare semver-looking tags (e.g. :0.0.3a14)
+            suffix="${tag##*:}"
+            if [[ "${suffix}" =~ ^[0-9] ]]; then
+              echo "Refusing semver-like tag: ${tag}" >&2
+              exit 1
+            fi
+          done
+          TAGS_CSV="$(IFS=,; echo "${TAGS[*]}")"
+          {
+            echo "image=${IMAGE}"
+            echo "kind=dev"
+            echo "platforms=linux/amd64"
+            echo "short_sha=${SHORT_SHA}"
+            echo "pr=${PR_NUMBER}"
+            echo "dev_version=${PKG_VER}.dev${RUN_ID}+pr${PR_NUMBER}"
+            echo "tags=${TAGS_CSV}"
+            echo "tags_list<<EOF"
+            printf '%s\n' "${TAGS[@]}"
+            echo "EOF"
+          } >>"${GITHUB_OUTPUT}"
+          printf 'dev tags:\n'
+          printf '  %s\n' "${TAGS[@]}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
+      - name: Build amd64 for Trivy gate + smoke
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/api/Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: papita-api:scan
+          cache-from: type=gha,scope=papita-api-dev
+          cache-to: type=gha,mode=max,scope=papita-api-dev
+          labels: |
+            org.opencontainers.image.title=save-ma-money-api
+            org.opencontainers.image.description=Papita transactions API (papita_txnsapi) PR preview
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+            org.opencontainers.image.version=${{ steps.meta.outputs.dev_version }}
+            com.github.papita.image.channel=dev
+
+      - name: Trivy image vulnerability gate
+        uses: ./.github/actions/trivy-api-image-gate
+        with:
+          image-ref: papita-api:scan
+          sarif-category: trivy-api-image-dev
+          sarif-file: trivy-api-image-dev.sarif
+
+      - name: Smoke GET /api/v1/health/live (pre-push)
+        run: /bin/bash .github/scripts/api_image_smoke.sh papita-api:scan
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push amd64 dev tags
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/api/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha,scope=papita-api-dev
+          cache-to: type=gha,mode=max,scope=papita-api-dev
+          labels: |
+            org.opencontainers.image.title=save-ma-money-api
+            org.opencontainers.image.description=Papita transactions API (papita_txnsapi) PR preview
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+            org.opencontainers.image.version=${{ steps.meta.outputs.dev_version }}
+            org.opencontainers.image.licenses=MIT
+            com.github.papita.module=api
+            com.github.papita.package=papita-transactions-api
+            com.github.papita.image.channel=dev
+            com.github.papita.pr.number=${{ github.event.pull_request.number }}
+
+      - name: Summary
+        env:
+          PKG_VER: ${{ steps.pkg_ver.outputs.version }}
+          DEV_VER: ${{ steps.meta.outputs.dev_version }}
+          IMAGE: ${{ steps.meta.outputs.image }}
+          TAGS_LIST: ${{ steps.meta.outputs.tags_list }}
+          PR: ${{ steps.meta.outputs.pr }}
+        run: |
+          {
+            echo "## API image publish — PR dev"
+            echo ""
+            echo "- PR: \`#${PR}\`"
+            echo "- Package version: \`${PKG_VER}\`"
+            echo "- Dev label: \`${DEV_VER}\`"
+            echo "- Image: \`${IMAGE}\`"
+            echo "- Gates: Trivy CRITICAL/HIGH (pre-push) · /health/live smoke"
+            echo "- Tags (dev channel only):"
+            while IFS= read -r tag; do
+              [[ -z "${tag}" ]] && continue
+              echo "  - \`${tag}\`"
+            done <<< "${TAGS_LIST}"
+            echo ""
+            echo "Opt out: label \`skip-api-image-dev\`"
+            echo ""
+            echo "SSOT: \`docker/README.md\` · environment: \`ghcr-dev\`"
+          } >>"${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -44,6 +44,8 @@ jobs:
           scan-ref: .
           scanners: vuln,misconfig
           severity: CRITICAL,HIGH
+          # Keep SARIF + exit-code aligned with severity (see trivy-action entrypoint).
+          limit-severities-for-sarif: true
           format: sarif
           output: trivy-results.sarif
           exit-code: "1"

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -19,6 +19,8 @@ Capture with `/strata:capture` only for work in flight.
 
 ### In progress (ACTIVE)
 
+- **PPT-067 / #132:** Stable GHCR publish from **main only**; PR `publish-dev` → `pr-*`/`dev-*`
+  (skip `skip-api-image-dev`); Environments `ghcr` / `ghcr-dev`; smoke + digest pins.
 - **`feat/bff-oauth-buttons` / [PR #169](https://github.com/Elmorralito/save-ma-money/pull/169):**
   BFF Google/GitHub OAuth (`/bff/auth/oauth/*`), SPA buttons, `access_expires_at`,
   redirect allowlist rebuild + IdP error digests (CodeQL), branding, dashboard TTL +
@@ -27,9 +29,12 @@ Capture with `/strata:capture` only for work in flight.
 ### Open (backlog)
 
 - **PPT-070** children #164–#168 — dues schema/services/API/SPA/tests (not started in code).
+- **PPT-066 / #131** — language-prefixed git tags (`py-api-v*` aligns with PPT-067 image tags).
 
 ### Next action
 
+- Land PPT-067 (#132) PR; first GHCR publish via `workflow_dispatch` or `py-api-v*` tag;
+  set package visibility on GHCR if needed
 - Merge PR #169 once CodeQL / CI green; enable IdP providers + redirect URLs per OAuth doc
 - Start PPT-071 schema when ready for dues
 - Do not re-add closed GH issues into `.strata/issues/`

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,18 @@ redis-down:
 # Vite BFF OAuth cookies/redirects.
 COMPOSE_LOCAL := env -u ALLOWED_ORIGINS docker compose --env-file environments/local/.env -f docker/docker-compose.yml
 
+# Build API image only (local tag; no registry). See docker/README.md (PPT-067).
+api-image-build:
+	@docker info >/dev/null 2>&1 || { \
+		echo "Docker is not running. Start Docker Desktop, then retry: make api-image-build"; \
+		exit 1; \
+	}
+	docker build -f docker/api/Dockerfile -t papita-api:local .
+
 # Canonical API runtime (PPT-045): uvicorn runs inside the Compose image — not on the host.
 # Brings up api + depends_on (Postgres, Redis, migrate). Bind: 0.0.0.0:8000 in-container;
 # host publish via API_PORT (environments/local/.env). No --reload / --workers in the container.
+# Registry publish (GHCR) is PPT-067 — not required for B0; see docker/README.md.
 api-up:
 	$(COMPOSE_LOCAL) up --build -d api
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 ![Python](https://img.shields.io/badge/python-3.12+-blue.svg)
-[![CI Adoption](https://img.shields.io/badge/CI%20Adoption-Advanced%20%7C%20Score%3A%2090-brightgreen?style=flat&logo=githubactions&logoColor=white)](https://github.com/Elmorralito/save-ma-money/actions)
+[![CI Adoption](https://img.shields.io/badge/CI%20Adoption-Advanced%20%7C%20Score%3A%2092-brightgreen?style=flat&logo=githubactions&logoColor=white)](https://github.com/Elmorralito/save-ma-money/actions)
 [![API image](https://img.shields.io/github/actions/workflow/status/Elmorralito/save-ma-money/publish-api-image.yml?branch=main&label=API%20image&logo=docker&logoColor=white)](https://github.com/Elmorralito/save-ma-money/actions/workflows/publish-api-image.yml)
 [![GHCR](https://img.shields.io/badge/ghcr.io-save--ma--money--api-blue?logo=github&logoColor=white)](https://github.com/Elmorralito/save-ma-money/pkgs/container/save-ma-money-api)
 ![interrogate score](./docs/interrogate_badge.svg)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ![Python](https://img.shields.io/badge/python-3.12+-blue.svg)
 [![CI Adoption](https://img.shields.io/badge/CI%20Adoption-Advanced%20%7C%20Score%3A%2090-brightgreen?style=flat&logo=githubactions&logoColor=white)](https://github.com/Elmorralito/save-ma-money/actions)
+[![API image](https://img.shields.io/github/actions/workflow/status/Elmorralito/save-ma-money/publish-api-image.yml?branch=main&label=API%20image&logo=docker&logoColor=white)](https://github.com/Elmorralito/save-ma-money/actions/workflows/publish-api-image.yml)
+[![GHCR](https://img.shields.io/badge/ghcr.io-save--ma--money--api-blue?logo=github&logoColor=white)](https://github.com/Elmorralito/save-ma-money/pkgs/container/save-ma-money-api)
 ![interrogate score](./docs/interrogate_badge.svg)
 [![coverage score](./docs/coverage-badge.svg)](https://app.codecov.io/github/Elmorralito/save-ma-money)
 ![pre-commit.ci status](https://results.pre-commit.ci/badge/github/pre-commit/pre-commit/main.svg)
@@ -126,11 +128,15 @@ save-ma-money/
 │       ├── README.md           # Node 22 + pnpm setup, BFF, OpenAPI types, quality
 │       └── src/
 ├── bin/                        # alembic.sh, test.sh, utils.sh, web_e2e_seed.*
-├── docker/database/            # local Postgres 15 Compose
+├── docker/                     # Compose stack + API/web Dockerfiles; GHCR naming SSOT in README
+│   ├── README.md               # image registry / tags (PPT-067) — B0 still builds locally
+│   ├── api/Dockerfile          # uvicorn CMD (PPT-045); GHCR publish from main (PPT-067)
+│   ├── web/                    # nginx SPA image (PPT-057 / PPT-063)
+│   └── database/               # local Postgres 15 Compose
 ├── docs/design/                # ARCHITECTURE.md (PPT-031) + README gates index
 ├── docs/issues/                # consolidated issue briefs (incl. PPT-046 Part VII)
 ├── .strata/                    # agent memory (hot/warm/cold tiers)
-└── .github/workflows/          # CI (quality, security, migrations, strata, web-ci)
+└── .github/workflows/          # CI (quality, security, migrations, strata, web-ci, GHCR)
 ```
 
 ---

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,165 @@
+# Docker images and Compose
+
+Operator SSOT for **runtime container images** in this monorepo (PPT-067 / [#132](https://github.com/Elmorralito/save-ma-money/issues/132)).
+
+Local B0 still builds from Dockerfiles via Compose (`make api-up` / `make web-up`) — a registry pull is **not** required for day-to-day development.
+
+## Coverage (who owns what)
+
+| Issue                                                                                | Owns                                                                     | Does **not** own                      |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------- |
+| [#93](https://github.com/Elmorralito/save-ma-money/issues/93) PPT-045 **closed**     | API **process packaging** (`docker/api/Dockerfile` uvicorn `CMD`)        | Registry publish / release automation |
+| [#122](https://github.com/Elmorralito/save-ma-money/issues/122) PPT-057 **closed**   | Web **nginx Compose image** (`docker/web/`)                              | API/model image releases              |
+| [#131](https://github.com/Elmorralito/save-ma-money/issues/131) PPT-066              | Language-prefixed **Git tags** (`py-api-v*`, `py-model-v*`, `js-web-v*`) | Container registry images             |
+| [#132](https://github.com/Elmorralito/save-ma-money/issues/132) PPT-067 **this doc** | **API image build + GHCR publish** + naming SSOT                         | Helm/K8s; web registry publish; PyPI  |
+
+PyPI wheels for `papita-transactions-model` stay on `publish-model.yml` / `release-model.yml` (PPT-024).
+
+## Locked decisions (PPT-067)
+
+| Topic                 | Decision                                                                                                  |
+| --------------------- | --------------------------------------------------------------------------------------------------------- |
+| Registry              | **GitHub Container Registry** — `ghcr.io/elmorralito/…`                                                   |
+| API image name        | `ghcr.io/elmorralito/save-ma-money-api`                                                                   |
+| Stable publish        | **`main` only** (path-relevant push or dispatch `publish` on main). No image publish from git tag events. |
+| PR publish            | **Dev channel** tags (`pr-*`, `dev-*`) unless label `skip-api-image-dev`                                  |
+| Model packaging       | **A — no standalone model runtime image.** Model is **PyPI-only**; API image vendors model at build.      |
+| Model “service” image | **C — rejected**                                                                                          |
+| Migrate / Alembic     | Reuse API image with overridden entrypoint (Compose `migrate`).                                           |
+| Provenance            | SBOM / cosign deferred (not MVP).                                                                         |
+| Multi-arch            | Stable (`main`): `linux/amd64` + `linux/arm64`. PR dev: `linux/amd64` only.                               |
+| Vuln gate             | **Trivy** CRITICAL/HIGH before any GHCR push (Environment required reviewers cannot be scanners).         |
+
+### Model = PyPI; API = container
+
+```text
+papita-transactions-model  →  PyPI / TestPyPI (wheels)
+papita_txnsapi runtime     →  GHCR image (vendors model at image build)
+@papita/web nginx          →  Compose/local build today; future GHCR under same naming (not this issue)
+```
+
+## Image tags (API)
+
+Image: **`ghcr.io/elmorralito/save-ma-money-api`**
+
+### Stable channel (`main` only)
+
+| Tag                | Meaning                                              |
+| ------------------ | ---------------------------------------------------- |
+| `edge`             | Moving tip of path-relevant `main` merges            |
+| `{semver}`         | `modules/api/pyproject.toml` version at that commit  |
+| `py-api-v{semver}` | Same version; aligns with PPT-066 naming             |
+| `sha-<12-char>`    | Immutable git commit short SHA — **prefer for pins** |
+
+Git tags such as `py-api-v*` (PPT-066) remain a **source/package** convention; they do **not** trigger image publish. Images are published when the version lands on **`main`**.
+
+### Dev channel (pull requests)
+
+| Tag                    | Meaning                                                       |
+| ---------------------- | ------------------------------------------------------------- |
+| `pr-<N>`               | Latest successful image for PR `#N` (mutable per synchronize) |
+| `pr-<N>-<12-char-sha>` | Immutable image for that PR head                              |
+| `dev-<run_id>`         | Unique per Actions run                                        |
+
+Dev publishes **never** write `:edge`, bare `{semver}`, or `:py-api-v*`.
+
+Skip with PR label **`skip-api-image-dev`** (same-repo non-draft PRs only; forks/drafts skipped).
+
+### Pinning for staging / production
+
+Prefer:
+
+1. **Digest** — `…@sha256:…` (Actions summary after stable publish)
+2. **`sha-<12-char>`** from `main`
+3. Semver / `py-api-v*` — OK with ops discipline; still prefer digest in prod
+
+Do **not** deploy `pr-*` / `dev-*` outside ephemeral PR validation.
+
+### Future web image (convention only)
+
+| Field  | Convention                                                        |
+| ------ | ----------------------------------------------------------------- |
+| Name   | `ghcr.io/elmorralito/save-ma-money-web`                           |
+| Stable | `{semver}`, `js-web-v{semver}`, `sha-<12-char>`, `edge` on `main` |
+| Dev    | `pr-<N>` / `pr-<N>-sha` (follow-up)                               |
+
+## CI workflow
+
+| Workflow          | File                                                                                    |
+| ----------------- | --------------------------------------------------------------------------------------- |
+| Publish API image | [`.github/workflows/publish-api-image.yml`](../.github/workflows/publish-api-image.yml) |
+| Smoke helper      | [`.github/scripts/api_image_smoke.sh`](../.github/scripts/api_image_smoke.sh)           |
+
+**Jobs**
+
+| Job           | Permissions / env                              | When                                                                          |
+| ------------- | ---------------------------------------------- | ----------------------------------------------------------------------------- |
+| `build-smoke` | `contents: read`                               | Dispatch `mode=smoke-only`                                                    |
+| `changes`     | `contents: read`                               | Push to `main` — API path detect                                              |
+| `publish`     | `packages: write` + Environment **`ghcr`**     | `main`: build → **Trivy gate** → smoke → multi-arch push                      |
+| `publish-dev` | `packages: write` + Environment **`ghcr-dev`** | PR: build → **Trivy gate** → smoke → amd64 push (unless `skip-api-image-dev`) |
+
+**Triggers**
+
+| Event                                  | Behavior                                     |
+| -------------------------------------- | -------------------------------------------- |
+| `push` `main` (API/docker/model paths) | Multi-arch stable tags + amd64 smoke         |
+| `pull_request` (same paths)            | Dev tags + amd64 smoke (skippable)           |
+| `workflow_dispatch` `smoke-only`       | Local build + smoke; no push                 |
+| `workflow_dispatch` `publish`          | Must run on **main**; same as stable publish |
+
+**First-time GHCR / Environments**
+
+1. Set package visibility for `save-ma-money-api` (public recommended).
+2. Environments **`ghcr`** (stable; deployment branches limited to `main`) and **`ghcr-dev`** (PR previews).
+3. Optional: add a **human** required reviewer on `ghcr` for manual approval after Trivy passes (scanners cannot be Environment reviewers).
+
+## Local B0 (no registry)
+
+```bash
+make api-up
+make api-image-build
+/bin/bash .github/scripts/api_image_smoke.sh papita-api:local
+make web-up
+```
+
+Compose `migrate` reuses the same API Dockerfile with an Alembic `command` override.
+
+### Optional: pull images
+
+```bash
+# Stable (after merge to main)
+docker pull ghcr.io/elmorralito/save-ma-money-api:sha-<12-char>
+# or digest from Actions summary
+
+# PR preview
+docker pull ghcr.io/elmorralito/save-ma-money-api:pr-<N>
+```
+
+## Security / supply chain
+
+- Base image digest-pinned; Dependabot watches `/docker/api`.
+- Stable publish gated to **main** + Environment `ghcr`.
+- PR `packages: write` only pushes `pr-*` / `dev-*` tags (guarded in workflow).
+- **Automated image review:** [`.github/actions/trivy-api-image-gate`](../.github/actions/trivy-api-image-gate/action.yml) fails the job on unfixed **CRITICAL/HIGH** findings and uploads SARIF to the Security tab. This is the equivalent of an automated environment “reviewer” — GitHub only allows people/teams as Environment required reviewers.
+- Optional: add yourself as a human required reviewer on Environment `ghcr` for an extra manual approval after Trivy passes.
+- No secrets in Dockerfiles.
+- Cosign / SBOM deferred.
+
+## Layout
+
+| Path                                                           | Role                                          |
+| -------------------------------------------------------------- | --------------------------------------------- |
+| [`api/Dockerfile`](./api/Dockerfile)                           | API + vendored model; uvicorn `CMD` (PPT-045) |
+| [`web/Dockerfile`](./web/Dockerfile)                           | SPA → nginx (PPT-057 / PPT-063)               |
+| [`docker-compose.yml`](./docker-compose.yml)                   | B0 full stack                                 |
+| [`database/docker-compose.yml`](./database/docker-compose.yml) | Postgres (+ Redis) only                       |
+| [`redis/redis.conf`](./redis/redis.conf)                       | Redis config                                  |
+
+## References
+
+- PPT-067 / [#132](https://github.com/Elmorralito/save-ma-money/issues/132)
+- PPT-045 / [#93](https://github.com/Elmorralito/save-ma-money/issues/93)
+- PPT-057 / [#122](https://github.com/Elmorralito/save-ma-money/issues/122)
+- PPT-066 / [#131](https://github.com/Elmorralito/save-ma-money/issues/131)
+- [`.github/CI.md`](../.github/CI.md)

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libpq5 libpq-dev gcc \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir "pip>=25.0"
+    && pip install --no-cache-dir "pip>=26.1.2"
 
 # Model package (includes Alembic migrations and config data)
 COPY modules/model/pyproject.toml modules/model/README.md modules/model/LICENSE /app/modules/model/

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,7 +1,11 @@
 # Papita Transactions API - B0 local / B1 pooler runtime
 # Build context: repository root (docker compose: context: .., dockerfile: docker/api/Dockerfile)
+# Registry publish: GHCR via .github/workflows/publish-api-image.yml (PPT-067 / #132)
+# Naming SSOT: docker/README.md
+#
+# Base digest pinned for supply-chain stability; Dependabot (docker /docker/api) refreshes it.
 
-FROM python:3.12-slim-bookworm
+FROM python:3.12-slim-bookworm@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b
 
 WORKDIR /app
 

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libpq5 libpq-dev gcc \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir "pip>=26.1.2"
+    && pip install --no-cache-dir "pip>=26.1.2" "setuptools>=78.1.1"
 
 # Model package (includes Alembic migrations and config data)
 COPY modules/model/pyproject.toml modules/model/README.md modules/model/LICENSE /app/modules/model/
@@ -24,7 +24,10 @@ COPY modules/model/alembic.ini /app/modules/model/
 COPY modules/api/pyproject.toml modules/api/README.md modules/api/LICENSE /app/modules/api/
 COPY modules/api/src /app/modules/api/src
 
+# Upgrade transitive / base tooling after package install so Trivy CRITICAL/HIGH stays green
+# (msgpack via redis stack; setuptools from python:slim base).
 RUN pip install --no-cache-dir /app/modules/model /app/modules/api \
+    && pip install --no-cache-dir --upgrade "msgpack>=1.2.1" "setuptools>=78.1.1" \
     && groupadd --system --gid 1001 appuser \
     && useradd --system --uid 1001 --gid appuser --home-dir /app appuser \
     && chown -R appuser:appuser /app

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,9 @@
 #   make web-up    # nginx SPA (:3000) + API deps; same-origin /api → BFF cookies (PPT-057)
 #   # uvicorn runs inside the api image (Dockerfile CMD) — not on the host
 #
+# Image naming / GHCR publish (PPT-067): docker/README.md — B0 builds from Dockerfiles here;
+# registry pull is optional for staging/prod pins.
+#
 # API (direct): http://localhost:8000/api/docs
 # Web (nginx):  http://localhost:3000/  (WEB_PORT) — /api proxied to api:8000
 # Health: http://localhost:8000/api/v1/health/ready  (or via nginx :3000/api/v1/health/live)

--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -4165,7 +4165,7 @@ ASGI target: `papita_txnsapi.main:app`. Compose `api` keeps `REDIS_URL=redis://r
 Kubernetes / ECS / systemd · TLS / reverse proxy · gunicorn worker fleet (unless ADR) · REST or
 `papita_txnsmodel` business-logic changes · Registrar / DuckDB / RLS (B3) · full PPT-044 security
 pack ([Part VIII](#part-viii--post-mvp-api-hardening-ppt-044-89) / #89) · host Poetry uvicorn as a
-supported B0 runtime.
+supported B0 runtime · **GHCR / registry image publish** (owned by PPT-067 / [#132](https://github.com/Elmorralito/save-ma-money/issues/132) — [`docker/README.md`](../../docker/README.md)).
 
 ### 4. References
 
@@ -4173,7 +4173,9 @@ supported B0 runtime.
 - [PR #103](https://github.com/Elmorralito/save-ma-money/pull/103) — closing PR
 - [`docker/api/Dockerfile`](../../docker/api/Dockerfile) — uvicorn `CMD` + healthcheck
 - [`docker/docker-compose.yml`](../../docker/docker-compose.yml) — `api` service
+- [`docker/README.md`](../../docker/README.md) — GHCR naming + publish (PPT-067 / #132; distinct from this part)
 - [`Makefile`](../../Makefile) — `api-up`, `api-down`, `stack-up`, `redis-up`, `redis-smoke`
 - [`modules/api/src/papita_txnsapi/main.py`](../../modules/api/src/papita_txnsapi/main.py) — `create_app`, lifespan
 - [#83](https://github.com/Elmorralito/save-ma-money/issues/83) — PPT-043 Redis lifespan / ready
 - [#89](https://github.com/Elmorralito/save-ma-money/issues/89) — PPT-044 hardening (distinct scope)
+- [#132](https://github.com/Elmorralito/save-ma-money/issues/132) — PPT-067 API image registry publish

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -79,7 +79,7 @@ Part V in [`ARCHITECTURE.md`](ARCHITECTURE.md#part-v--api-coverage-matrix-ppt-03
 
 ## Ops (Redis + optional B1 pooler)
 
-Canonical contract detail stays in [`modules/api/README.md`](../../modules/api/README.md). Env layout: [`environments/README.md`](../../environments/README.md). Design summary: [Part VIII](ARCHITECTURE.md#part-viii--post-mvp-api-hardening-ppt-044-89). Packaging: [Part IX](ARCHITECTURE.md#part-ix--uvicorn-process-packaging-ppt-045-93).
+Canonical contract detail stays in [`modules/api/README.md`](../../modules/api/README.md). Env layout: [`environments/README.md`](../../environments/README.md). Design summary: [Part VIII](ARCHITECTURE.md#part-viii--post-mvp-api-hardening-ppt-044-89). Packaging: [Part IX](ARCHITECTURE.md#part-ix--uvicorn-process-packaging-ppt-045-93). **Container registry (API GHCR publish, PPT-067 / [#132](https://github.com/Elmorralito/save-ma-money/issues/132)):** [`docker/README.md`](../../docker/README.md) — not Helm; model stays PyPI.
 
 ### Redis (PPT-043 / B0 + B1)
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -1902,6 +1902,7 @@ When PPT-036–038 land, apply cache-aside on hot GETs:
 
 > Post-MVP ops packaging brief. Closed ([#93](https://github.com/Elmorralito/save-ma-money/issues/93), [PR #103](https://github.com/Elmorralito/save-ma-money/pull/103)).
 > Technical packaging: [`ARCHITECTURE.md` Part IX](../design/ARCHITECTURE.md#part-ix--uvicorn-process-packaging-ppt-045-93) · operator run paths: [`modules/api/README.md`](../../modules/api/README.md).
+> **Not this part:** API registry image publish is PPT-067 / [#132](https://github.com/Elmorralito/save-ma-money/issues/132) — [`docker/README.md`](../../docker/README.md).
 
 **Parent program:** [#28](https://github.com/Elmorralito/save-ma-money/issues/28) (PPT-031) · **Parent epic:** [#42](https://github.com/Elmorralito/save-ma-money/issues/42) (PPT-032) · **PPT-045** · **Step:** Post-MVP ops packaging
 

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -223,6 +223,8 @@ make api-up
 
 In-container bind is literal `0.0.0.0:8000` ([`docker/api/Dockerfile`](../../docker/api/Dockerfile) `CMD` — no `--reload` / `--workers`). Host publish uses Compose `API_PORT` (`${API_PORT}:8000`). Settings `HOST`/`PORT` are **unused for bind** (env-file compatibility only).
 
+**Registry images (PPT-067 / [#132](https://github.com/Elmorralito/save-ma-money/issues/132)):** stable GHCR tags publish from **`main` only**; PRs get `pr-*` / `dev-*` previews unless labeled `skip-api-image-dev`. Prefer digest or `sha-*` pins for staging/prod. Naming, Decision A, and pull examples: [`docker/README.md`](../../docker/README.md). B0: `make api-up` / `make api-image-build` (no registry).
+
 | Service      | URL                                       |
 | ------------ | ----------------------------------------- |
 | Swagger UI   | http://localhost:8000/api/docs            |


### PR DESCRIPTION
**Branch:** `ops/PPT-067` (tracks `origin/ops/PPT-067`, clean) · **Base:** `main` · **7 commits** · **18+ files**

**Suggested title:** `ops/PPT-067: [infra] Publish versioned Docker images for API`

## Summary

Closes the PPT-067 gap where Compose could build the API image locally but CI never published versioned runtime artifacts to a registry. Stable images now publish to GHCR from `main` only (edge / semver / `py-api-v*` / sha tags); same-repo PRs get skippable `pr-*` / `dev-*` preview tags. Pre-push Trivy CRITICAL/HIGH (rootfs gate) and `/api/v1/health/live` smoke gate pushes. Decision A is locked: model stays on PyPI; Compose migrate reuses the API image (no separate migrate runtime image). Helm remains out of scope.

## Out of scope / Highlights

**Out of scope**

- Helm charts / full-platform packaging
- Separate model or migrate runtime images (Decision A: model = PyPI)
- Driving shields.io badges via `auto-updates.yml` (badges resolve at render time)
- First post-merge GHCR package visibility / optional human reviewers on Environment `ghcr`

**Highlights**

- Main-only stable publish + PR `publish-dev` with label `skip-api-image-dev`
- Rootfs Trivy CRITICAL/HIGH gate (avoids stale third-party SBOM false positives) + SARIF upload
- Environments `ghcr` / `ghcr-dev`; digest-pinned Python base; Dependabot docker for `/docker/api`
- `docker/README.md` as registry/naming SSOT; root README API image + GHCR badges

## Changes

**CI / ops**

- New workflow `publish-api-image.yml`: path detect → stable publish on `main` / dispatch `publish`; PR `publish-dev` for non-draft PRs
- Composite action `trivy-api-image-gate` (export rootfs → Trivy table gate; strip embedded SBOMs; SARIF non-gating) + `api_image_smoke.sh`
- Dependabot weekly docker updates for `/docker/api`
- Makefile `api-image-build`; Compose pointer to `docker/README.md`
- Docs: `.github/CI.md`, issue conventions (`skip-api-image-dev`), AGENTS / project_structure

**Docker**

- `docker/README.md`: registry, tags, Decision A, coverage vs PPT-045/057/066
- `docker/api/Dockerfile`: pin base by digest; raise `pip` / `setuptools` / `msgpack` floors for known HIGHs

**Docs / memory**

- Root / API README badges and pointers; ARCHITECTURE Part IX + design/issues indexes
- Strata `project_state.md` session note for PPT-067

## File changes

<details>
<summary>File changes (see tip vs main)</summary>

```
.github/workflows/publish-api-image.yml
.github/actions/trivy-api-image-gate/action.yml
.github/scripts/api_image_smoke.sh
.github/dependabot.yml
.github/CI.md
.github/workflows/trivy.yml
docker/README.md
docker/api/Dockerfile
docker/docker-compose.yml
Makefile
README.md
modules/api/README.md
docs/design/ARCHITECTURE.md
docs/design/README.md
docs/issues/README.md
.cursor/AGENTS.md
.cursor/rules/gen-custom/*
.strata/memory/project_state.md
```

</details>

## Commits

- `da7fdb3` ops(infra): publish versioned API Docker images to GHCR
- `b1e2841` ci: update CI adoption badge [skip ci]
- `7ffda93` fix(ci): keep Trivy SARIF exit-code on CRITICAL/HIGH only
- `e3bfaaa` fix(docker): upgrade setuptools and msgpack for Trivy HIGH gate
- `dd4f7e6` fix(ci): harden API image Trivy gate against scan drift
- `f1c7af7` fix(ci): scan API image rootfs to ignore stale SBOM attestations
- `6ec8ecc` fix(ci): strip embedded third-party SBOMs before API image Trivy gate

## Checks, tests, and validation already done

- [x] Local `make api-image-build` + smoke on `papita-api:local` (session, pre-PR)
- [x] `actionlint` clean on `publish-api-image.yml`
- [x] Pre-commit on commits (prettier, ShellCheck, yamllint, actionlint, strata, markdownlint)
- [x] Remote CI on tip `6ec8ecc`: all completed checks green, including **Publish API image** (`publish-dev`)
- [ ] First `main` publish after merge — **deferred to post-merge**

## QA / test plan

- [x] Confirm PR triggers `publish-dev` and does **not** push `:edge` / semver tags
- [ ] After merge to `main` (path-relevant or dispatch `publish`): tags `:edge`, `:{semver}`, `:py-api-v{semver}`, `:sha-<12>` appear on GHCR package `save-ma-money-api`
- [x] Trivy CRITICAL/HIGH gate + smoke path exercised on PR (`publish-dev` success)
- [ ] Set GHCR package visibility as intended (often private until first push)
- [ ] Optional: add human required reviewers on Environment `ghcr`
- [ ] Confirm B0 Compose still builds from Dockerfiles without requiring a registry pull

## Risks

> [!CAUTION]
>
> ### Risks
>
> - First publish creates the GHCR package; visibility and package permissions may need an operator pass after merge.
> - Environments `ghcr` / `ghcr-dev` must exist (`ghcr` deployment branches limited to `main`).
> - Trivy CRITICAL/HIGH rootfs gate can still block on real OS/library findings; Dependabot docker track helps for the base digest.
> - Stable tags move on `main` (`:edge` and semver rewrite on publish) — pin by digest or `sha-<12>` for immutability.

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - Git tag events (`py-api-v*`) do **not** trigger this workflow; version tags come from the API package version on `main` publish / dispatch.
> - PR preview tags are same-repo only; forks do not publish.
> - Image builds set `provenance: false` / `sbom: false` so Trivy is not poisoned by stale BuildKit/third-party SBOMs; gate scans exported rootfs.
> - No Helm; model remains PyPI-only for runtime distribution.

## References

- Closes [#132](https://github.com/Elmorralito/save-ma-money/issues/132) (ops/PPT-067)
- [`docker/README.md`](https://github.com/Elmorralito/save-ma-money/blob/ops/PPT-067/docker/README.md) — registry/naming SSOT
- [`.github/CI.md`](https://github.com/Elmorralito/save-ma-money/blob/ops/PPT-067/.github/CI.md) — workflow + skip label
- [`ARCHITECTURE.md` Part IX](https://github.com/Elmorralito/save-ma-money/blob/ops/PPT-067/docs/design/ARCHITECTURE.md) — packaging notes