### PR TITLE
feat/PPT-071: [model] Schema and migration for payment dues on transaction_templates

### DIFF
--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -28,19 +28,21 @@ Capture with `/strata:capture` only for work in flight.
 
 ### In progress (ACTIVE)
 
+- **PPT-071 / #164:** schema + Alembic for payment dues on `transaction_templates`
+  (`due_date`, `remind_days_before`, `from_account_id`; head → `j7e8f9a0b1c2`).
 - **[PR #193](https://github.com/Elmorralito/save-ma-money/pull/193):** GHA Dependabot bumps +
   e2e login/nav hardening + Hadolint HEALTHCHECK JSON / DL3066 ignore.
 
 ### Open (backlog)
 
-- **PPT-070** children #164–#168 — dues schema/services/API/SPA/tests (not started in code).
+- **PPT-070** children #165–#168 — services/API/SPA/tests after PPT-071 lands.
 - **PPT-066 follow-up:** after 1–2 releases, drop legacy `model-v*` publish trigger.
 
 ### Next action
 
+- Finish PPT-071 verification (migration check + focused tests); open PR for #164
+- PPT-072 / #165 upcoming-dues + mark-paid (owner check on `from_account_id`)
 - Merge PR #193; set GHCR package visibility if needed
-- Verify next model release produces `py-model-v*`; close #131 when dual-trigger docs + CI land
-- Start PPT-071 schema when ready for dues
 - Do not re-add closed GH issues into `.strata/issues/`
 
 ### Uncommitted / staging notes

--- a/modules/model/alembic/versions/2026_08_06_1500-j7e8f9a0b1c2_ppt_071_transaction_templates_payment_dues.py
+++ b/modules/model/alembic/versions/2026_08_06_1500-j7e8f9a0b1c2_ppt_071_transaction_templates_payment_dues.py
@@ -1,0 +1,82 @@
+# pylint: disable=C0103
+"""Add payment-due columns on transaction_templates (PPT-071 / #164).
+
+Revision ID: j7e8f9a0b1c2
+Revises: i6d7e8f9a0b1
+Create Date: 2026-08-06 15:00:00.000000+00:00
+
+Additive nullable columns only — no backfill. Paid state remains derived from
+posted ``transactions.template_id`` (mark-paid in PPT-072), not template flags.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from papita_txnsmodel.model.contstants import (
+    ACCOUNTS__TABLENAME,
+    SCHEMA_NAME,
+    TRANSACTION_TEMPLATES__TABLENAME,
+)
+
+revision: str = "j7e8f9a0b1c2"
+down_revision: Union[str, Sequence[str], None] = "i6d7e8f9a0b1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_FK_FROM_ACCOUNT = "fk_transaction_templates_from_account_id"
+_IX_OWNER_DUE_DATE = "ix_transaction_templates_owner_due_date"
+
+
+def upgrade() -> None:
+    """Add due_date, remind_days_before, and optional pay-from account FK."""
+    op.add_column(
+        TRANSACTION_TEMPLATES__TABLENAME,
+        sa.Column("due_date", sa.Date(), nullable=True),
+        schema=SCHEMA_NAME,
+    )
+    op.add_column(
+        TRANSACTION_TEMPLATES__TABLENAME,
+        sa.Column("remind_days_before", sa.SmallInteger(), nullable=True),
+        schema=SCHEMA_NAME,
+    )
+    op.add_column(
+        TRANSACTION_TEMPLATES__TABLENAME,
+        sa.Column("from_account_id", sa.Uuid(), nullable=True),
+        schema=SCHEMA_NAME,
+    )
+    op.create_foreign_key(
+        _FK_FROM_ACCOUNT,
+        TRANSACTION_TEMPLATES__TABLENAME,
+        ACCOUNTS__TABLENAME,
+        ["from_account_id"],
+        ["id"],
+        source_schema=SCHEMA_NAME,
+        referent_schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        _IX_OWNER_DUE_DATE,
+        TRANSACTION_TEMPLATES__TABLENAME,
+        ["owner_id", "due_date"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+
+
+def downgrade() -> None:
+    """Drop payment-due columns and supporting FK/index."""
+    op.drop_index(
+        _IX_OWNER_DUE_DATE,
+        table_name=TRANSACTION_TEMPLATES__TABLENAME,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_constraint(
+        _FK_FROM_ACCOUNT,
+        TRANSACTION_TEMPLATES__TABLENAME,
+        schema=SCHEMA_NAME,
+        type_="foreignkey",
+    )
+    op.drop_column(TRANSACTION_TEMPLATES__TABLENAME, "from_account_id", schema=SCHEMA_NAME)
+    op.drop_column(TRANSACTION_TEMPLATES__TABLENAME, "remind_days_before", schema=SCHEMA_NAME)
+    op.drop_column(TRANSACTION_TEMPLATES__TABLENAME, "due_date", schema=SCHEMA_NAME)

--- a/modules/model/src/papita_txnsmodel/access/transactions/dto.py
+++ b/modules/model/src/papita_txnsmodel/access/transactions/dto.py
@@ -43,6 +43,9 @@ class TransactionTemplatesDTO(OwnedTableDTO, CoreTableDTO):
         planned_amount (float): Expected transaction amount. Must be positive.
         planned_day (int): Day of the month when the transaction is expected (1-31).
         use_month_end (bool): Whether to schedule on the last day of the month.
+        due_date (datetime.date | None): Optional one-off calendar due date (PPT-071).
+        remind_days_before (int | None): Optional lead days before due for in-app reminders.
+        from_account_id (uuid.UUID | AccountsDTO | None): Optional pay-from account.
     """
 
     __dao_type__ = TransactionTemplates
@@ -51,17 +54,32 @@ class TransactionTemplatesDTO(OwnedTableDTO, CoreTableDTO):
     planned_amount: float = Field(gt=0, description="Expected value of the transaction")
     planned_day: int = Field(ge=1, le=31, description="Day of the month when the transaction is expected to occur")
     use_month_end: bool = False
+    due_date: datetime.date | None = Field(
+        default=None,
+        description="One-off payment due calendar date; recurring templates leave this null",
+    )
+    remind_days_before: int | None = Field(
+        default=None,
+        ge=0,
+        description="Days before due to surface an in-app reminder; null means no lead window",
+    )
+    from_account_id: uuid.UUID | AccountsDTO | None = Field(
+        default=None,
+        description="Optional account to pay from when marking a due as paid",
+    )
 
-    @field_serializer("category_id")
-    def _serialize_category_id(self, value: uuid.UUID | TableDTO) -> uuid.UUID:
-        """Serialize category_id to its UUID value.
+    @field_serializer("category_id", "from_account_id")
+    def _serialize_template_relations(self, value: uuid.UUID | TableDTO | None) -> uuid.UUID | None:
+        """Serialize category_id / from_account_id to UUID values.
 
         Args:
-            value: Category as UUID or DTO.
+            value: Relation as UUID, DTO, or None.
 
         Returns:
-            uuid.UUID: The category UUID.
+            uuid.UUID | None: The related entity UUID, or None.
         """
+        if value is None:
+            return None
         return _serialize_relation_id(value)
 
 

--- a/modules/model/src/papita_txnsmodel/model/transactions.py
+++ b/modules/model/src/papita_txnsmodel/model/transactions.py
@@ -1,10 +1,10 @@
 """Transaction templates and posted transactions (v3)."""
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 from typing import TYPE_CHECKING, List, Optional
 
-from sqlalchemy import ARRAY, CHAR, DECIMAL, TIMESTAMP, Column
+from sqlalchemy import ARRAY, CHAR, DECIMAL, TIMESTAMP, Column, Date
 from sqlalchemy import Enum as SAEnum
 from sqlalchemy import Index, SmallInteger, String, Text
 from sqlmodel import Field, Relationship
@@ -26,11 +26,12 @@ if TYPE_CHECKING:
 
 
 class TransactionTemplates(BaseSQLModel, table=True):  # type: ignore
-    """Recurring or planned transaction template."""
+    """Recurring or planned transaction template (including payment-due reminders)."""
 
     __tablename__ = TRANSACTION_TEMPLATES__TABLENAME
     __table_args__ = (
         Index("ix_transaction_templates_owner_category", "owner_id", "category_id"),
+        Index("ix_transaction_templates_owner_due_date", "owner_id", "due_date"),
         {"schema": SCHEMA_NAME},
     )
 
@@ -43,6 +44,11 @@ class TransactionTemplates(BaseSQLModel, table=True):  # type: ignore
     planned_amount: float = Field(sa_column=Column(DECIMAL(22, 8), nullable=False), gt=0)
     planned_day: int = Field(sa_column=Column(SmallInteger, nullable=False), ge=1, le=31)
     use_month_end: bool = Field(nullable=False, default=False)
+    # PPT-071 / #164 — payment due reminders (in-app). Precedence for due resolution
+    # (one-off ``due_date`` vs recurring ``planned_day`` / ``use_month_end``) is service-owned (PPT-072).
+    due_date: date | None = Field(default=None, sa_column=Column(Date, nullable=True))
+    remind_days_before: int | None = Field(default=None, sa_column=Column(SmallInteger, nullable=True), ge=0)
+    from_account_id: uuid.UUID | None = Field(foreign_key=f"{ACCOUNTS__TABLENAME}.id", default=None, nullable=True)
 
     owner: "Users" = Relationship(back_populates="owned_transaction_templates")
     category: "Categories" = Relationship(back_populates="transaction_templates")

--- a/modules/model/tests/tests_papita_txnsmodel/access/transactions/test_transaction_templates_dto.py
+++ b/modules/model/tests/tests_papita_txnsmodel/access/transactions/test_transaction_templates_dto.py
@@ -1,0 +1,77 @@
+"""Unit tests for TransactionTemplatesDTO payment-due fields (PPT-071)."""
+
+import datetime
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from papita_txnsmodel.access.transactions.dto import TransactionTemplatesDTO
+from papita_txnsmodel.model.transactions import TransactionTemplates
+
+
+def _base_kwargs(**overrides):
+    """Minimal valid template payload with optional field overrides."""
+    payload = {
+        "owner_id": uuid.uuid4(),
+        "category_id": uuid.uuid4(),
+        "name": "Rent",
+        "planned_amount": 1200.0,
+        "planned_day": 1,
+        "use_month_end": False,
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestTransactionTemplatesDTOPaymentDues:
+    """PPT-071 additive due fields round-trip and validate."""
+
+    def test_defaults_leave_due_fields_null(self):
+        """Existing recurring shape stays valid without due columns set."""
+        dto = TransactionTemplatesDTO(**_base_kwargs())
+        assert dto.due_date is None
+        assert dto.remind_days_before is None
+        assert dto.from_account_id is None
+
+    def test_accepts_one_off_due_fields(self):
+        """One-off due date, remind lead, and pay-from account are stored."""
+        account_id = uuid.uuid4()
+        due = datetime.date(2026, 9, 15)
+        dto = TransactionTemplatesDTO(
+            **_base_kwargs(
+                due_date=due,
+                remind_days_before=3,
+                from_account_id=account_id,
+            )
+        )
+        assert dto.due_date == due
+        assert dto.remind_days_before == 3
+        assert dto.from_account_id == account_id
+
+    def test_remind_days_before_rejects_negative(self):
+        """Lead window cannot be negative."""
+        with pytest.raises(ValidationError):
+            TransactionTemplatesDTO(**_base_kwargs(remind_days_before=-1))
+
+    def test_from_dao_round_trip_includes_due_fields(self):
+        """DAO → DTO preserves payment-due columns."""
+        owner_id = uuid.uuid4()
+        category_id = uuid.uuid4()
+        account_id = uuid.uuid4()
+        due = datetime.date(2026, 10, 1)
+        dao = TransactionTemplates(
+            owner_id=owner_id,
+            category_id=category_id,
+            name="Insurance",
+            planned_amount=50.0,
+            planned_day=1,
+            use_month_end=False,
+            due_date=due,
+            remind_days_before=7,
+            from_account_id=account_id,
+        )
+        dto = TransactionTemplatesDTO.from_dao(dao)
+        assert dto.due_date == due
+        assert dto.remind_days_before == 7
+        assert dto.from_account_id == account_id

--- a/modules/model/tests/tests_papita_txnsmodel/model/test_model_indexes.py
+++ b/modules/model/tests/tests_papita_txnsmodel/model/test_model_indexes.py
@@ -29,6 +29,11 @@ class TestModelTableIndexes:
         index_names = {index.name for index in TransactionTemplates.__table__.indexes}
         assert "ix_transaction_templates_owner_category" in index_names
 
+    def test_transaction_templates_has_owner_due_date_index(self):
+        """One-off payment dues are listed per owner and due_date (PPT-071)."""
+        index_names = {index.name for index in TransactionTemplates.__table__.indexes}
+        assert "ix_transaction_templates_owner_due_date" in index_names
+
     def test_categories_has_unique_owner_name_kind_index(self):
         """FR-15 uniqueness constraint remains on the model."""
         index_names = {index.name for index in Categories.__table__.indexes}


### PR DESCRIPTION
**Branch:** `feat/PPT-071` · **Base:** `main` · **1 commit** · **6 files**

**Suggested title:** `feat/PPT-071: [model] Schema and migration for payment dues on transaction_templates`

## Summary

Delivers **PPT-071 / #164** (epic [#163](https://github.com/Elmorralito/save-ma-money/issues/163) step 0): additive payment-due fields on `transaction_templates` so later steps can query upcoming dues and mark paid without inventing schema. Templates previously only had `planned_day` / `use_month_end`; they now also support one-off `due_date`, `remind_days_before`, and optional pay-from `from_account_id`, with a reversible Alembic revision on B0 Postgres.

## Out of scope / Highlights

**Out of scope**

- Upcoming-dues / mark-paid services ([#165](https://github.com/Elmorralito/save-ma-money/issues/165) PPT-072)
- API routers ([#166](https://github.com/Elmorralito/save-ma-money/issues/166)) and SPA ([#167](https://github.com/Elmorralito/save-ma-money/issues/167))
- v4.2 `recurrence_*` / RRULE and paid-state columns on templates
- Owner-match CHECK for `from_account_id` (service-owned in PPT-072)

**Highlights**

- Additive nullable columns only — no backfill; Compose/local can still build without registry
- Index `(owner_id, due_date)` ready for one-off due listings
- Paid state remains derived from posted `transactions.template_id`

## Changes

**Model**

- `TransactionTemplates`: `due_date` (DATE), `remind_days_before` (SMALLINT), `from_account_id` FK → `accounts`
- Keep `planned_day` / `use_month_end`; due-resolution precedence documented as PPT-072-owned

**DTO**

- `TransactionTemplatesDTO` mirrors new fields; `remind_days_before >= 0`; serialize `from_account_id`

**Migrations**

- Alembic `j7e8f9a0b1c2` after `i6d7e8f9a0b1`: columns + FK + `ix_transaction_templates_owner_due_date`; reversible downgrade

**Tests**

- Index assertion + DTO unit coverage (defaults, negative remind rejection, `from_dao` round-trip)

**Ops / memory**

- Strata `project_state` marks PPT-071 in progress and hands off to PPT-072

## File changes

<details>
<summary>File changes (6 files)</summary>

```
 .strata/memory/project_state.md                                            |  8 ++-
 .../2026_08_06_1500-j7e8f9a0b1c2_ppt_071_transaction_templates_payment_dues.py | 82 ++++++++++++++++++++++
 modules/model/src/papita_txnsmodel/access/transactions/dto.py              | 30 +++++---
 modules/model/src/papita_txnsmodel/model/transactions.py                   | 12 +++-
 .../access/transactions/test_transaction_templates_dto.py                 | 77 ++++++++++++++++++++
 modules/model/tests/tests_papita_txnsmodel/model/test_model_indexes.py      |  5 ++
 6 files changed, 202 insertions(+), 12 deletions(-)
```

</details>

## Commits

- `0d342bc` feat/PPT-071: [model] Add payment-due columns on transaction_templates

## Checks, tests, and validation already done

- Pre-commit on commit — pass (black/isort/flake8/pylint/mypy/interrogate/strata validate)
- `poetry run pytest` focused model index + DTO tests — 10 passed (this session)
- Fresh-volume B0 `migration_check.sh` (upgrade → downgrade -1 → upgrade → `alembic check`) — pass (this session)
- CI on this PR — not observed yet

## QA / test plan

- [ ] Migration Check workflow green on the PR
- [ ] Code Quality / model tests green on the PR
- [ ] Confirm Alembic head is `j7e8f9a0b1c2` after upgrade on a clean B0 DB
- [ ] Spot-check that existing template rows migrate with NULL due fields

## Risks

> [!CAUTION]
>
> ### Risks
>
> - **Migration:** new Alembic head `j7e8f9a0b1c2` must run on every environment before PPT-072 code expects the columns
> - **Semantics:** one-off `due_date` vs recurring `planned_day` precedence is not enforced in DB — PPT-072 must own it
> - **Tenant safety:** `from_account_id` is FK-only; cross-owner misuse must be rejected in PPT-072 services

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - No upcoming-dues or mark-paid behavior in this PR
> - `planned_day` remains NOT NULL for one-offs (product convention until PPT-072 documents precedence)
> - ARCHITECTURE.md schema tables not updated here (docs pass deferred toward PPT-075)

## References

- Closes [#164](https://github.com/Elmorralito/save-ma-money/issues/164) (PPT-071)
- Parent epic [#163](https://github.com/Elmorralito/save-ma-money/issues/163) (PPT-070)
- Blocks [#165](https://github.com/Elmorralito/save-ma-money/issues/165) (PPT-072)

Made with [Cursor](https://cursor.com)