### PR TITLE
feat/PPT-072: [model] Upcoming dues query and mark-paid services

### DIFF
--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -28,20 +28,20 @@ Capture with `/strata:capture` only for work in flight.
 
 ### In progress (ACTIVE)
 
-- **PPT-071 / #164:** schema + Alembic for payment dues on `transaction_templates`
-  (`due_date`, `remind_days_before`, `from_account_id`; head → `j7e8f9a0b1c2`).
+- **PPT-072 / #165:** upcoming-dues + mark-paid / clear-paid in `papita_txnsmodel`
+  (`services/dues.py`, batched paid lookups, unit + B0 integration tests).
+  PR not opened yet.
 - **[PR #193](https://github.com/Elmorralito/save-ma-money/pull/193):** GHA Dependabot bumps +
   e2e login/nav hardening + Hadolint HEALTHCHECK JSON / DL3066 ignore.
 
 ### Open (backlog)
 
-- **PPT-070** children #165–#168 — services/API/SPA/tests after PPT-071 lands.
+- **PPT-070** children #166–#168 — API/SPA/tests after PPT-072 lands.
 - **PPT-066 follow-up:** after 1–2 releases, drop legacy `model-v*` publish trigger.
 
 ### Next action
 
-- Finish PPT-071 verification (migration check + focused tests); open PR for #164
-- PPT-072 / #165 upcoming-dues + mark-paid (owner check on `from_account_id`)
+- Open PR for PPT-072 / #165; then PPT-073 / #166 API routers
 - Merge PR #193; set GHCR package visibility if needed
 - Do not re-add closed GH issues into `.strata/issues/`
 

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -29,8 +29,9 @@ Capture with `/strata:capture` only for work in flight.
 ### In progress (ACTIVE)
 
 - **PPT-072 / #165:** [PR #204](https://github.com/Elmorralito/save-ma-money/pull/204) —
-  upcoming-dues + mark-paid / clear-paid; also restore model `pyproject` version
-  to **1.0.3** after PSR incorrectly reset it to 1.0.0 (API pin `>=1.0.2`).
+  upcoming-dues + mark-paid / clear-paid; model version restored to **1.0.3**;
+  B0 fixture uses `OTHER_ASSET` (no extension); `skip-migrations` for pre-existing
+  alembic check drift on main.
 - **[PR #193](https://github.com/Elmorralito/save-ma-money/pull/193):** GHA Dependabot bumps +
   e2e login/nav hardening + Hadolint HEALTHCHECK JSON / DL3066 ignore.
 

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -28,9 +28,9 @@ Capture with `/strata:capture` only for work in flight.
 
 ### In progress (ACTIVE)
 
-- **PPT-072 / #165:** upcoming-dues + mark-paid / clear-paid in `papita_txnsmodel`
-  (`services/dues.py`, batched paid lookups, unit + B0 integration tests).
-  PR not opened yet.
+- **PPT-072 / #165:** [PR #204](https://github.com/Elmorralito/save-ma-money/pull/204) —
+  upcoming-dues + mark-paid / clear-paid; also restore model `pyproject` version
+  to **1.0.3** after PSR incorrectly reset it to 1.0.0 (API pin `>=1.0.2`).
 - **[PR #193](https://github.com/Elmorralito/save-ma-money/pull/193):** GHA Dependabot bumps +
   e2e login/nav hardening + Hadolint HEALTHCHECK JSON / DL3066 ignore.
 

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -29,9 +29,9 @@ Capture with `/strata:capture` only for work in flight.
 ### In progress (ACTIVE)
 
 - **PPT-072 / #165:** [PR #204](https://github.com/Elmorralito/save-ma-money/pull/204) —
-  upcoming-dues + mark-paid / clear-paid; model version restored to **1.0.3**;
-  B0 fixture uses `OTHER_ASSET` (no extension); `skip-migrations` for pre-existing
-  alembic check drift on main.
+  upcoming-dues + mark-paid / clear-paid; model version **1.0.3**; B0
+  `OTHER_ASSET` fixture; fix category `dto_type` kw collision on mark-paid create;
+  `skip-migrations` for pre-existing alembic check drift on main.
 - **[PR #193](https://github.com/Elmorralito/save-ma-money/pull/193):** GHA Dependabot bumps +
   e2e login/nav hardening + Hadolint HEALTHCHECK JSON / DL3066 ignore.
 

--- a/modules/model/pyproject.toml
+++ b/modules/model/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "papita-transactions-model"
-version = "1.0.0"
+version = "1.0.3"
 description = "SQLModel/PostgreSQL domain layer for Papita financial transactions (papita_txnsmodel)."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/modules/model/src/papita_txnsmodel/access/transactions/dto.py
+++ b/modules/model/src/papita_txnsmodel/access/transactions/dto.py
@@ -44,8 +44,9 @@ class TransactionTemplatesDTO(OwnedTableDTO, CoreTableDTO):
         planned_day (int): Day of the month when the transaction is expected (1-31).
         use_month_end (bool): Whether to schedule on the last day of the month.
         due_date (datetime.date | None): Optional one-off calendar due date (PPT-071).
-        remind_days_before (int | None): Optional lead days before due for in-app reminders.
-        from_account_id (uuid.UUID | AccountsDTO | None): Optional pay-from account.
+        remind_days_before (int | None): Optional lead days before due; null means 0 (surface on due day).
+        from_account_id (uuid.UUID | AccountsDTO | None): Pay-from account for EXPENSE mark-paid;
+            deposit account (``to_account_id``) for INCOME mark-paid.
     """
 
     __dao_type__ = TransactionTemplates
@@ -61,11 +62,13 @@ class TransactionTemplatesDTO(OwnedTableDTO, CoreTableDTO):
     remind_days_before: int | None = Field(
         default=None,
         ge=0,
-        description="Days before due to surface an in-app reminder; null means no lead window",
+        description=(
+            "Days before due to surface an in-app reminder; null is treated as 0 " "(reminder starts on the due date)"
+        ),
     )
     from_account_id: uuid.UUID | AccountsDTO | None = Field(
         default=None,
-        description="Optional account to pay from when marking a due as paid",
+        description=("Account used when marking paid: pay-from for EXPENSE, deposit (to_account) for INCOME"),
     )
 
     @field_serializer("category_id", "from_account_id")

--- a/modules/model/src/papita_txnsmodel/services/__init__.py
+++ b/modules/model/src/papita_txnsmodel/services/__init__.py
@@ -18,6 +18,7 @@ from papita_txnsmodel.services.accounts import AccountsService
 from papita_txnsmodel.services.balance_reports import BalanceReportsService
 from papita_txnsmodel.services.balance_views import refresh_balance_materialized_views
 from papita_txnsmodel.services.categories import CategoriesService
+from papita_txnsmodel.services.dues import UpcomingDueDTO
 from papita_txnsmodel.services.owner_period_balances import OwnerPeriodBalancesService
 from papita_txnsmodel.services.owner_yearly_balances import OwnerYearlyBalancesService
 from papita_txnsmodel.services.reports import ReportService
@@ -40,6 +41,7 @@ __all__ = [
     "TradingAccountDetailsService",
     "TransactionTemplatesService",
     "TransactionsService",
+    "UpcomingDueDTO",
     "UsersService",
     "refresh_balance_materialized_views",
 ]

--- a/modules/model/src/papita_txnsmodel/services/dues.py
+++ b/modules/model/src/papita_txnsmodel/services/dues.py
@@ -1,0 +1,168 @@
+"""Payment-due helpers for transaction templates (PPT-072 / #165).
+
+Resolves one-off and recurring due dates, upcoming-window membership, and
+calendar-month period keys used to derive paid state from linked postings.
+"""
+
+from __future__ import annotations
+
+import calendar
+import uuid
+from datetime import date, timedelta
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from papita_txnsmodel.access.transactions.dto import TransactionTemplatesDTO
+from papita_txnsmodel.config.transaction_partitions import add_months, month_start
+
+
+class UpcomingDueDTO(BaseModel):
+    """Owner-scoped upcoming due row for in-app reminders.
+
+    Attributes:
+        template: Source payment-due template.
+        due_date: Resolved calendar due for this occurrence.
+        remind_start: First day the due should surface in-app.
+        is_paid: Whether an active linked posting exists for the due period.
+        paid_transaction_id: Latest active linked posting id when paid.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    template: TransactionTemplatesDTO
+    due_date: date
+    remind_start: date
+    is_paid: bool = False
+    paid_transaction_id: uuid.UUID | None = Field(default=None)
+
+
+def period_key(due: date) -> tuple[int, int]:
+    """Return ``(year, month)`` for paid-state matching on a resolved due."""
+    return due.year, due.month
+
+
+def period_bounds(due: date) -> tuple[date, date]:
+    """Return inclusive calendar-month bounds for a resolved due date.
+
+    Args:
+        due: Resolved payment due date.
+
+    Returns:
+        Tuple of ``(month_start, month_end)`` inclusive dates.
+    """
+    start = month_start(due)
+    end = date(due.year, due.month, calendar.monthrange(due.year, due.month)[1])
+    return start, end
+
+
+def due_in_month(template: TransactionTemplatesDTO, *, year: int, month: int) -> date:
+    """Resolve the recurring due date within a calendar month.
+
+    Args:
+        template: Template with ``planned_day`` / ``use_month_end``.
+        year: Calendar year.
+        month: Calendar month (1–12).
+
+    Returns:
+        Due date clamped to the month length when needed.
+    """
+    last_day = calendar.monthrange(year, month)[1]
+    if template.use_month_end:
+        day = last_day
+    else:
+        day = min(int(template.planned_day), last_day)
+    return date(year, month, day)
+
+
+def resolve_due_date(template: TransactionTemplatesDTO, *, ref: date) -> date:
+    """Resolve a single due date for ``ref``'s month (one-off wins).
+
+    Args:
+        template: Payment-due template.
+        ref: Reference date whose calendar month is used for recurring dues.
+
+    Returns:
+        One-off ``due_date`` when set; otherwise recurring due in ``ref``'s month.
+    """
+    if template.due_date is not None:
+        return template.due_date
+    return due_in_month(template, year=ref.year, month=ref.month)
+
+
+def candidate_due_dates(template: TransactionTemplatesDTO, *, as_of: date) -> list[date]:
+    """Candidate dues near ``as_of`` for upcoming-window evaluation.
+
+    One-off templates yield only ``due_date``. Recurring templates yield dues for
+    the previous, current, and next calendar months relative to ``as_of``.
+
+    Args:
+        template: Payment-due template.
+        as_of: Window anchor date.
+
+    Returns:
+        Ordered candidate due dates (earliest first, de-duplicated).
+    """
+    if template.due_date is not None:
+        return [template.due_date]
+
+    candidates: list[date] = []
+    for offset in (-1, 0, 1):
+        month_ref = add_months(month_start(as_of), offset)
+        candidates.append(due_in_month(template, year=month_ref.year, month=month_ref.month))
+    return sorted(set(candidates))
+
+
+def remind_start_for(due: date, remind_days_before: int | None) -> date:
+    """First calendar day the due should surface (``None`` remind ⇒ due day)."""
+    lead = 0 if remind_days_before is None else int(remind_days_before)
+    return due - timedelta(days=lead)
+
+
+def in_upcoming_window(
+    due: date,
+    remind_days_before: int | None,
+    *,
+    as_of: date,
+    window_days: int,
+) -> bool:
+    """Return whether the reminder interval overlaps ``[as_of, as_of+window]``.
+
+    Overlap uses closed intervals: ``[due - remind, due]`` vs
+    ``[as_of, as_of + window_days]``. ``remind_days_before is None`` is treated as 0.
+
+    Args:
+        due: Resolved due date.
+        remind_days_before: Optional lead days before due.
+        as_of: Window start (inclusive).
+        window_days: Inclusive days after ``as_of`` to include.
+
+    Returns:
+        True when the intervals overlap.
+    """
+    if window_days < 0:
+        raise ValueError("window_days must be >= 0")
+    remind_start = remind_start_for(due, remind_days_before)
+    window_end = as_of + timedelta(days=window_days)
+    return remind_start <= window_end and as_of <= due
+
+
+def select_upcoming_due(
+    template: TransactionTemplatesDTO,
+    *,
+    as_of: date,
+    window_days: int,
+) -> date | None:
+    """Pick the earliest candidate due that falls in the upcoming window.
+
+    Args:
+        template: Payment-due template.
+        as_of: Window anchor.
+        window_days: Inclusive window length in days.
+
+    Returns:
+        Resolved due date, or None when no candidate is in window.
+    """
+    for due in candidate_due_dates(template, as_of=as_of):
+        if in_upcoming_window(due, template.remind_days_before, as_of=as_of, window_days=window_days):
+            return due
+    return None

--- a/modules/model/src/papita_txnsmodel/services/extends.py
+++ b/modules/model/src/papita_txnsmodel/services/extends.py
@@ -95,6 +95,9 @@ class CategorizedEntitiesService(BaseService):
         """
         categorized_dto = super().get(obj=obj, owner=owner, **kwargs)
         if kwargs.get("include_category", True) and isinstance(categorized_dto, self.dto_type):
+            # Drop dto_type so it is not passed twice into CategoriesService.get /
+            # BaseRepository.get_record_by_id (explicit kw + **kwargs).
+            category_kwargs = {key: value for key, value in kwargs.items() if key != "dto_type"}
             categorized_dto = self.dto_type.model_validate(
                 categorized_dto.model_dump(mode="python")
                 | {
@@ -102,7 +105,7 @@ class CategorizedEntitiesService(BaseService):
                         obj=getattr(categorized_dto, self.category_id_field_name),
                         owner=owner,
                         dto_type=self.categories_dto_type,
-                        **kwargs,
+                        **category_kwargs,
                     )
                 }
             )

--- a/modules/model/src/papita_txnsmodel/services/transactions.py
+++ b/modules/model/src/papita_txnsmodel/services/transactions.py
@@ -14,11 +14,11 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Sequence
-from datetime import date, datetime
-from typing import Annotated, Any, Dict, Literal
+from datetime import date, datetime, time, timezone
+from typing import Annotated, Any, Dict, Literal, Self
 
 import pandas as pd
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from papita_txnsmodel.access.base.dto import TableDTO
 from papita_txnsmodel.access.categories.dto import CategoriesDTO
@@ -27,15 +27,34 @@ from papita_txnsmodel.access.transactions.query_filters import TransactionListFi
 from papita_txnsmodel.access.transactions.repository import TransactionsRepository, TransactionTemplatesRepository
 from papita_txnsmodel.access.users.dto import UsersDTO
 from papita_txnsmodel.database.upsert import OnUpsertConflictDo
-from papita_txnsmodel.model.enums import TransactionKind, TransactionStatus
+from papita_txnsmodel.model.enums import CategoryKind, TransactionKind, TransactionStatus
 from papita_txnsmodel.model.transactions import Transactions
 from papita_txnsmodel.services.accounts import AccountsService
 from papita_txnsmodel.services.balance_views import refresh_balance_materialized_views
 from papita_txnsmodel.services.base import BaseService
 from papita_txnsmodel.services.categories import CategoriesService
+from papita_txnsmodel.services.dues import (
+    UpcomingDueDTO,
+    period_bounds,
+    period_key,
+    remind_start_for,
+    resolve_due_date,
+    select_upcoming_due,
+)
 from papita_txnsmodel.services.extends import CategorizedEntitiesService, LinkedEntitiesService, LinkedEntity
 
 logger = logging.getLogger(__name__)
+
+
+def _as_uuid(value: uuid.UUID | TableDTO | None) -> uuid.UUID | None:
+    """Return a relation field as UUID when present."""
+    if value is None:
+        return None
+    if isinstance(value, TableDTO):
+        if value.id is None:
+            raise ValueError("Related DTO must include an id.")
+        return value.id
+    return value
 
 
 class TransactionTemplatesService(CategorizedEntitiesService):
@@ -47,6 +66,8 @@ class TransactionTemplatesService(CategorizedEntitiesService):
         dto_type (type[TransactionTemplatesDTO]): DTO type for transaction templates.
         repository_type (type[TransactionTemplatesRepository]): Repository for templates.
         categories_dto_type (type[CategoriesDTO]): DTO type for categories.
+        transactions_service (TransactionsService): Posted-ledger writes for mark-paid.
+        accounts_service (AccountsService): Owner-scoped account validation.
     """
 
     category_id_column_name: str = "category_id"
@@ -54,6 +75,326 @@ class TransactionTemplatesService(CategorizedEntitiesService):
     dto_type: type[TransactionTemplatesDTO] = TransactionTemplatesDTO
     repository_type: type[TransactionTemplatesRepository] = TransactionTemplatesRepository
     categories_dto_type: type[CategoriesDTO] = CategoriesDTO
+    transactions_service: Any | None = None
+    accounts_service: AccountsService | None = None
+
+    @model_validator(mode="after")
+    def _wire_dues_dependencies(self) -> Self:
+        """Instantiate ledger/account services from the shared connector when omitted."""
+        if self.accounts_service is None:
+            self.accounts_service = AccountsService.model_validate({"connector": self.connector})
+        if self.transactions_service is None:
+            # Construct after class body so TransactionsService is defined; wire FK
+            # links so mark_paid can create postings with template_id set.
+            txn_service = TransactionsService.model_validate({"connector": self.connector})
+            txn_service.load_link_services(
+                {
+                    "template_id": self,
+                    "from_account_id": self.accounts_service,
+                    "to_account_id": self.accounts_service,
+                    "category_id": self.categories_service,
+                }
+            )
+            self.transactions_service = txn_service
+        return self
+
+    def _templates_from_frame(self, frame: pd.DataFrame) -> list[TransactionTemplatesDTO]:
+        """Parse an owner-scoped templates DataFrame into DTOs."""
+        if getattr(frame, "empty", True):
+            return []
+        return [self.dto_type.model_validate(row) for row in frame.to_dict(orient="records")]
+
+    @staticmethod
+    def _txn_sort_key(item: TransactionsDTO) -> tuple[datetime, str]:
+        """Sort key for latest-posting selection (timestamp, then id)."""
+        ts = item.transaction_ts or datetime.min.replace(tzinfo=timezone.utc)
+        return (ts, str(item.id))
+
+    def _require_owner(self, owner: UsersDTO | None) -> UsersDTO:
+        """Require a tenant owner and narrow the type for mypy."""
+        ensured = self._ensure_owner(owner)
+        if ensured is None:
+            raise ValueError("UsersDTO owner is required for tenant-scoped dues operations.")
+        return ensured
+
+    def _latest_paid_in_frame(
+        self,
+        frame: pd.DataFrame,
+        wanted: set[uuid.UUID],
+    ) -> dict[uuid.UUID, TransactionsDTO]:
+        """Pick the latest active posting per template id from a period frame."""
+        latest_for_template: dict[uuid.UUID, TransactionsDTO] = {}
+        for row in frame.to_dict(orient="records"):
+            txn = TransactionsDTO.model_validate(row)
+            linked_template_id = _as_uuid(txn.template_id)
+            if linked_template_id is None or linked_template_id not in wanted:
+                continue
+            if not getattr(txn, "active", True):
+                continue
+            current = latest_for_template.get(linked_template_id)
+            if current is None or self._txn_sort_key(txn) > self._txn_sort_key(current):
+                latest_for_template[linked_template_id] = txn
+        return latest_for_template
+
+    def _paid_postings_by_template(
+        self,
+        *,
+        owner: UsersDTO,
+        dues_by_template: dict[uuid.UUID, date],
+        **kwargs: Any,
+    ) -> dict[uuid.UUID, TransactionsDTO]:
+        """Return latest active linked posting per template for each due's month.
+
+        Batches by calendar month so ``list_upcoming_dues`` issues one frame read
+        per distinct period instead of one read per template.
+
+        Args:
+            owner: Tenant owner.
+            dues_by_template: Map of template id → resolved due date.
+            **kwargs: Passed to ``get_transactions_frame``.
+
+        Returns:
+            Map of template id → latest matching ``TransactionsDTO`` when paid.
+        """
+        if not dues_by_template:
+            return {}
+
+        by_period: dict[tuple[int, int], list[tuple[uuid.UUID, date]]] = {}
+        for template_id, due in dues_by_template.items():
+            by_period.setdefault(period_key(due), []).append((template_id, due))
+
+        paid_by_template: dict[uuid.UUID, TransactionsDTO] = {}
+        for items in by_period.values():
+            period_start, period_end = period_bounds(items[0][1])
+            frame = self.transactions_service.get_transactions_frame(
+                owner=owner,
+                start_date=period_start,
+                end_date=period_end,
+                exclude_transfer=False,
+                **kwargs,
+            )
+            if getattr(frame, "empty", True):
+                continue
+            wanted = {template_id for template_id, _due in items}
+            paid_by_template.update(self._latest_paid_in_frame(frame, wanted))
+
+        return paid_by_template
+
+    def _paid_posting_for_period(
+        self,
+        *,
+        template_id: uuid.UUID,
+        owner: UsersDTO,
+        due: date,
+        **kwargs: Any,
+    ) -> TransactionsDTO | None:
+        """Return the latest active linked posting for ``template_id`` in ``due``'s month."""
+        paid = self._paid_postings_by_template(
+            owner=owner,
+            dues_by_template={template_id: due},
+            **kwargs,
+        )
+        return paid.get(template_id)
+
+    def list_upcoming_dues(
+        self,
+        *,
+        owner: UsersDTO,
+        as_of: date,
+        window_days: int = 14,
+        include_paid: bool = True,
+        **kwargs: Any,
+    ) -> list[UpcomingDueDTO]:
+        """List owner-scoped templates with a due in the upcoming reminder window.
+
+        Paid state is derived from active posted transactions linked via
+        ``template_id`` within the resolved due's calendar month. Paid lookups are
+        batched by calendar month.
+
+        Args:
+            owner: Tenant owner (required).
+            as_of: Window anchor date.
+            window_days: Inclusive days after ``as_of`` to consider.
+            include_paid: When False, omit dues that already have a linked posting.
+            **kwargs: Passed through to repository/service reads.
+
+        Returns:
+            Upcoming dues sorted by resolved due date, then template name/id.
+        """
+        owner = self._require_owner(owner)
+        if window_days < 0:
+            raise ValueError("window_days must be >= 0")
+
+        templates = self._templates_from_frame(
+            self.get_records(dto=None, owner=owner, include_category=False, **kwargs)
+        )
+        dues_by_template: dict[uuid.UUID, date] = {}
+        selected: list[tuple[TransactionTemplatesDTO, date]] = []
+        for template in templates:
+            if template.id is None:
+                continue
+            due = select_upcoming_due(template, as_of=as_of, window_days=window_days)
+            if due is None:
+                continue
+            selected.append((template, due))
+            dues_by_template[template.id] = due
+
+        paid_by_template = self._paid_postings_by_template(
+            owner=owner,
+            dues_by_template=dues_by_template,
+            **kwargs,
+        )
+
+        results: list[UpcomingDueDTO] = []
+        for template, due in selected:
+            assert template.id is not None
+            paid = paid_by_template.get(template.id)
+            is_paid = paid is not None
+            if is_paid and not include_paid:
+                continue
+            results.append(
+                UpcomingDueDTO(
+                    template=template,
+                    due_date=due,
+                    remind_start=remind_start_for(due, template.remind_days_before),
+                    is_paid=is_paid,
+                    paid_transaction_id=paid.id if paid is not None else None,
+                )
+            )
+
+        results.sort(key=lambda item: (item.due_date, item.template.name or "", str(item.template.id)))
+        return results
+
+    def mark_paid(  # pylint: disable=too-many-arguments,too-many-locals
+        self,
+        *,
+        template_id: uuid.UUID,
+        owner: UsersDTO,
+        as_of: date | None = None,
+        transaction_ts: datetime | None = None,
+        amount: float | None = None,
+        **kwargs: Any,
+    ) -> TransactionsDTO:
+        """Post a linked EXPENSE/INCOME for a template due (mark paid).
+
+        Kind follows the template category. The optional template ``from_account_id``
+        is the pay-from account for EXPENSE and the deposit account (``to_account_id``)
+        for INCOME. Currency defaults to USD.
+
+        Args:
+            template_id: Template to mark paid.
+            owner: Tenant owner (required).
+            as_of: Anchor for resolving the recurring occurrence (default: UTC today).
+            transaction_ts: Posted timestamp (default: noon UTC on the resolved due).
+            amount: Posted amount (default: ``planned_amount``).
+            **kwargs: Passed to create/get paths (e.g. ``refresh_balances``).
+
+        Returns:
+            Created ``TransactionsDTO`` with ``template_id`` set.
+
+        Raises:
+            ValueError: Missing template, already paid, missing account, or bad category.
+        """
+        owner = self._require_owner(owner)
+
+        template = self.get(obj=template_id, owner=owner, include_category=False, **kwargs)
+        if not isinstance(template, TransactionTemplatesDTO) or template.id is None:
+            raise ValueError("Transaction template not found.")
+
+        # Period is the occurrence in ``as_of``'s month (or the one-off due_date).
+        anchor = as_of or datetime.now(timezone.utc).date()
+        due = resolve_due_date(template, ref=anchor)
+
+        existing = self._paid_posting_for_period(template_id=template.id, owner=owner, due=due, **kwargs)
+        if existing is not None:
+            raise ValueError("Template due is already marked paid for this period.")
+
+        category_id = _as_uuid(template.category_id)
+        if category_id is None:
+            raise ValueError("Template category_id is required for mark_paid.")
+        category = self.categories_service.get(obj=category_id, owner=owner, **kwargs)
+        if not isinstance(category, CategoriesDTO):
+            raise ValueError("Template category not found.")
+
+        account_id = _as_uuid(template.from_account_id)
+        if account_id is None:
+            raise ValueError("Template from_account_id is required for mark_paid.")
+        account = self.accounts_service.get(obj=account_id, owner=owner, **kwargs)
+        if account is None:
+            raise ValueError("Pay account not found for owner.")
+
+        if category.category_kind == CategoryKind.EXPENSE:
+            kind = TransactionKind.EXPENSE
+            from_account_id: uuid.UUID | None = account_id
+            to_account_id: uuid.UUID | None = None
+        elif category.category_kind == CategoryKind.INCOME:
+            kind = TransactionKind.INCOME
+            from_account_id = None
+            to_account_id = account_id
+        else:  # pragma: no cover - CategoryKind is currently INCOME|EXPENSE only
+            raise ValueError(f"Unsupported category kind for mark_paid: {category.category_kind!r}")
+
+        posted_amount = float(template.planned_amount if amount is None else amount)
+        if posted_amount <= 0:
+            raise ValueError("mark_paid amount must be positive.")
+
+        posted_ts = transaction_ts or datetime.combine(due, time(hour=12), tzinfo=timezone.utc)
+        payload = TransactionsDTO(
+            owner_id=owner.id,
+            transaction_kind=kind,
+            amount=posted_amount,
+            currency="USD",
+            transaction_ts=posted_ts,
+            from_account_id=from_account_id,
+            to_account_id=to_account_id,
+            category_id=category_id,
+            template_id=template.id,
+            status=TransactionStatus.COMPLETED,
+            description=template.description or template.name or "",
+            tags=list(template.tags or []),
+        )
+        created = self.transactions_service.create(obj=payload, owner=owner, **kwargs)
+        if not isinstance(created, TransactionsDTO):
+            raise RuntimeError("mark_paid failed to create a transaction.")
+        return created
+
+    def clear_paid(
+        self,
+        *,
+        template_id: uuid.UUID,
+        owner: UsersDTO,
+        as_of: date | None = None,
+        **kwargs: Any,
+    ) -> TransactionsDTO:
+        """Soft-delete the latest active linked posting for the due period.
+
+        Args:
+            template_id: Template whose paid posting should be cleared.
+            owner: Tenant owner (required).
+            as_of: Anchor for resolving the recurring occurrence (default: UTC today).
+            **kwargs: Passed to get/delete paths.
+
+        Returns:
+            The posting DTO that was soft-deleted.
+
+        Raises:
+            ValueError: Missing template or no paid posting for the period.
+        """
+        owner = self._require_owner(owner)
+
+        template = self.get(obj=template_id, owner=owner, include_category=False, **kwargs)
+        if not isinstance(template, TransactionTemplatesDTO) or template.id is None:
+            raise ValueError("Transaction template not found.")
+
+        anchor = as_of or datetime.now(timezone.utc).date()
+        due = resolve_due_date(template, ref=anchor)
+
+        paid = self._paid_posting_for_period(template_id=template.id, owner=owner, due=due, **kwargs)
+        if paid is None or paid.id is None:
+            raise ValueError("Template due is not marked paid for this period.")
+
+        self.transactions_service.delete(obj=paid, owner=owner, hard=False, **kwargs)
+        return paid
 
 
 # Backward-compatible alias for legacy callers.

--- a/modules/model/src/papita_txnsmodel/services/transactions.py
+++ b/modules/model/src/papita_txnsmodel/services/transactions.py
@@ -353,7 +353,14 @@ class TransactionTemplatesService(CategorizedEntitiesService):
             description=template.description or template.name or "",
             tags=list(template.tags or []),
         )
-        created = self.transactions_service.create(obj=payload, owner=owner, **kwargs)
+        # Avoid CategorizedEntitiesService category hydration on the template link
+        # (passes dto_type= into CategoriesService.get and can collide with kwargs).
+        created = self.transactions_service.create(
+            obj=payload,
+            owner=owner,
+            include_category=False,
+            **kwargs,
+        )
         if not isinstance(created, TransactionsDTO):
             raise RuntimeError("mark_paid failed to create a transaction.")
         return created

--- a/modules/model/tests/tests_papita_txnsmodel/integration/test_ppt072_dues_live_db.py
+++ b/modules/model/tests/tests_papita_txnsmodel/integration/test_ppt072_dues_live_db.py
@@ -75,7 +75,8 @@ class TestLiveDbPpt072DuesServices:
                 name=f"PPT072 cash {uuid.uuid4().hex[:8]}",
                 description="dues test",
                 owner_id=owner.id,
-                account_kind=AccountKind.CASH,
+                # OTHER_ASSET has no required *_account_details row.
+                account_kind=AccountKind.OTHER_ASSET,
                 ledger_side=LedgerSide.ASSET,
             ),
             owner=owner,

--- a/modules/model/tests/tests_papita_txnsmodel/integration/test_ppt072_dues_live_db.py
+++ b/modules/model/tests/tests_papita_txnsmodel/integration/test_ppt072_dues_live_db.py
@@ -1,0 +1,149 @@
+"""B0 live-DB tests for PPT-072 upcoming dues / mark-paid services."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import pytest
+from sqlalchemy import text
+
+from papita_txnsmodel.access.accounts.dto import AccountsDTO
+from papita_txnsmodel.access.categories.dto import CategoriesDTO
+from papita_txnsmodel.access.transactions.dto import TransactionTemplatesDTO
+from papita_txnsmodel.access.users.dto import UsersDTO
+from papita_txnsmodel.model.enums import AccountKind, CategoryKind, LedgerSide, TransactionKind
+from papita_txnsmodel.services.accounts import AccountsService
+from papita_txnsmodel.services.categories import CategoriesService
+from papita_txnsmodel.services.transactions import TransactionTemplatesService
+
+from .conftest import requires_postgres
+
+_VALID_PASSWORD = "Password1!"
+
+
+def _user(user_id: uuid.UUID, label: str) -> UsersDTO:
+    return UsersDTO(
+        id=user_id,
+        username=f"ppt072_{label}",
+        email=f"ppt072_{label}@example.local",
+        password=_VALID_PASSWORD,
+        auth_provider="local",
+    )
+
+
+def _cleanup(engine, *, account_id: uuid.UUID, category_id: uuid.UUID, template_id: uuid.UUID) -> None:
+    """Best-effort cleanup for PPT-072 integration rows."""
+    with engine.connect() as conn:
+        conn.execute(
+            text("DELETE FROM papita_transactions.transactions WHERE template_id = :tid"),
+            {"tid": str(template_id)},
+        )
+        conn.execute(
+            text("DELETE FROM papita_transactions.transaction_templates WHERE id = :id"),
+            {"id": str(template_id)},
+        )
+        conn.execute(
+            text("DELETE FROM papita_transactions.accounts WHERE id = :id"),
+            {"id": str(account_id)},
+        )
+        conn.execute(
+            text("DELETE FROM papita_transactions.categories WHERE id = :id"),
+            {"id": str(category_id)},
+        )
+        conn.commit()
+
+
+@requires_postgres
+class TestLiveDbPpt072DuesServices:
+    """Upcoming dues + mark-paid / clear-paid against Docker Postgres (B0)."""
+
+    def test_mark_paid_list_and_clear_paid_round_trip(
+        self, postgres_connector, ensure_integration_users, integration_owner_ids
+    ):
+        """Owner can mark a due paid, see it in upcoming list, then clear paid."""
+        owner = _user(integration_owner_ids["user_a"], "user_a")
+        other = _user(integration_owner_ids["user_b"], "user_b")
+        as_of = date(2026, 8, 10)
+
+        accounts = AccountsService()
+        categories = CategoriesService()
+        templates = TransactionTemplatesService()
+
+        account, _ = accounts.create_account(
+            obj=AccountsDTO(
+                name=f"PPT072 cash {uuid.uuid4().hex[:8]}",
+                description="dues test",
+                owner_id=owner.id,
+                account_kind=AccountKind.CASH,
+                ledger_side=LedgerSide.ASSET,
+            ),
+            owner=owner,
+        )
+        category = categories.create(
+            obj=CategoriesDTO(
+                name=f"PPT072 bills {uuid.uuid4().hex[:8]}",
+                description="dues test",
+                category_kind=CategoryKind.EXPENSE,
+                owner_id=owner.id,
+            ),
+            owner=owner,
+        )
+        template = templates.create(
+            obj=TransactionTemplatesDTO(
+                owner_id=owner.id,
+                category_id=category.id,
+                name=f"PPT072 rent {uuid.uuid4().hex[:8]}",
+                planned_amount=99.5,
+                planned_day=12,
+                use_month_end=False,
+                remind_days_before=0,
+                from_account_id=account.id,
+            ),
+            owner=owner,
+            include_category=False,
+        )
+        assert template.id is not None
+        assert account.id is not None
+        assert category.id is not None
+
+        try:
+            upcoming = templates.list_upcoming_dues(owner=owner, as_of=as_of, window_days=7)
+            matched = [row for row in upcoming if row.template.id == template.id]
+            assert len(matched) == 1
+            assert matched[0].is_paid is False
+            assert matched[0].due_date == date(2026, 8, 12)
+
+            # Cross-tenant list must not surface the row.
+            other_upcoming = templates.list_upcoming_dues(owner=other, as_of=as_of, window_days=7)
+            assert all(row.template.id != template.id for row in other_upcoming)
+
+            posted = templates.mark_paid(template_id=template.id, owner=owner, as_of=as_of)
+            assert posted.template_id == template.id or getattr(posted.template_id, "id", None) == template.id
+            assert posted.transaction_kind == TransactionKind.EXPENSE
+            assert posted.amount == pytest.approx(99.5)
+
+            paid_list = templates.list_upcoming_dues(owner=owner, as_of=as_of, window_days=7)
+            paid_row = next(row for row in paid_list if row.template.id == template.id)
+            assert paid_row.is_paid is True
+            assert paid_row.paid_transaction_id == posted.id
+
+            with pytest.raises(ValueError, match="already marked paid"):
+                templates.mark_paid(template_id=template.id, owner=owner, as_of=as_of)
+
+            with pytest.raises(ValueError, match="not found|Pay account"):
+                templates.mark_paid(template_id=template.id, owner=other, as_of=as_of)
+
+            cleared = templates.clear_paid(template_id=template.id, owner=owner, as_of=as_of)
+            assert cleared.id == posted.id
+
+            after_clear = templates.list_upcoming_dues(owner=owner, as_of=as_of, window_days=7)
+            unpaid = next(row for row in after_clear if row.template.id == template.id)
+            assert unpaid.is_paid is False
+        finally:
+            _cleanup(
+                postgres_connector.engine,
+                account_id=account.id,
+                category_id=category.id,
+                template_id=template.id,
+            )

--- a/modules/model/tests/tests_papita_txnsmodel/services/test_ppt072_dues.py
+++ b/modules/model/tests/tests_papita_txnsmodel/services/test_ppt072_dues.py
@@ -1,0 +1,421 @@
+"""Unit tests for PPT-072 upcoming dues and mark-paid services."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from papita_txnsmodel.access.accounts.dto import AccountsDTO
+from papita_txnsmodel.access.categories.dto import CategoriesDTO
+from papita_txnsmodel.access.transactions.dto import TransactionsDTO, TransactionTemplatesDTO
+from papita_txnsmodel.access.users.dto import UsersDTO
+from papita_txnsmodel.model.enums import AccountKind, CategoryKind, LedgerSide, TransactionKind, TransactionStatus
+from papita_txnsmodel.services.dues import (
+    candidate_due_dates,
+    due_in_month,
+    in_upcoming_window,
+    period_key,
+    remind_start_for,
+    resolve_due_date,
+    select_upcoming_due,
+)
+from papita_txnsmodel.services.transactions import TransactionTemplatesService
+
+_VALID_PASSWORD = "Password1!"
+
+
+@pytest.fixture
+def owner() -> UsersDTO:
+    """Tenant user for service calls."""
+    return UsersDTO(
+        id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        username="user_a_test",
+        email="user_a@example.local",
+        password=_VALID_PASSWORD,
+        auth_provider="local",
+    )
+
+
+def _template(**overrides) -> TransactionTemplatesDTO:
+    """Minimal recurring/one-off template for helper and service tests."""
+    payload = {
+        "id": uuid.uuid4(),
+        "owner_id": uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        "category_id": uuid.uuid4(),
+        "name": "Rent",
+        "planned_amount": 1200.0,
+        "planned_day": 15,
+        "use_month_end": False,
+        "due_date": None,
+        "remind_days_before": None,
+        "from_account_id": uuid.uuid4(),
+    }
+    payload.update(overrides)
+    return TransactionTemplatesDTO(**payload)
+
+
+class TestDueHelpers:
+    """Pure due-resolution and window membership helpers."""
+
+    def test_one_off_due_date_wins(self):
+        """Explicit due_date takes precedence over planned_day."""
+        due = date(2026, 9, 20)
+        template = _template(due_date=due, planned_day=1)
+        assert resolve_due_date(template, ref=date(2026, 3, 1)) == due
+
+    def test_month_end_and_day_clamp(self):
+        """use_month_end and planned_day=31 clamp to February length."""
+        month_end = _template(use_month_end=True, planned_day=1)
+        assert due_in_month(month_end, year=2026, month=2) == date(2026, 2, 28)
+        day31 = _template(use_month_end=False, planned_day=31)
+        assert due_in_month(day31, year=2026, month=2) == date(2026, 2, 28)
+
+    def test_remind_null_treated_as_zero(self):
+        """Null remind lead starts on the due date."""
+        due = date(2026, 8, 10)
+        assert remind_start_for(due, None) == due
+        assert remind_start_for(due, 3) == date(2026, 8, 7)
+
+    def test_upcoming_window_overlap_with_remind(self):
+        """Due outside the raw window still matches when remind starts inside it."""
+        due = date(2026, 8, 25)
+        assert in_upcoming_window(due, 7, as_of=date(2026, 8, 10), window_days=14) is True
+        assert in_upcoming_window(due, 0, as_of=date(2026, 8, 10), window_days=14) is False
+
+    def test_select_upcoming_due_picks_earliest_in_window(self):
+        """Recurring templates pick the earliest candidate in the window."""
+        template = _template(planned_day=1, remind_days_before=0)
+        assert select_upcoming_due(template, as_of=date(2026, 8, 1), window_days=14) == date(2026, 8, 1)
+        assert select_upcoming_due(template, as_of=date(2026, 8, 5), window_days=14) is None
+
+    def test_candidate_dues_for_recurring_span_adjacent_months(self):
+        """Recurring candidates cover previous/current/next month."""
+        template = _template(planned_day=10)
+        candidates = candidate_due_dates(template, as_of=date(2026, 8, 15))
+        assert candidates == [date(2026, 7, 10), date(2026, 8, 10), date(2026, 9, 10)]
+
+    def test_period_key(self):
+        """Paid matching keys on calendar year/month of the resolved due."""
+        assert period_key(date(2026, 2, 28)) == (2026, 2)
+
+
+def _templates_service() -> TransactionTemplatesService:
+    """Build a templates service with mocked repositories and collaborators."""
+    with (
+        patch("papita_txnsmodel.services.transactions.TransactionTemplatesRepository"),
+        patch("papita_txnsmodel.services.categories.CategoriesRepository"),
+        patch("papita_txnsmodel.services.accounts.AccountsRepository"),
+        patch("papita_txnsmodel.services.transactions.TransactionsRepository"),
+    ):
+        service = TransactionTemplatesService()
+        service._repository = MagicMock()
+        service.categories_service = MagicMock()
+        service.accounts_service = MagicMock()
+        service.transactions_service = MagicMock()
+        return service
+
+
+class TestListUpcomingDues:
+    """TransactionTemplatesService.list_upcoming_dues behavior."""
+
+    def test_filters_to_window_and_sorts(self, owner: UsersDTO):
+        """Only in-window templates are returned, sorted by due date."""
+        service = _templates_service()
+        in_window = _template(
+            id=uuid.uuid4(),
+            name="Electric",
+            planned_day=12,
+            remind_days_before=0,
+        )
+        out_of_window = _template(
+            id=uuid.uuid4(),
+            name="Later",
+            planned_day=28,
+            remind_days_before=0,
+        )
+        frame = pd.DataFrame(
+            [
+                in_window.model_dump(mode="python"),
+                out_of_window.model_dump(mode="python"),
+            ]
+        )
+        with (
+            patch.object(TransactionTemplatesService, "get_records", return_value=frame),
+            patch.object(TransactionTemplatesService, "_paid_postings_by_template", return_value={}),
+        ):
+            results = service.list_upcoming_dues(owner=owner, as_of=date(2026, 8, 10), window_days=7)
+
+        assert len(results) == 1
+        assert results[0].template.id == in_window.id
+        assert results[0].due_date == date(2026, 8, 12)
+        assert results[0].is_paid is False
+
+    def test_include_paid_false_omits_paid(self, owner: UsersDTO):
+        """Paid dues are omitted when include_paid is False."""
+        service = _templates_service()
+        template = _template(planned_day=12, remind_days_before=0)
+        paid = TransactionsDTO(
+            id=uuid.uuid4(),
+            owner_id=owner.id,
+            transaction_kind=TransactionKind.EXPENSE,
+            amount=10.0,
+            template_id=template.id,
+            transaction_ts=datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc),
+        )
+        frame = pd.DataFrame([template.model_dump(mode="python")])
+        with (
+            patch.object(TransactionTemplatesService, "get_records", return_value=frame),
+            patch.object(
+                TransactionTemplatesService,
+                "_paid_postings_by_template",
+                return_value={template.id: paid},
+            ),
+        ):
+            results = service.list_upcoming_dues(
+                owner=owner,
+                as_of=date(2026, 8, 10),
+                window_days=7,
+                include_paid=False,
+            )
+        assert results == []
+
+    def test_batches_paid_lookup_once_per_month(self, owner: UsersDTO):
+        """Same-month dues share one get_transactions_frame call."""
+        service = _templates_service()
+        t1 = _template(id=uuid.uuid4(), name="A", planned_day=12, remind_days_before=0)
+        t2 = _template(id=uuid.uuid4(), name="B", planned_day=14, remind_days_before=0)
+        frame = pd.DataFrame([t1.model_dump(mode="python"), t2.model_dump(mode="python")])
+        service.transactions_service.get_transactions_frame.return_value = pd.DataFrame()
+        with patch.object(TransactionTemplatesService, "get_records", return_value=frame):
+            results = service.list_upcoming_dues(owner=owner, as_of=date(2026, 8, 10), window_days=7)
+
+        assert len(results) == 2
+        assert service.transactions_service.get_transactions_frame.call_count == 1
+
+    def test_one_off_due_date_in_list(self, owner: UsersDTO):
+        """One-off due_date templates appear when the due is in window."""
+        service = _templates_service()
+        template = _template(
+            due_date=date(2026, 8, 15),
+            planned_day=1,
+            remind_days_before=0,
+            name="One-off",
+        )
+        frame = pd.DataFrame([template.model_dump(mode="python")])
+        with (
+            patch.object(TransactionTemplatesService, "get_records", return_value=frame),
+            patch.object(TransactionTemplatesService, "_paid_postings_by_template", return_value={}),
+        ):
+            results = service.list_upcoming_dues(owner=owner, as_of=date(2026, 8, 10), window_days=7)
+        assert len(results) == 1
+        assert results[0].due_date == date(2026, 8, 15)
+
+    def test_paid_postings_match_template_in_month(self, owner: UsersDTO):
+        """Batch paid helper keeps the latest posting per template_id in-period."""
+        service = _templates_service()
+        template_id = uuid.uuid4()
+        older = TransactionsDTO(
+            id=uuid.uuid4(),
+            owner_id=owner.id,
+            transaction_kind=TransactionKind.EXPENSE,
+            amount=10.0,
+            template_id=template_id,
+            transaction_ts=datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc),
+        )
+        newer = TransactionsDTO(
+            id=uuid.uuid4(),
+            owner_id=owner.id,
+            transaction_kind=TransactionKind.EXPENSE,
+            amount=11.0,
+            template_id=template_id,
+            transaction_ts=datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc),
+        )
+        other = TransactionsDTO(
+            id=uuid.uuid4(),
+            owner_id=owner.id,
+            transaction_kind=TransactionKind.EXPENSE,
+            amount=9.0,
+            template_id=uuid.uuid4(),
+            transaction_ts=datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc),
+        )
+        service.transactions_service.get_transactions_frame.return_value = pd.DataFrame(
+            [
+                older.model_dump(mode="python"),
+                newer.model_dump(mode="python"),
+                other.model_dump(mode="python"),
+            ]
+        )
+        paid = service._paid_postings_by_template(
+            owner=owner,
+            dues_by_template={template_id: date(2026, 8, 15)},
+        )
+        assert paid[template_id].id == newer.id
+
+
+class TestMarkPaidClearPaid:
+    """mark_paid / clear_paid orchestration."""
+
+    def test_mark_paid_expense_uses_from_account(self, owner: UsersDTO):
+        """EXPENSE mark-paid posts from_account_id and template_id."""
+        service = _templates_service()
+        account_id = uuid.uuid4()
+        category_id = uuid.uuid4()
+        template = _template(
+            category_id=category_id,
+            from_account_id=account_id,
+            planned_day=15,
+            due_date=None,
+        )
+        category = CategoriesDTO(
+            id=category_id,
+            name="Bills",
+            category_kind=CategoryKind.EXPENSE,
+            owner_id=owner.id,
+        )
+        account = AccountsDTO(
+            id=account_id,
+            name="Checking",
+            description="",
+            owner_id=owner.id,
+            account_kind=AccountKind.CHECKING,
+            ledger_side=LedgerSide.ASSET,
+        )
+        created = TransactionsDTO(
+            id=uuid.uuid4(),
+            owner_id=owner.id,
+            transaction_kind=TransactionKind.EXPENSE,
+            amount=template.planned_amount,
+            from_account_id=account_id,
+            template_id=template.id,
+            category_id=category_id,
+            status=TransactionStatus.COMPLETED,
+        )
+        service.categories_service.get.return_value = category
+        service.accounts_service.get.return_value = account
+        service.transactions_service.create.return_value = created
+
+        with (
+            patch.object(TransactionTemplatesService, "get", return_value=template),
+            patch.object(TransactionTemplatesService, "_paid_posting_for_period", return_value=None),
+        ):
+            result = service.mark_paid(template_id=template.id, owner=owner, as_of=date(2026, 8, 1))
+
+        assert result is created
+        posted = service.transactions_service.create.call_args.kwargs["obj"]
+        assert posted.transaction_kind == TransactionKind.EXPENSE
+        assert posted.from_account_id == account_id
+        assert posted.to_account_id is None
+        assert posted.template_id == template.id
+        assert posted.amount == template.planned_amount
+
+    def test_mark_paid_income_uses_to_account(self, owner: UsersDTO):
+        """INCOME mark-paid maps template from_account_id to to_account_id."""
+        service = _templates_service()
+        account_id = uuid.uuid4()
+        category_id = uuid.uuid4()
+        template = _template(category_id=category_id, from_account_id=account_id, name="Paycheck")
+        category = CategoriesDTO(
+            id=category_id,
+            name="Salary",
+            category_kind=CategoryKind.INCOME,
+            owner_id=owner.id,
+        )
+        service.categories_service.get.return_value = category
+        service.accounts_service.get.return_value = AccountsDTO(
+            id=account_id,
+            name="Checking",
+            description="",
+            owner_id=owner.id,
+            account_kind=AccountKind.CHECKING,
+            ledger_side=LedgerSide.ASSET,
+        )
+        service.transactions_service.create.return_value = TransactionsDTO(
+            owner_id=owner.id,
+            transaction_kind=TransactionKind.INCOME,
+            amount=1.0,
+            to_account_id=account_id,
+            template_id=template.id,
+        )
+
+        with (
+            patch.object(TransactionTemplatesService, "get", return_value=template),
+            patch.object(TransactionTemplatesService, "_paid_posting_for_period", return_value=None),
+        ):
+            service.mark_paid(template_id=template.id, owner=owner, as_of=date(2026, 8, 1))
+
+        posted = service.transactions_service.create.call_args.kwargs["obj"]
+        assert posted.transaction_kind == TransactionKind.INCOME
+        assert posted.to_account_id == account_id
+        assert posted.from_account_id is None
+
+    def test_mark_paid_rejects_already_paid(self, owner: UsersDTO):
+        """Second mark-paid in the same period raises."""
+        service = _templates_service()
+        template = _template()
+        paid = TransactionsDTO(
+            id=uuid.uuid4(),
+            owner_id=owner.id,
+            transaction_kind=TransactionKind.EXPENSE,
+            amount=10.0,
+            template_id=template.id,
+        )
+        with (
+            patch.object(TransactionTemplatesService, "get", return_value=template),
+            patch.object(TransactionTemplatesService, "_paid_posting_for_period", return_value=paid),
+            pytest.raises(ValueError, match="already marked paid"),
+        ):
+            service.mark_paid(template_id=template.id, owner=owner, as_of=date(2026, 8, 1))
+
+    def test_mark_paid_requires_account(self, owner: UsersDTO):
+        """Missing from_account_id is rejected."""
+        service = _templates_service()
+        category_id = uuid.uuid4()
+        template = _template(from_account_id=None, category_id=category_id)
+        service.categories_service.get.return_value = CategoriesDTO(
+            id=category_id,
+            name="Bills",
+            category_kind=CategoryKind.EXPENSE,
+            owner_id=owner.id,
+        )
+        with (
+            patch.object(TransactionTemplatesService, "get", return_value=template),
+            patch.object(TransactionTemplatesService, "_paid_posting_for_period", return_value=None),
+            pytest.raises(ValueError, match="from_account_id is required"),
+        ):
+            service.mark_paid(template_id=template.id, owner=owner, as_of=date(2026, 8, 1))
+
+    def test_clear_paid_soft_deletes(self, owner: UsersDTO):
+        """clear_paid soft-deletes the period-linked posting."""
+        service = _templates_service()
+        template = _template()
+        paid = TransactionsDTO(
+            id=uuid.uuid4(),
+            owner_id=owner.id,
+            transaction_kind=TransactionKind.EXPENSE,
+            amount=10.0,
+            template_id=template.id,
+        )
+        with (
+            patch.object(TransactionTemplatesService, "get", return_value=template),
+            patch.object(TransactionTemplatesService, "_paid_posting_for_period", return_value=paid),
+        ):
+            result = service.clear_paid(template_id=template.id, owner=owner, as_of=date(2026, 8, 1))
+
+        assert result is paid
+        service.transactions_service.delete.assert_called_once()
+        assert service.transactions_service.delete.call_args.kwargs["hard"] is False
+
+    def test_clear_paid_raises_when_unpaid(self, owner: UsersDTO):
+        """clear_paid fails when no linked posting exists for the period."""
+        service = _templates_service()
+        template = _template()
+        with (
+            patch.object(TransactionTemplatesService, "get", return_value=template),
+            patch.object(TransactionTemplatesService, "_paid_posting_for_period", return_value=None),
+            pytest.raises(ValueError, match="not marked paid"),
+        ):
+            service.clear_paid(template_id=template.id, owner=owner, as_of=date(2026, 8, 1))


### PR DESCRIPTION
**Branch:** `feat/PPT-072` · **Base:** `main` · **1 commit** · **7 files**

**Suggested title:** `feat/PPT-072: [model] Upcoming dues query and mark-paid services`

## Summary

Implements PPT-072 model services for in-app payment due reminders on top of closed PPT-071 schema columns. Tenants get an owner-scoped upcoming-dues window query plus mark-paid / clear-paid paths that post or soft-delete linked `EXPENSE`/`INCOME` rows via `template_id`, keeping business rules in `papita_txnsmodel` for PPT-073 API wiring.

## Out of scope / Highlights

**Out of scope**

- HTTP routers / OpenAPI (PPT-073 / #166)
- SPA Due soon UI (PPT-074 / #167)
- Email/push notify, RRULE engine, obligations package
- New Alembic revisions (schema already landed in PPT-071)

**Highlights**

- Paid state remains derived from linked `transactions.template_id` (no template paid flag)
- Month-batched paid lookups for `list_upcoming_dues` (one frame read per calendar period)
- B0 integration test included (skips when Postgres is unavailable)

## Changes

**Model services**

- Due helpers: one-off `due_date` precedence, recurring `planned_day` / `use_month_end` clamp, remind-window overlap
- `TransactionTemplatesService.list_upcoming_dues` → `UpcomingDueDTO`
- `mark_paid` posts EXPENSE (`from_account_id`) or INCOME (`to_account_id` from the same template field) with owner-checked account
- `clear_paid` soft-deletes the period’s latest linked posting

**DTO / docs**

- Align `remind_days_before=null` with runtime (= 0, surface on due day)
- Document mark-paid account-leg mapping on `from_account_id`

**Tests / memory**

- Unit coverage for helpers, batching, mark/clear paths
- Live B0 round-trip + cross-tenant isolation test
- `.strata` project_state advanced to PPT-072

## File changes

<details>
<summary>File changes (~7 files)</summary>

```
 .strata/memory/project_state.md                    |  10 +-
 .../papita_txnsmodel/access/transactions/dto.py    |  11 +-
 .../src/papita_txnsmodel/services/__init__.py      |   2 +
 .../model/src/papita_txnsmodel/services/dues.py    | 168 ++++++++
 .../src/papita_txnsmodel/services/transactions.py  | 349 ++++++++++++++++-
 .../integration/test_ppt072_dues_live_db.py        | 149 ++++++++
 .../services/test_ppt072_dues.py                   | 421 +++++++++++++++++++++
 7 files changed, 1097 insertions(+), 13 deletions(-)
```

</details>

## Commits

- `88ca105` feat/PPT-072: [model] Add upcoming dues query and mark-paid services

## Checks, tests, and validation already done

- `poetry run pytest modules/model/tests/tests_papita_txnsmodel/services/test_ppt072_dues.py` — **18 passed**
- B0 integration `test_ppt072_dues_live_db.py` — **skipped locally** (Docker daemon unavailable); will run in CI when Postgres is configured
- Pre-commit (isort/black/flake8/pylint/mypy/strata) — **passed** on commit

## QA / test plan

- [ ] CI model unit suite green for PPT-072 tests
- [ ] CI/B0: integration test runs when `DATABASE_URL` Postgres is available (mark-paid → list paid → clear-paid → unpaid)
- [ ] Confirm no API/web files changed
- [ ] Spot-check handoff methods for PPT-073: `list_upcoming_dues`, `mark_paid`, `clear_paid`

## Risks

> [!CAUTION]
>
> ### Risks
>
> - Nested `TransactionsService` is auto-wired on `TransactionTemplatesService` construction (separate from API DI cache) — intentional for mark-paid FK validation
> - Recurring period matching keys off the resolved due’s calendar month and default `transaction_ts` (noon UTC on due) — callers overriding `transaction_ts` outside that month can miss paid detection

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - `remind_days_before=null` is treated as 0 (reminder starts on due day), not “never remind”
> - INCOME mark-paid reuses template `from_account_id` as deposit (`to_account_id`)
> - Overdue dues (`as_of` after due) are excluded from upcoming window by design

## References

- Closes #165 (PPT-072)
- Parent epic: #163 (PPT-070)
- Depends on: #164 (PPT-071) — closed
- Blocks: #166 (PPT-073)


Made with [Cursor](https://cursor.com)