### PR TITLE
feat/PPT-074: [web] Payment dues UI and dashboard Due soon panel

### DIFF
--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -14,8 +14,10 @@ Capture with `/strata:capture` only for work in flight.
 
 ### Last completed (this session)
 
-- **PPT-072 / #165:** landed on main ([PR #204](https://github.com/Elmorralito/save-ma-money/pull/204)) —
-  upcoming-dues + mark-paid / clear-paid in `papita_txnsmodel`.
+- **PPT-073 / #166:** landed on main ([PR #205](https://github.com/Elmorralito/save-ma-money/pull/205)) —
+  `/transaction-templates` CRUD + upcoming-dues / mark-paid / clear-paid FastAPI routers.
+- **PPT-072 / #165:** upcoming-dues + mark-paid / clear-paid in `papita_txnsmodel`
+  ([PR #204](https://github.com/Elmorralito/save-ma-money/pull/204)).
 - **PPT-071 / #164:** schema + migration for dues columns on `transaction_templates`.
 - **PPT-068 / #139**, **PPT-063 / #128**, **PPT-069 / #140**, **PPT-067 / #132**: on main.
 
@@ -27,22 +29,18 @@ Capture with `/strata:capture` only for work in flight.
 
 ### In progress (ACTIVE)
 
-- **PPT-073 / #166:** [PR #205](https://github.com/Elmorralito/save-ma-money/pull/205) —
-  transaction-templates CRUD + upcoming-dues / mark-paid / clear-paid FastAPI routers;
-  restore model path version **1.0.3** (PSR had rewritten to 1.0.1, breaking API `>=1.0.3`);
-  CI fix: coerce pandas NaN on optional ints before DTO validate; flatten nested `TableDTO`
-  FKs in `_relation_uuid` for mark-paid responses.
-- **[PR #193](https://github.com/Elmorralito/save-ma-money/pull/193):** GHA Dependabot bumps +
-  e2e login/nav hardening + Hadolint HEALTHCHECK JSON / DL3066 ignore (if still open).
+- **PPT-074 / #167:** SPA payment dues UI + dashboard **Due soon** — OpenAPI sync, typed
+  `transactionTemplates` client/query keys, `/payment-dues` CRUD + mark/clear paid,
+  dashboard panel; presentation only over PPT-073 API (branch `feat/PPT-074`).
 
 ### Open (backlog)
 
-- **PPT-070** children #167–#168 — SPA Due soon + OpenAPI/docs after PPT-073 lands.
+- **PPT-070** child #168 — tests, OpenAPI sync gate, docs index after PPT-074.
 - **PPT-066 follow-up:** after 1–2 releases, drop legacy `model-v*` publish trigger.
 
 ### Next action
 
-- Open / merge PR for PPT-073 / #166; then PPT-074 / #167 web dues UI
+- Open / merge PR for PPT-074 / #167; then PPT-075 / #168
 - Do not re-add closed GH issues into `.strata/issues/`
 
 ### Uncommitted / staging notes

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -29,9 +29,9 @@ Capture with `/strata:capture` only for work in flight.
 
 ### In progress (ACTIVE)
 
-- **PPT-074 / #167:** SPA payment dues UI + dashboard **Due soon** — OpenAPI sync, typed
-  `transactionTemplates` client/query keys, `/payment-dues` CRUD + mark/clear paid,
-  dashboard panel; presentation only over PPT-073 API (branch `feat/PPT-074`).
+- **PPT-074 / #167:** [PR #206](https://github.com/Elmorralito/save-ma-money/pull/206) —
+  SPA payment dues UI + dashboard **Due soon**; also restore model path version **1.0.3**
+  after main PSR `chore(model): release 1.0.2` incorrectly downgraded past API `>=1.0.3`.
 
 ### Open (backlog)
 

--- a/modules/model/pyproject.toml
+++ b/modules/model/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "papita-transactions-model"
-version = "1.0.2"
+version = "1.0.3"
 description = "SQLModel/PostgreSQL domain layer for Papita financial transactions (papita_txnsmodel)."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/modules/web/e2e/a11y.spec.ts
+++ b/modules/web/e2e/a11y.spec.ts
@@ -10,6 +10,7 @@ const AUTHED_ROUTES = [
   "/accounts",
   "/categories",
   "/transactions",
+  "/payment-dues",
   "/movements",
   "/reports",
 ] as const;

--- a/modules/web/openapi/openapi.json
+++ b/modules/web/openapi/openapi.json
@@ -1125,6 +1125,26 @@
         "title": "CategoryUpdate",
         "type": "object"
       },
+      "ClearPaidRequest": {
+        "additionalProperties": false,
+        "description": "Optional body for ``POST …/clear-paid``.",
+        "properties": {
+          "as_of": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "As Of"
+          }
+        },
+        "title": "ClearPaidRequest",
+        "type": "object"
+      },
       "CreditCardDetailsSchema": {
         "additionalProperties": false,
         "description": "Credit card extension fields.\n\nAttributes:\n    credit_limit: Maximum revolving credit; must be positive.",
@@ -1410,6 +1430,50 @@
           "refresh_token"
         ],
         "title": "LogoutRequest",
+        "type": "object"
+      },
+      "MarkPaidRequest": {
+        "additionalProperties": false,
+        "description": "Optional body for ``POST …/mark-paid``.",
+        "properties": {
+          "amount": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Amount"
+          },
+          "as_of": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "As Of"
+          },
+          "transaction_ts": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Transaction Ts"
+          }
+        },
+        "title": "MarkPaidRequest",
         "type": "object"
       },
       "MonthlyTrendItem": {
@@ -1922,6 +1986,39 @@
           "limit"
         ],
         "title": "PaginatedResponse[TransactionResponse]",
+        "type": "object"
+      },
+      "PaginatedResponse_TransactionTemplateResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TransactionTemplateResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "skip": {
+            "minimum": 0.0,
+            "title": "Skip",
+            "type": "integer"
+          },
+          "total": {
+            "minimum": 0.0,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "skip",
+          "limit"
+        ],
+        "title": "PaginatedResponse[TransactionTemplateResponse]",
         "type": "object"
       },
       "ProviderType": {
@@ -2779,6 +2876,357 @@
         "title": "TransactionResponse",
         "type": "object"
       },
+      "TransactionTemplateCreate": {
+        "additionalProperties": false,
+        "description": "Request body for ``POST /transaction-templates``.",
+        "properties": {
+          "category_id": {
+            "format": "uuid",
+            "title": "Category Id",
+            "type": "string"
+          },
+          "description": {
+            "default": "",
+            "maxLength": 2000,
+            "title": "Description",
+            "type": "string"
+          },
+          "due_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Due Date"
+          },
+          "from_account_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "From Account Id"
+          },
+          "name": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "planned_amount": {
+            "exclusiveMinimum": 0.0,
+            "title": "Planned Amount",
+            "type": "number"
+          },
+          "planned_day": {
+            "maximum": 31.0,
+            "minimum": 1.0,
+            "title": "Planned Day",
+            "type": "integer"
+          },
+          "remind_days_before": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remind Days Before"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 20,
+            "title": "Tags",
+            "type": "array"
+          },
+          "use_month_end": {
+            "default": false,
+            "title": "Use Month End",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "category_id",
+          "planned_amount",
+          "planned_day"
+        ],
+        "title": "TransactionTemplateCreate",
+        "type": "object"
+      },
+      "TransactionTemplateResponse": {
+        "description": "Transaction-template resource returned by CRUD endpoints.",
+        "properties": {
+          "category_id": {
+            "format": "uuid",
+            "title": "Category Id",
+            "type": "string"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "due_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Due Date"
+          },
+          "from_account_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "From Account Id"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "planned_amount": {
+            "title": "Planned Amount",
+            "type": "number"
+          },
+          "planned_day": {
+            "title": "Planned Day",
+            "type": "integer"
+          },
+          "remind_days_before": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remind Days Before"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "use_month_end": {
+            "title": "Use Month End",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "category_id",
+          "planned_amount",
+          "planned_day",
+          "use_month_end",
+          "is_active"
+        ],
+        "title": "TransactionTemplateResponse",
+        "type": "object"
+      },
+      "TransactionTemplateUpdate": {
+        "additionalProperties": false,
+        "description": "Partial update body for ``PUT /transaction-templates/{template_id}``.",
+        "properties": {
+          "category_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "due_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Due Date"
+          },
+          "from_account_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "From Account Id"
+          },
+          "is_active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Active"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "planned_amount": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Planned Amount"
+          },
+          "planned_day": {
+            "anyOf": [
+              {
+                "maximum": 31.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Planned Day"
+          },
+          "remind_days_before": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remind Days Before"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 20,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          },
+          "use_month_end": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Use Month End"
+          }
+        },
+        "title": "TransactionTemplateUpdate",
+        "type": "object"
+      },
       "TransactionUpdate": {
         "additionalProperties": false,
         "description": "Request body for ``PUT /transactions/{transaction_id}``.",
@@ -2969,6 +3417,75 @@
           "analysis_period"
         ],
         "title": "TrendsReportResponse",
+        "type": "object"
+      },
+      "UpcomingDueResponse": {
+        "description": "Single upcoming-due row for in-app reminders.",
+        "properties": {
+          "due_date": {
+            "format": "date",
+            "title": "Due Date",
+            "type": "string"
+          },
+          "is_paid": {
+            "default": false,
+            "title": "Is Paid",
+            "type": "boolean"
+          },
+          "paid_transaction_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paid Transaction Id"
+          },
+          "remind_start": {
+            "format": "date",
+            "title": "Remind Start",
+            "type": "string"
+          },
+          "template": {
+            "$ref": "#/components/schemas/TransactionTemplateResponse"
+          }
+        },
+        "required": [
+          "template",
+          "due_date",
+          "remind_start"
+        ],
+        "title": "UpcomingDueResponse",
+        "type": "object"
+      },
+      "UpcomingDuesResponse": {
+        "description": "List payload for ``GET /transaction-templates/upcoming-dues``.",
+        "properties": {
+          "as_of": {
+            "format": "date",
+            "title": "As Of",
+            "type": "string"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/UpcomingDueResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "window_days": {
+            "title": "Window Days",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "as_of",
+          "window_days"
+        ],
+        "title": "UpcomingDuesResponse",
         "type": "object"
       },
       "UserResponse": {
@@ -5866,6 +6383,515 @@
         "summary": "Get Trends Report",
         "tags": [
           "Reports"
+        ]
+      }
+    },
+    "/api/v1/transaction-templates": {
+      "get": {
+        "description": "List tenant transaction templates with optional filters.\n\nArgs:\n    owner: Authenticated tenant from JWT.\n    pagination: Skip/limit window for the response page.\n    templates_service: Injected templates service.\n    category_id: Optional category filter.\n    is_active: Optional soft-active filter.\n\nReturns:\n    Paginated ``TransactionTemplateResponse`` items owned by ``owner``.",
+        "operationId": "list_transaction_templates_api_v1_transaction_templates_get",
+        "parameters": [
+          {
+            "description": "Filter by category",
+            "in": "query",
+            "name": "category_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by category",
+              "title": "Category Id"
+            }
+          },
+          {
+            "description": "Filter by active status",
+            "in": "query",
+            "name": "is_active",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by active status",
+              "title": "Is Active"
+            }
+          },
+          {
+            "description": "Number of records to skip",
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of records to skip",
+              "minimum": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum records to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "description": "Maximum records to return",
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_TransactionTemplateResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Transaction Templates",
+        "tags": [
+          "Transaction templates"
+        ]
+      },
+      "post": {
+        "description": "Create a tenant-owned transaction template.",
+        "operationId": "create_transaction_template_api_v1_transaction_templates_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransactionTemplateCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionTemplateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Create Transaction Template",
+        "tags": [
+          "Transaction templates"
+        ]
+      }
+    },
+    "/api/v1/transaction-templates/upcoming-dues": {
+      "get": {
+        "description": "List owner-scoped templates with a due in the upcoming reminder window.\n\nArgs:\n    owner: Authenticated tenant from JWT.\n    templates_service: Injected templates service.\n    filters: ``as_of`` / ``window_days`` / ``include_paid`` query bundle.\n\nReturns:\n    Upcoming dues sorted by the model service (due date, then name/id).\n\nRaises:\n    HTTPException: 422 when ``window_days`` is rejected by the service.",
+        "operationId": "list_upcoming_dues_api_v1_transaction_templates_upcoming_dues_get",
+        "parameters": [
+          {
+            "description": "Window anchor date (UTC today when omitted)",
+            "in": "query",
+            "name": "as_of",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Window anchor date (UTC today when omitted)",
+              "title": "As Of"
+            }
+          },
+          {
+            "description": "Inclusive days after as_of",
+            "in": "query",
+            "name": "window_days",
+            "required": false,
+            "schema": {
+              "default": 14,
+              "description": "Inclusive days after as_of",
+              "minimum": 0,
+              "title": "Window Days",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include dues already marked paid",
+            "in": "query",
+            "name": "include_paid",
+            "required": false,
+            "schema": {
+              "default": true,
+              "description": "Include dues already marked paid",
+              "title": "Include Paid",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpcomingDuesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Upcoming Dues",
+        "tags": [
+          "Transaction templates"
+        ]
+      }
+    },
+    "/api/v1/transaction-templates/{template_id}": {
+      "delete": {
+        "description": "Soft-delete a tenant-owned transaction template.\n\nRaises:\n    HTTPException: 404 when missing or not owned by ``owner``.",
+        "operationId": "delete_transaction_template_api_v1_transaction_templates__template_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "template_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Template Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Transaction Template",
+        "tags": [
+          "Transaction templates"
+        ]
+      },
+      "get": {
+        "description": "Retrieve a tenant-owned transaction template by id.\n\nRaises:\n    HTTPException: 404 when missing or not owned by ``owner``.",
+        "operationId": "get_transaction_template_api_v1_transaction_templates__template_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "template_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Template Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionTemplateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Transaction Template",
+        "tags": [
+          "Transaction templates"
+        ]
+      },
+      "put": {
+        "description": "Update a tenant-owned transaction template.\n\nRaises:\n    HTTPException: 404 when missing or not owned by ``owner``.",
+        "operationId": "update_transaction_template_api_v1_transaction_templates__template_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "template_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Template Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransactionTemplateUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionTemplateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Transaction Template",
+        "tags": [
+          "Transaction templates"
+        ]
+      }
+    },
+    "/api/v1/transaction-templates/{template_id}/clear-paid": {
+      "post": {
+        "description": "Soft-delete the linked posting for the template due period.\n\nRaises:\n    HTTPException: 404 / 409 / 422 from mapped service ValueErrors.",
+        "operationId": "clear_template_paid_api_v1_transaction_templates__template_id__clear_paid_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "template_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Template Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ClearPaidRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Clear Template Paid",
+        "tags": [
+          "Transaction templates"
+        ]
+      }
+    },
+    "/api/v1/transaction-templates/{template_id}/mark-paid": {
+      "post": {
+        "description": "Post a linked EXPENSE/INCOME for the template due (mark paid).\n\nRaises:\n    HTTPException: 404 / 409 / 422 from mapped service ValueErrors.",
+        "operationId": "mark_template_paid_api_v1_transaction_templates__template_id__mark_paid_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "template_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Template Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/MarkPaidRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Mark Template Paid",
+        "tags": [
+          "Transaction templates"
         ]
       }
     },

--- a/modules/web/src/App.test.tsx
+++ b/modules/web/src/App.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as authApi from "@/api/auth";
 import * as accountsApi from "@/api/accounts";
 import * as movementsApi from "@/api/movements";
+import * as templatesApi from "@/api/transactionTemplates";
 import { RequireAuth } from "@/auth/RequireAuth";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { PublicLayout } from "@/components/layout/PublicLayout";
@@ -36,6 +37,17 @@ vi.mock("@/api/movements", () => ({
   updateMovement: vi.fn(),
   executeMovement: vi.fn(),
   cancelMovement: vi.fn(),
+}));
+
+vi.mock("@/api/transactionTemplates", () => ({
+  listTransactionTemplates: vi.fn(),
+  listUpcomingDues: vi.fn(),
+  getTransactionTemplate: vi.fn(),
+  createTransactionTemplate: vi.fn(),
+  updateTransactionTemplate: vi.fn(),
+  deleteTransactionTemplate: vi.fn(),
+  markTemplatePaid: vi.fn(),
+  clearTemplatePaid: vi.fn(),
 }));
 
 vi.mock("@/api/health", () => ({
@@ -152,7 +164,7 @@ describe("auth routing", () => {
 });
 
 describe("DashboardPage (authenticated)", () => {
-  it("renders welcome, session TTL, accounts, and pending transfers", async () => {
+  it("renders welcome, session TTL, accounts, due soon, and pending transfers", async () => {
     const expiresAt = Math.floor(Date.now() / 1000) + 3600;
     vi.mocked(authApi.getBffSession).mockResolvedValue({
       authenticated: true,
@@ -205,6 +217,32 @@ describe("DashboardPage (authenticated)", () => {
       skip: 0,
       limit: 5,
     });
+    vi.mocked(templatesApi.listUpcomingDues).mockResolvedValue({
+      as_of: "2026-08-10",
+      window_days: 14,
+      items: [
+        {
+          due_date: "2026-08-15",
+          remind_start: "2026-08-12",
+          is_paid: false,
+          paid_transaction_id: null,
+          template: {
+            id: "dddddddd-dddd-dddd-dddd-dddddddddddd",
+            name: "Electric bill",
+            description: "",
+            tags: [],
+            category_id: "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+            planned_amount: 90,
+            planned_day: 15,
+            use_month_end: false,
+            due_date: null,
+            remind_days_before: 3,
+            from_account_id: null,
+            is_active: true,
+          },
+        },
+      ],
+    });
 
     render(
       <QueryTestProvider>
@@ -224,8 +262,10 @@ describe("DashboardPage (authenticated)", () => {
     expect(screen.getByRole("region", { name: "Pending transfers" })).toHaveTextContent(
       "Rent hold",
     );
+    expect(screen.getByRole("region", { name: "Due soon" })).toHaveTextContent("Electric bill");
     expect(screen.getByRole("region", { name: "Quick links" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Balances and account details/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Bills and payment deadlines/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /View spending report/i })).toBeInTheDocument();
   });
 });

--- a/modules/web/src/App.tsx
+++ b/modules/web/src/App.tsx
@@ -51,6 +51,10 @@ const ReportsPage = lazy(async () => {
   const mod = await import("@/pages/ReportsPage");
   return { default: mod.ReportsPage };
 });
+const PaymentDuesPage = lazy(async () => {
+  const mod = await import("@/pages/PaymentDuesPage");
+  return { default: mod.PaymentDuesPage };
+});
 
 function RouteFallback() {
   return (
@@ -87,6 +91,7 @@ function App() {
             <Route path="/accounts/:accountId" element={<AccountDetailPage />} />
             <Route path="/categories" element={<CategoriesPage />} />
             <Route path="/transactions" element={<TransactionsPage />} />
+            <Route path="/payment-dues" element={<PaymentDuesPage />} />
             <Route path="/movements" element={<MovementsPage />} />
             <Route path="/reports" element={<ReportsPage />} />
           </Route>

--- a/modules/web/src/api/index.ts
+++ b/modules/web/src/api/index.ts
@@ -53,7 +53,7 @@ export {
 } from "@/api/categories";
 export { getHealth, getHealthLive } from "@/api/health";
 export { IDEMPOTENCY_KEY_HEADER, newIdempotencyKey } from "@/api/idempotency";
-export { invalidateAfterLedgerWrite } from "@/api/invalidateLedger";
+export { invalidateAfterLedgerWrite, invalidateAfterTemplateWrite } from "@/api/invalidateLedger";
 export { getClientContract } from "@/api/meta";
 export {
   cancelMovement,
@@ -85,8 +85,23 @@ export {
   movementsListQueryOptions,
   spendingReportQueryOptions,
   transactionDetailQueryOptions,
+  transactionTemplateDetailQueryOptions,
+  transactionTemplatesListQueryOptions,
   transactionsListQueryOptions,
+  upcomingDuesQueryOptions,
 } from "@/api/queries";
 export { createAppQueryClient } from "@/api/queryClient";
 export { queryKeys } from "@/api/queryKeys";
 export { getSpendingReport, type SpendingGroupBy, type SpendingReportParams } from "@/api/reports";
+export {
+  clearTemplatePaid,
+  createTransactionTemplate,
+  deleteTransactionTemplate,
+  getTransactionTemplate,
+  listTransactionTemplates,
+  listUpcomingDues,
+  markTemplatePaid,
+  updateTransactionTemplate,
+  type ListTransactionTemplatesParams,
+  type ListUpcomingDuesParams,
+} from "@/api/transactionTemplates";

--- a/modules/web/src/api/invalidateLedger.ts
+++ b/modules/web/src/api/invalidateLedger.ts
@@ -12,6 +12,7 @@ export async function invalidateAfterLedgerWrite(
   options: {
     transactions?: boolean;
     movements?: boolean;
+    templates?: boolean;
     transactionId?: string;
     movementId?: string;
     removeTransactionId?: string;
@@ -28,6 +29,9 @@ export async function invalidateAfterLedgerWrite(
   }
   if (options.movements) {
     tasks.push(queryClient.invalidateQueries({ queryKey: queryKeys.movements.lists() }));
+  }
+  if (options.templates) {
+    tasks.push(queryClient.invalidateQueries({ queryKey: queryKeys.transactionTemplates.all }));
   }
   if (options.transactionId) {
     tasks.push(
@@ -53,4 +57,45 @@ export async function invalidateAfterLedgerWrite(
   }
 
   await Promise.all(tasks);
+}
+
+/**
+ * Invalidate payment-due template caches (list, detail, upcoming dues).
+ *
+ * When ``markPaid`` is true, also refreshes ledger lists (accounts / transactions).
+ */
+export async function invalidateAfterTemplateWrite(
+  queryClient: QueryClient,
+  options: {
+    templateId?: string;
+    removeTemplateId?: string;
+    markPaid?: boolean;
+    transactionId?: string;
+  } = {},
+): Promise<void> {
+  const tasks: Promise<unknown>[] = [
+    queryClient.invalidateQueries({ queryKey: queryKeys.transactionTemplates.all }),
+  ];
+
+  if (options.templateId) {
+    tasks.push(
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.transactionTemplates.detail(options.templateId),
+      }),
+    );
+  }
+  if (options.removeTemplateId) {
+    queryClient.removeQueries({
+      queryKey: queryKeys.transactionTemplates.detail(options.removeTemplateId),
+    });
+  }
+
+  await Promise.all(tasks);
+
+  if (options.markPaid) {
+    await invalidateAfterLedgerWrite(queryClient, {
+      transactions: true,
+      transactionId: options.transactionId,
+    });
+  }
 }

--- a/modules/web/src/api/queries.ts
+++ b/modules/web/src/api/queries.ts
@@ -8,6 +8,13 @@ import { getMovement, listMovements, type ListMovementsParams } from "@/api/move
 import { queryKeys } from "@/api/queryKeys";
 import { getSpendingReport, type SpendingGroupBy, type SpendingReportParams } from "@/api/reports";
 import { getTransaction, listTransactions, type ListTransactionsParams } from "@/api/transactions";
+import {
+  getTransactionTemplate,
+  listTransactionTemplates,
+  listUpcomingDues,
+  type ListTransactionTemplatesParams,
+  type ListUpcomingDuesParams,
+} from "@/api/transactionTemplates";
 
 /** Shared query definition for PPT-044 client-contract discovery. */
 export function clientContractQueryOptions() {
@@ -174,5 +181,53 @@ export function spendingReportQueryOptions(
   return queryOptions({
     queryKey: queryKeys.reports.spending(spendingReportFilters(params)),
     queryFn: ({ signal }) => getSpendingReport({ ...params, signal }),
+  });
+}
+
+function transactionTemplatesListFilters(
+  params: Omit<ListTransactionTemplatesParams, "signal">,
+): Record<string, string | number | boolean | undefined> {
+  return {
+    category_id: params.category_id,
+    is_active: params.is_active,
+    skip: params.skip,
+    limit: params.limit,
+  };
+}
+
+function upcomingDuesFilters(
+  params: Omit<ListUpcomingDuesParams, "signal">,
+): Record<string, string | number | boolean | undefined> {
+  return {
+    as_of: params.as_of,
+    window_days: params.window_days,
+    include_paid: params.include_paid,
+  };
+}
+
+/** Shared query definition for paginated transaction templates (payment dues). */
+export function transactionTemplatesListQueryOptions(
+  params: Omit<ListTransactionTemplatesParams, "signal"> = {},
+) {
+  return queryOptions({
+    queryKey: queryKeys.transactionTemplates.list(transactionTemplatesListFilters(params)),
+    queryFn: ({ signal }) => listTransactionTemplates({ ...params, signal }),
+  });
+}
+
+/** Shared query definition for a single transaction template. */
+export function transactionTemplateDetailQueryOptions(templateId: string) {
+  return queryOptions({
+    queryKey: queryKeys.transactionTemplates.detail(templateId),
+    queryFn: ({ signal }) => getTransactionTemplate(templateId, signal),
+    enabled: templateId.length > 0,
+  });
+}
+
+/** Shared query definition for ``GET /transaction-templates/upcoming-dues``. */
+export function upcomingDuesQueryOptions(params: Omit<ListUpcomingDuesParams, "signal"> = {}) {
+  return queryOptions({
+    queryKey: queryKeys.transactionTemplates.upcomingDues(upcomingDuesFilters(params)),
+    queryFn: ({ signal }) => listUpcomingDues({ ...params, signal }),
   });
 }

--- a/modules/web/src/api/queryKeys.test.ts
+++ b/modules/web/src/api/queryKeys.test.ts
@@ -13,6 +13,7 @@ describe("queryKeys", () => {
     expect(queryKeys.transactions.all).toEqual(["papita", "transactions"]);
     expect(queryKeys.movements.all).toEqual(["papita", "movements"]);
     expect(queryKeys.reports.all).toEqual(["papita", "reports"]);
+    expect(queryKeys.transactionTemplates.all).toEqual(["papita", "transactionTemplates"]);
   });
 
   it("builds distinct leaf keys for meta, health, auth, and feature resources", () => {
@@ -60,6 +61,24 @@ describe("queryKeys", () => {
       "reports",
       "spending",
       { start_date: "2026-01-01", end_date: "2026-01-31" },
+    ]);
+    expect(queryKeys.transactionTemplates.list({ limit: 100 })).toEqual([
+      "papita",
+      "transactionTemplates",
+      "list",
+      { limit: 100 },
+    ]);
+    expect(queryKeys.transactionTemplates.detail("tmpl-1")).toEqual([
+      "papita",
+      "transactionTemplates",
+      "detail",
+      "tmpl-1",
+    ]);
+    expect(queryKeys.transactionTemplates.upcomingDues({ window_days: 14 })).toEqual([
+      "papita",
+      "transactionTemplates",
+      "upcomingDues",
+      { window_days: 14 },
     ]);
   });
 });

--- a/modules/web/src/api/queryKeys.ts
+++ b/modules/web/src/api/queryKeys.ts
@@ -56,4 +56,16 @@ export const queryKeys = {
     spending: (filters: Record<string, string | number | boolean | undefined | null>) =>
       ["papita", "reports", "spending", filters] as const,
   },
+  transactionTemplates: {
+    all: ["papita", "transactionTemplates"] as const,
+    lists: () => ["papita", "transactionTemplates", "list"] as const,
+    list: (filters: Record<string, string | number | boolean | undefined>) =>
+      ["papita", "transactionTemplates", "list", filters] as const,
+    details: () => ["papita", "transactionTemplates", "detail"] as const,
+    detail: (templateId: string) =>
+      ["papita", "transactionTemplates", "detail", templateId] as const,
+    upcomingDuesAll: () => ["papita", "transactionTemplates", "upcomingDues"] as const,
+    upcomingDues: (filters: Record<string, string | number | boolean | undefined>) =>
+      ["papita", "transactionTemplates", "upcomingDues", filters] as const,
+  },
 } as const;

--- a/modules/web/src/api/transactionTemplates.test.ts
+++ b/modules/web/src/api/transactionTemplates.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  listTransactionTemplates,
+  listUpcomingDues,
+  markTemplatePaid,
+} from "@/api/transactionTemplates";
+
+describe("transactionTemplates API helpers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("lists templates with query filters and credentials include", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json({ items: [], limit: 100, skip: 0, total: 0 }, { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await listTransactionTemplates({
+      category_id: "11111111-1111-1111-1111-111111111111",
+      is_active: true,
+      limit: 100,
+      skip: 0,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/transaction-templates?"),
+      expect.objectContaining({ credentials: "include", method: "GET" }),
+    );
+    const url = String(fetchMock.mock.calls[0]?.[0]);
+    expect(url).toContain("category_id=11111111-1111-1111-1111-111111111111");
+    expect(url).toContain("is_active=true");
+    expect(url).toContain("limit=100");
+  });
+
+  it("lists upcoming dues with window params", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json({ items: [], as_of: "2026-08-10", window_days: 14 }, { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await listUpcomingDues({ window_days: 14, include_paid: false });
+
+    const url = String(fetchMock.mock.calls[0]?.[0]);
+    expect(url).toContain("/api/v1/transaction-templates/upcoming-dues?");
+    expect(url).toContain("window_days=14");
+    expect(url).toContain("include_paid=false");
+  });
+
+  it("posts mark-paid with JSON body", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json(
+        {
+          id: "22222222-2222-2222-2222-222222222222",
+          amount: 50,
+          currency: "USD",
+          description: "Rent",
+          status: "completed",
+          transaction_date: "2026-08-01",
+          transaction_type: "expense",
+          is_recurring: false,
+        },
+        { status: 201 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await markTemplatePaid("33333333-3333-3333-3333-333333333333", { amount: 50 });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+      "/api/v1/transaction-templates/33333333-3333-3333-3333-333333333333/mark-paid",
+    );
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({ amount: 50 });
+  });
+});

--- a/modules/web/src/api/transactionTemplates.ts
+++ b/modules/web/src/api/transactionTemplates.ts
@@ -1,0 +1,161 @@
+import { apiFetch } from "@/api/http";
+import type {
+  ClearPaidRequest,
+  MarkPaidRequest,
+  PaginatedTransactionTemplates,
+  TransactionResponse,
+  TransactionTemplateCreate,
+  TransactionTemplateResponse,
+  TransactionTemplateUpdate,
+  UpcomingDuesResponse,
+} from "@/types/domain";
+
+const TEMPLATES_PATH = "/api/v1/transaction-templates";
+
+export type ListTransactionTemplatesParams = {
+  category_id?: string;
+  is_active?: boolean;
+  skip?: number;
+  limit?: number;
+  signal?: AbortSignal;
+};
+
+export type ListUpcomingDuesParams = {
+  as_of?: string;
+  window_days?: number;
+  include_paid?: boolean;
+  signal?: AbortSignal;
+};
+
+function buildListQuery(params: ListTransactionTemplatesParams): string {
+  const search = new URLSearchParams();
+  if (params.category_id) {
+    search.set("category_id", params.category_id);
+  }
+  if (params.is_active !== undefined) {
+    search.set("is_active", String(params.is_active));
+  }
+  if (params.skip !== undefined) {
+    search.set("skip", String(params.skip));
+  }
+  if (params.limit !== undefined) {
+    search.set("limit", String(params.limit));
+  }
+  const qs = search.toString();
+  return qs === "" ? TEMPLATES_PATH : `${TEMPLATES_PATH}?${qs}`;
+}
+
+function buildUpcomingDuesQuery(params: ListUpcomingDuesParams): string {
+  const search = new URLSearchParams();
+  if (params.as_of) {
+    search.set("as_of", params.as_of);
+  }
+  if (params.window_days !== undefined) {
+    search.set("window_days", String(params.window_days));
+  }
+  if (params.include_paid !== undefined) {
+    search.set("include_paid", String(params.include_paid));
+  }
+  const qs = search.toString();
+  const path = `${TEMPLATES_PATH}/upcoming-dues`;
+  return qs === "" ? path : `${path}?${qs}`;
+}
+
+/** ``GET /api/v1/transaction-templates`` — paginated payment-due templates. */
+export async function listTransactionTemplates(
+  params: ListTransactionTemplatesParams = {},
+): Promise<PaginatedTransactionTemplates> {
+  const { signal, ...filters } = params;
+  const result = await apiFetch<PaginatedTransactionTemplates>(buildListQuery(filters), { signal });
+  return result.data;
+}
+
+/** ``GET /api/v1/transaction-templates/upcoming-dues``. */
+export async function listUpcomingDues(
+  params: ListUpcomingDuesParams = {},
+): Promise<UpcomingDuesResponse> {
+  const { signal, ...filters } = params;
+  const result = await apiFetch<UpcomingDuesResponse>(buildUpcomingDuesQuery(filters), { signal });
+  return result.data;
+}
+
+/** ``GET /api/v1/transaction-templates/{template_id}``. */
+export async function getTransactionTemplate(
+  templateId: string,
+  signal?: AbortSignal,
+): Promise<TransactionTemplateResponse> {
+  const result = await apiFetch<TransactionTemplateResponse>(`${TEMPLATES_PATH}/${templateId}`, {
+    signal,
+  });
+  return result.data;
+}
+
+/** ``POST /api/v1/transaction-templates``. */
+export async function createTransactionTemplate(
+  body: TransactionTemplateCreate,
+  signal?: AbortSignal,
+): Promise<TransactionTemplateResponse> {
+  const result = await apiFetch<TransactionTemplateResponse>(TEMPLATES_PATH, {
+    method: "POST",
+    signal,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return result.data;
+}
+
+/** ``PUT /api/v1/transaction-templates/{template_id}``. */
+export async function updateTransactionTemplate(
+  templateId: string,
+  body: TransactionTemplateUpdate,
+  signal?: AbortSignal,
+): Promise<TransactionTemplateResponse> {
+  const result = await apiFetch<TransactionTemplateResponse>(`${TEMPLATES_PATH}/${templateId}`, {
+    method: "PUT",
+    signal,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return result.data;
+}
+
+/** ``DELETE /api/v1/transaction-templates/{template_id}`` — soft-delete (204). */
+export async function deleteTransactionTemplate(
+  templateId: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  await apiFetch<undefined>(`${TEMPLATES_PATH}/${templateId}`, {
+    method: "DELETE",
+    signal,
+  });
+}
+
+/** ``POST /api/v1/transaction-templates/{template_id}/mark-paid``. */
+export async function markTemplatePaid(
+  templateId: string,
+  body: MarkPaidRequest = {},
+  signal?: AbortSignal,
+): Promise<TransactionResponse> {
+  const result = await apiFetch<TransactionResponse>(`${TEMPLATES_PATH}/${templateId}/mark-paid`, {
+    method: "POST",
+    signal,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return result.data;
+}
+
+/** ``POST /api/v1/transaction-templates/{template_id}/clear-paid``. */
+export async function clearTemplatePaid(
+  templateId: string,
+  body: ClearPaidRequest = {},
+  signal?: AbortSignal,
+): Promise<TransactionResponse> {
+  const result = await apiFetch<TransactionResponse>(`${TEMPLATES_PATH}/${templateId}/clear-paid`, {
+    method: "POST",
+    signal,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return result.data;
+}

--- a/modules/web/src/components/layout/AppLayout.test.tsx
+++ b/modules/web/src/components/layout/AppLayout.test.tsx
@@ -37,6 +37,21 @@ vi.mock("@/api/movements", () => ({
   cancelMovement: vi.fn(),
 }));
 
+vi.mock("@/api/transactionTemplates", () => ({
+  listTransactionTemplates: vi.fn(async () => ({ items: [], total: 0, skip: 0, limit: 100 })),
+  listUpcomingDues: vi.fn(async () => ({
+    items: [],
+    as_of: "2026-08-10",
+    window_days: 14,
+  })),
+  getTransactionTemplate: vi.fn(),
+  createTransactionTemplate: vi.fn(),
+  updateTransactionTemplate: vi.fn(),
+  deleteTransactionTemplate: vi.fn(),
+  markTemplatePaid: vi.fn(),
+  clearTemplatePaid: vi.fn(),
+}));
+
 vi.mock("@/api/health", () => ({
   getHealth: vi.fn(async () => ({
     status: "healthy",

--- a/modules/web/src/components/layout/navItems.ts
+++ b/modules/web/src/components/layout/navItems.ts
@@ -3,12 +3,13 @@ export type AppNavItem = {
   label: string;
 };
 
-/** Primary authenticated navigation (accounts/categories: PPT-052; txns/movements: PPT-053). */
+/** Primary authenticated navigation (accounts/categories: PPT-052; txns/movements: PPT-053; dues: PPT-074). */
 export const APP_NAV_ITEMS: readonly AppNavItem[] = [
   { to: "/dashboard", label: "Dashboard" },
   { to: "/accounts", label: "Accounts" },
   { to: "/categories", label: "Categories" },
   { to: "/transactions", label: "Transactions" },
+  { to: "/payment-dues", label: "Payment dues" },
   { to: "/movements", label: "Movements" },
   { to: "/reports", label: "Reports" },
 ] as const;

--- a/modules/web/src/components/paymentDues/PaymentDueFormDialog.tsx
+++ b/modules/web/src/components/paymentDues/PaymentDueFormDialog.tsx
@@ -1,0 +1,327 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState, type FormEvent } from "react";
+import { toast } from "sonner";
+
+import { invalidateAfterTemplateWrite } from "@/api/invalidateLedger";
+import { accountsListQueryOptions, categoriesListQueryOptions } from "@/api/queries";
+import { createTransactionTemplate, updateTransactionTemplate } from "@/api/transactionTemplates";
+import {
+  emptyPaymentDueFormState,
+  paymentDueFormFromResponse,
+  toTransactionTemplateCreate,
+  toTransactionTemplateUpdate,
+  type PaymentDueFormState,
+  type PaymentDueSchedule,
+} from "@/components/paymentDues/paymentDueFormState";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { NativeSelect } from "@/components/ui/native-select";
+import { formatApiError } from "@/lib/formatApiError";
+import type { TransactionTemplateResponse } from "@/types/domain";
+
+const PICKER_PARAMS = { limit: 100, skip: 0 } as const;
+
+type PaymentDueFormDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "create" | "edit";
+  template?: TransactionTemplateResponse | null;
+};
+
+type PaymentDueFormBodyProps = {
+  mode: "create" | "edit";
+  template?: TransactionTemplateResponse | null;
+  onOpenChange: (open: boolean) => void;
+};
+
+function PaymentDueFormBody({ mode, template, onOpenChange }: PaymentDueFormBodyProps) {
+  const queryClient = useQueryClient();
+  const accountsQuery = useQuery(accountsListQueryOptions(PICKER_PARAMS));
+  const categoriesQuery = useQuery(categoriesListQueryOptions(PICKER_PARAMS));
+  const [form, setForm] = useState<PaymentDueFormState>(() =>
+    mode === "edit" && template ? paymentDueFormFromResponse(template) : emptyPaymentDueFormState(),
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (mode === "create") {
+        return createTransactionTemplate(toTransactionTemplateCreate(form));
+      }
+      if (!template) {
+        throw new Error("Missing payment due");
+      }
+      return updateTransactionTemplate(template.id, toTransactionTemplateUpdate(form));
+    },
+    onSuccess: async (saved) => {
+      await invalidateAfterTemplateWrite(queryClient, { templateId: saved.id });
+      toast.success(mode === "create" ? "Payment due created" : "Payment due updated");
+      onOpenChange(false);
+    },
+    onError: (err: unknown) => {
+      setError(formatApiError(err));
+      toast.error(formatApiError(err));
+    },
+  });
+
+  function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    try {
+      if (mode === "create") {
+        toTransactionTemplateCreate(form);
+      } else {
+        toTransactionTemplateUpdate(form);
+      }
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Invalid form");
+      return;
+    }
+    mutation.mutate();
+  }
+
+  function patch(partial: Partial<PaymentDueFormState>) {
+    setForm((prev) => ({ ...prev, ...partial }));
+  }
+
+  const idPrefix = mode === "create" ? "due-create" : "due-edit";
+  const accounts = accountsQuery.data?.items ?? [];
+  const categories = categoriesQuery.data?.items ?? [];
+
+  return (
+    <form className="space-y-4" onSubmit={onSubmit}>
+      <div className="space-y-2">
+        <Label htmlFor={`${idPrefix}-name`}>Name</Label>
+        <Input
+          id={`${idPrefix}-name`}
+          value={form.name}
+          onChange={(event) => {
+            patch({ name: event.target.value });
+          }}
+          placeholder="Rent, credit card, utilities…"
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`${idPrefix}-description`}>Description</Label>
+        <Input
+          id={`${idPrefix}-description`}
+          value={form.description}
+          onChange={(event) => {
+            patch({ description: event.target.value });
+          }}
+        />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor={`${idPrefix}-category`}>Category</Label>
+          <NativeSelect
+            id={`${idPrefix}-category`}
+            value={form.category_id}
+            onChange={(event) => {
+              patch({ category_id: event.target.value });
+            }}
+            required
+          >
+            <option value="">Select category</option>
+            {categories.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </NativeSelect>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`${idPrefix}-from-account`}>Pay from (optional)</Label>
+          <NativeSelect
+            id={`${idPrefix}-from-account`}
+            value={form.from_account_id}
+            onChange={(event) => {
+              patch({ from_account_id: event.target.value });
+            }}
+          >
+            <option value="">Not set</option>
+            {accounts.map((account) => (
+              <option key={account.id} value={account.id}>
+                {account.name}
+              </option>
+            ))}
+          </NativeSelect>
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor={`${idPrefix}-amount`}>Planned amount</Label>
+          <Input
+            id={`${idPrefix}-amount`}
+            inputMode="decimal"
+            value={form.planned_amount}
+            onChange={(event) => {
+              patch({ planned_amount: event.target.value });
+            }}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`${idPrefix}-schedule`}>Schedule</Label>
+          <NativeSelect
+            id={`${idPrefix}-schedule`}
+            value={form.schedule}
+            onChange={(event) => {
+              patch({ schedule: event.target.value as PaymentDueSchedule });
+            }}
+          >
+            <option value="recurring">Recurring monthly</option>
+            <option value="one_off">One-off deadline</option>
+          </NativeSelect>
+        </div>
+      </div>
+
+      {form.schedule === "recurring" ? (
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor={`${idPrefix}-planned-day`}>Day of month</Label>
+            <Input
+              id={`${idPrefix}-planned-day`}
+              inputMode="numeric"
+              value={form.planned_day}
+              onChange={(event) => {
+                patch({ planned_day: event.target.value });
+              }}
+              disabled={form.use_month_end}
+              required={!form.use_month_end}
+            />
+          </div>
+          <div className="flex items-end gap-2 pb-2">
+            <input
+              id={`${idPrefix}-month-end`}
+              type="checkbox"
+              checked={form.use_month_end}
+              onChange={(event) => {
+                patch({ use_month_end: event.target.checked });
+              }}
+            />
+            <Label htmlFor={`${idPrefix}-month-end`}>Use month end</Label>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <Label htmlFor={`${idPrefix}-due-date`}>Due date</Label>
+          <Input
+            id={`${idPrefix}-due-date`}
+            type="date"
+            value={form.due_date}
+            onChange={(event) => {
+              patch({ due_date: event.target.value });
+            }}
+            required
+          />
+        </div>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor={`${idPrefix}-remind`}>Remind days before</Label>
+          <Input
+            id={`${idPrefix}-remind`}
+            inputMode="numeric"
+            value={form.remind_days_before}
+            onChange={(event) => {
+              patch({ remind_days_before: event.target.value });
+            }}
+            placeholder="Optional"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`${idPrefix}-tags`}>Tags</Label>
+          <Input
+            id={`${idPrefix}-tags`}
+            value={form.tags}
+            onChange={(event) => {
+              patch({ tags: event.target.value });
+            }}
+            placeholder="comma, separated"
+          />
+        </div>
+      </div>
+
+      {mode === "edit" ? (
+        <div className="flex items-center gap-2">
+          <input
+            id={`${idPrefix}-active`}
+            type="checkbox"
+            checked={form.is_active}
+            onChange={(event) => {
+              patch({ is_active: event.target.checked });
+            }}
+          />
+          <Label htmlFor={`${idPrefix}-active`}>Active</Label>
+        </div>
+      ) : null}
+
+      {error ? (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => {
+            onOpenChange(false);
+          }}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={mutation.isPending}>
+          {mutation.isPending ? "Saving…" : "Save"}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+export function PaymentDueFormDialog({
+  open,
+  onOpenChange,
+  mode,
+  template,
+}: PaymentDueFormDialogProps) {
+  const formKey = mode === "edit" ? (template?.id ?? "edit") : "create";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{mode === "create" ? "New payment due" : "Edit payment due"}</DialogTitle>
+          <DialogDescription>
+            Recurring bills and one-off deadlines. Due dates and mark-paid live in the API — this
+            screen only collects the fields.
+          </DialogDescription>
+        </DialogHeader>
+        {open ? (
+          <PaymentDueFormBody
+            key={formKey}
+            mode={mode}
+            template={template}
+            onOpenChange={onOpenChange}
+          />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/modules/web/src/components/paymentDues/paymentDueFormState.test.ts
+++ b/modules/web/src/components/paymentDues/paymentDueFormState.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  emptyPaymentDueFormState,
+  toTransactionTemplateCreate,
+  toTransactionTemplateUpdate,
+} from "@/components/paymentDues/paymentDueFormState";
+
+const CATEGORY_ID = "11111111-1111-1111-1111-111111111111";
+const ACCOUNT_ID = "22222222-2222-2222-2222-222222222222";
+
+describe("paymentDueFormState", () => {
+  it("maps recurring form to create payload", () => {
+    const create = toTransactionTemplateCreate(
+      emptyPaymentDueFormState({
+        name: " Rent ",
+        category_id: CATEGORY_ID,
+        from_account_id: ACCOUNT_ID,
+        planned_amount: "1200.5",
+        schedule: "recurring",
+        planned_day: "15",
+        use_month_end: false,
+        remind_days_before: "3",
+        tags: "housing, bills",
+      }),
+    );
+
+    expect(create).toEqual({
+      name: "Rent",
+      description: "",
+      category_id: CATEGORY_ID,
+      planned_amount: 1200.5,
+      planned_day: 15,
+      use_month_end: false,
+      due_date: null,
+      from_account_id: ACCOUNT_ID,
+      remind_days_before: 3,
+      tags: ["housing", "bills"],
+    });
+  });
+
+  it("maps one-off form using due date day for planned_day", () => {
+    const create = toTransactionTemplateCreate(
+      emptyPaymentDueFormState({
+        name: "Passport renewal",
+        category_id: CATEGORY_ID,
+        planned_amount: "160",
+        schedule: "one_off",
+        due_date: "2026-09-20",
+        remind_days_before: "",
+      }),
+    );
+
+    expect(create.due_date).toBe("2026-09-20");
+    expect(create.planned_day).toBe(20);
+    expect(create.use_month_end).toBe(false);
+    expect(create.remind_days_before).toBeNull();
+  });
+
+  it("includes is_active on update", () => {
+    const update = toTransactionTemplateUpdate(
+      emptyPaymentDueFormState({
+        name: "Utilities",
+        category_id: CATEGORY_ID,
+        planned_amount: "80",
+        schedule: "recurring",
+        planned_day: "1",
+        is_active: false,
+      }),
+    );
+
+    expect(update.is_active).toBe(false);
+    expect(update.name).toBe("Utilities");
+  });
+
+  it("rejects missing category", () => {
+    expect(() =>
+      toTransactionTemplateCreate(
+        emptyPaymentDueFormState({
+          name: "Bill",
+          planned_amount: "10",
+        }),
+      ),
+    ).toThrow("Category is required");
+  });
+});

--- a/modules/web/src/components/paymentDues/paymentDueFormState.ts
+++ b/modules/web/src/components/paymentDues/paymentDueFormState.ts
@@ -1,0 +1,179 @@
+import type {
+  TransactionTemplateCreate,
+  TransactionTemplateResponse,
+  TransactionTemplateUpdate,
+} from "@/types/domain";
+
+export type PaymentDueSchedule = "recurring" | "one_off";
+
+export type PaymentDueFormState = {
+  name: string;
+  description: string;
+  category_id: string;
+  from_account_id: string;
+  planned_amount: string;
+  schedule: PaymentDueSchedule;
+  planned_day: string;
+  use_month_end: boolean;
+  due_date: string;
+  remind_days_before: string;
+  tags: string;
+  is_active: boolean;
+};
+
+function todayDateInput(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function emptyPaymentDueFormState(
+  overrides: Partial<PaymentDueFormState> = {},
+): PaymentDueFormState {
+  return {
+    name: "",
+    description: "",
+    category_id: "",
+    from_account_id: "",
+    planned_amount: "",
+    schedule: "recurring",
+    planned_day: "1",
+    use_month_end: false,
+    due_date: todayDateInput(),
+    remind_days_before: "3",
+    tags: "",
+    is_active: true,
+    ...overrides,
+  };
+}
+
+export function paymentDueFormFromResponse(
+  template: TransactionTemplateResponse,
+): PaymentDueFormState {
+  const isOneOff = Boolean(template.due_date);
+  return emptyPaymentDueFormState({
+    name: template.name,
+    description: template.description ?? "",
+    category_id: template.category_id,
+    from_account_id: template.from_account_id ?? "",
+    planned_amount: String(template.planned_amount),
+    schedule: isOneOff ? "one_off" : "recurring",
+    planned_day: String(template.planned_day),
+    use_month_end: Boolean(template.use_month_end),
+    due_date: template.due_date ?? todayDateInput(),
+    remind_days_before:
+      template.remind_days_before === null || template.remind_days_before === undefined
+        ? ""
+        : String(template.remind_days_before),
+    tags: (template.tags ?? []).join(", "),
+    is_active: Boolean(template.is_active),
+  });
+}
+
+function parseRequiredAmount(value: string): number {
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    throw new Error("Amount is required");
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error("Amount must be a positive number");
+  }
+  return parsed;
+}
+
+function parsePlannedDay(value: string): number {
+  const parsed = Number(value.trim());
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 31) {
+    throw new Error("Planned day must be an integer from 1 to 31");
+  }
+  return parsed;
+}
+
+function parseOptionalRemindDays(value: string): number | null | undefined {
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return null;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error("Remind days before must be zero or a positive integer");
+  }
+  return parsed;
+}
+
+function parseTags(value: string): string[] {
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+function dayFromDateInput(value: string): number {
+  const day = Number(value.slice(8, 10));
+  if (!Number.isInteger(day) || day < 1 || day > 31) {
+    throw new Error("Due date is required for one-off dues");
+  }
+  return day;
+}
+
+/** Map form state → OpenAPI ``TransactionTemplateCreate``. */
+export function toTransactionTemplateCreate(state: PaymentDueFormState): TransactionTemplateCreate {
+  if (!state.name.trim()) {
+    throw new Error("Name is required");
+  }
+  if (!state.category_id) {
+    throw new Error("Category is required");
+  }
+
+  const remind = parseOptionalRemindDays(state.remind_days_before);
+  const create: TransactionTemplateCreate = {
+    name: state.name.trim(),
+    description: state.description.trim(),
+    category_id: state.category_id,
+    planned_amount: parseRequiredAmount(state.planned_amount),
+    planned_day:
+      state.schedule === "one_off"
+        ? dayFromDateInput(state.due_date)
+        : parsePlannedDay(state.planned_day),
+    use_month_end: state.schedule === "recurring" ? state.use_month_end : false,
+    tags: parseTags(state.tags),
+  };
+
+  if (state.schedule === "one_off") {
+    if (!state.due_date.trim()) {
+      throw new Error("Due date is required for one-off dues");
+    }
+    create.due_date = state.due_date.trim();
+  } else {
+    create.due_date = null;
+  }
+
+  if (state.from_account_id) {
+    create.from_account_id = state.from_account_id;
+  } else {
+    create.from_account_id = null;
+  }
+
+  if (remind !== undefined) {
+    create.remind_days_before = remind;
+  }
+
+  return create;
+}
+
+/** Map form state → OpenAPI ``TransactionTemplateUpdate``. */
+export function toTransactionTemplateUpdate(state: PaymentDueFormState): TransactionTemplateUpdate {
+  const create = toTransactionTemplateCreate(state);
+  return {
+    name: create.name,
+    description: create.description,
+    category_id: create.category_id,
+    planned_amount: create.planned_amount,
+    planned_day: create.planned_day,
+    use_month_end: create.use_month_end,
+    due_date: create.due_date ?? null,
+    remind_days_before: create.remind_days_before ?? null,
+    from_account_id: create.from_account_id ?? null,
+    tags: create.tags ?? [],
+    is_active: state.is_active,
+  };
+}

--- a/modules/web/src/pages/DashboardPage.tsx
+++ b/modules/web/src/pages/DashboardPage.tsx
@@ -1,31 +1,60 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
+import { toast } from "sonner";
 
-import { accountsListQueryOptions, movementsListQueryOptions } from "@/api/queries";
+import { invalidateAfterTemplateWrite } from "@/api/invalidateLedger";
+import {
+  accountsListQueryOptions,
+  movementsListQueryOptions,
+  upcomingDuesQueryOptions,
+} from "@/api/queries";
+import { markTemplatePaid } from "@/api/transactionTemplates";
 import { bffSessionQueryOptions } from "@/auth/sessionQueries";
 import { APP_NAV_ITEMS } from "@/components/layout/navItems";
 import { Button } from "@/components/ui/button";
+import { formatApiError } from "@/lib/formatApiError";
 import { formatDate } from "@/lib/formatDate";
 import { formatMoney } from "@/lib/formatMoney";
 import { formatRemainingDuration, secondsUntil } from "@/lib/formatRemainingDuration";
-import type { AccountResponse, MovementResponse } from "@/types/domain";
+import type { AccountResponse, MovementResponse, UpcomingDueResponse } from "@/types/domain";
 
 const QUICK_LINKS = APP_NAV_ITEMS.filter((item) => item.to !== "/dashboard");
 const SNAPSHOT_PARAMS = { limit: 5, skip: 0 } as const;
 const PENDING_PARAMS = { ...SNAPSHOT_PARAMS, status: "pending" } as const;
+const DUE_SOON_PARAMS = { window_days: 14, include_paid: false } as const;
+const DUE_SOON_LIMIT = 5;
 
 /** Authenticated landing with session TTL, ledger snapshots, and quick links. */
 export function DashboardPage() {
+  const queryClient = useQueryClient();
   const sessionQuery = useQuery(bffSessionQueryOptions());
   const accountsQuery = useQuery(accountsListQueryOptions(SNAPSHOT_PARAMS));
   const pendingQuery = useQuery(movementsListQueryOptions(PENDING_PARAMS));
+  const duesQuery = useQuery(upcomingDuesQueryOptions(DUE_SOON_PARAMS));
+
+  const markPaidMutation = useMutation({
+    mutationFn: (templateId: string) => markTemplatePaid(templateId),
+    onSuccess: async (txn, templateId) => {
+      await invalidateAfterTemplateWrite(queryClient, {
+        templateId,
+        markPaid: true,
+        transactionId: txn.id,
+      });
+      toast.success("Marked paid");
+    },
+    onError: (err: unknown) => {
+      toast.error(formatApiError(err));
+    },
+  });
 
   const user = sessionQuery.data?.user;
   const greetingName =
     user?.display_name?.trim() || user?.username?.trim() || user?.email?.split("@")[0] || null;
   const accounts = accountsQuery.data?.items ?? [];
   const pendingMovements = pendingQuery.data?.items ?? [];
+  const dueSoonAll = duesQuery.data?.items ?? [];
+  const dueSoon = dueSoonAll.slice(0, DUE_SOON_LIMIT);
   const accountsTotal = accountsQuery.data?.total ?? accounts.length;
   const pendingTotal = pendingQuery.data?.total ?? pendingMovements.length;
 
@@ -36,7 +65,7 @@ export function DashboardPage() {
           {greetingName ? `Welcome back, ${greetingName}` : "Dashboard"}
         </h1>
         <p className="text-sm text-muted-foreground">
-          Session status, account balances, and pending transfers — then jump into the ledger.
+          Session status, balances, due soon, and pending transfers — then jump into the ledger.
         </p>
       </div>
 
@@ -93,6 +122,37 @@ export function DashboardPage() {
           </ul>
         </SnapshotPanel>
       </div>
+
+      <SnapshotPanel
+        title="Due soon"
+        viewAllTo="/payment-dues"
+        isPending={duesQuery.isPending}
+        isError={duesQuery.isError}
+        itemCount={dueSoon.length}
+        emptyLabel="Nothing due in the next 14 days"
+        emptyActionTo="/payment-dues"
+        emptyActionLabel="Add a payment due"
+        footer={
+          dueSoonAll.length > dueSoon.length
+            ? `Showing ${String(dueSoon.length)} of ${String(dueSoonAll.length)}`
+            : dueSoonAll.length > 0
+              ? `${String(dueSoonAll.length)} in the next ${String(DUE_SOON_PARAMS.window_days)} days`
+              : null
+        }
+      >
+        <ul className="divide-y divide-border">
+          {dueSoon.map((due) => (
+            <DueSoonRow
+              key={`${due.template.id}-${due.due_date}`}
+              due={due}
+              markPaidPending={markPaidMutation.isPending}
+              onMarkPaid={() => {
+                markPaidMutation.mutate(due.template.id);
+              }}
+            />
+          ))}
+        </ul>
+      </SnapshotPanel>
 
       <section aria-label="Quick links" className="grid gap-3 sm:grid-cols-2">
         {QUICK_LINKS.map((item) => (
@@ -247,6 +307,44 @@ function PendingMovementRow({ movement }: { movement: MovementResponse }) {
   );
 }
 
+function DueSoonRow({
+  due,
+  markPaidPending,
+  onMarkPaid,
+}: {
+  due: UpcomingDueResponse;
+  markPaidPending: boolean;
+  onMarkPaid: () => void;
+}) {
+  return (
+    <li className="space-y-1 py-2 text-sm">
+      <div className="flex items-baseline justify-between gap-3">
+        <Link
+          to="/payment-dues"
+          className="truncate font-medium text-primary underline-offset-4 hover:underline"
+        >
+          {due.template.name}
+        </Link>
+        <span className="shrink-0 tabular-nums text-muted-foreground">
+          {formatMoney(due.template.planned_amount, "USD")}
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-xs text-muted-foreground">Due {formatDate(due.due_date)}</p>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={markPaidPending || due.is_paid}
+          onClick={onMarkPaid}
+        >
+          {due.is_paid ? "Paid" : "Mark paid"}
+        </Button>
+      </div>
+    </li>
+  );
+}
+
 function quickLinkHint(path: string): string {
   switch (path) {
     case "/accounts":
@@ -255,6 +353,8 @@ function quickLinkHint(path: string): string {
       return "Income and expense labels";
     case "/transactions":
       return "Income and expenses";
+    case "/payment-dues":
+      return "Bills and payment deadlines";
     case "/movements":
       return "Transfers between accounts";
     case "/reports":

--- a/modules/web/src/pages/PaymentDuesPage.tsx
+++ b/modules/web/src/pages/PaymentDuesPage.tsx
@@ -1,0 +1,290 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { invalidateAfterTemplateWrite } from "@/api/invalidateLedger";
+import { transactionTemplatesListQueryOptions } from "@/api/queries";
+import {
+  clearTemplatePaid,
+  deleteTransactionTemplate,
+  markTemplatePaid,
+} from "@/api/transactionTemplates";
+import { PaymentDueFormDialog } from "@/components/paymentDues/PaymentDueFormDialog";
+import { QueryState } from "@/components/QueryState";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatApiError } from "@/lib/formatApiError";
+import { formatDate } from "@/lib/formatDate";
+import { formatMoney } from "@/lib/formatMoney";
+import type { TransactionTemplateResponse } from "@/types/domain";
+
+/** First-page list window (pagination UI deferred). */
+const LIST_PARAMS = { limit: 100, skip: 0, is_active: true } as const;
+
+function scheduleLabel(template: TransactionTemplateResponse): string {
+  if (template.due_date) {
+    return `One-off · ${formatDate(template.due_date)}`;
+  }
+  if (template.use_month_end) {
+    return "Monthly · month end";
+  }
+  return `Monthly · day ${String(template.planned_day)}`;
+}
+
+export function PaymentDuesPage() {
+  const queryClient = useQueryClient();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<TransactionTemplateResponse | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<TransactionTemplateResponse | null>(null);
+
+  const listQuery = useQuery(transactionTemplatesListQueryOptions(LIST_PARAMS));
+  const items = listQuery.data?.items ?? [];
+
+  const markPaidMutation = useMutation({
+    mutationFn: (templateId: string) => markTemplatePaid(templateId),
+    onSuccess: async (txn, templateId) => {
+      await invalidateAfterTemplateWrite(queryClient, {
+        templateId,
+        markPaid: true,
+        transactionId: txn.id,
+      });
+      toast.success("Marked paid");
+    },
+    onError: (err: unknown) => {
+      toast.error(formatApiError(err));
+    },
+  });
+
+  const clearPaidMutation = useMutation({
+    mutationFn: (templateId: string) => clearTemplatePaid(templateId),
+    onSuccess: async (_txn, templateId) => {
+      await invalidateAfterTemplateWrite(queryClient, {
+        templateId,
+        markPaid: true,
+      });
+      toast.success("Cleared paid status");
+    },
+    onError: (err: unknown) => {
+      toast.error(formatApiError(err));
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (templateId: string) => deleteTransactionTemplate(templateId),
+    onSuccess: async (_void, templateId) => {
+      await invalidateAfterTemplateWrite(queryClient, { removeTemplateId: templateId });
+      toast.success("Payment due deleted");
+      setDeleteTarget(null);
+    },
+    onError: (err: unknown) => {
+      toast.error(formatApiError(err));
+    },
+  });
+
+  const actionPending =
+    markPaidMutation.isPending || clearPaidMutation.isPending || deleteMutation.isPending;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">Payment dues</h1>
+          <p className="text-sm text-muted-foreground">
+            Recurring bills and one-off deadlines — when something must be paid, not account
+            balances.
+          </p>
+        </div>
+        <Button
+          type="button"
+          onClick={() => {
+            setCreateOpen(true);
+          }}
+        >
+          New payment due
+        </Button>
+      </div>
+
+      <QueryState
+        isPending={listQuery.isPending}
+        isError={listQuery.isError}
+        error={listQuery.error}
+        isEmpty={!listQuery.isPending && !listQuery.isError && items.length === 0}
+        emptyTitle="No payment dues yet"
+        emptyDescription="Add a recurring bill or one-off deadline to see it under Due soon."
+        emptyAction={
+          <Button
+            type="button"
+            onClick={() => {
+              setCreateOpen(true);
+            }}
+          >
+            Create your first payment due
+          </Button>
+        }
+        onRetry={() => {
+          void listQuery.refetch();
+        }}
+      >
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Schedule</TableHead>
+              <TableHead className="text-right">Amount</TableHead>
+              <TableHead>Remind</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.map((template) => (
+              <TableRow key={template.id}>
+                <TableCell>
+                  <div className="space-y-0.5">
+                    <p className="font-medium">{template.name}</p>
+                    {template.description.trim() ? (
+                      <p className="text-xs text-muted-foreground">{template.description}</p>
+                    ) : null}
+                  </div>
+                </TableCell>
+                <TableCell className="text-muted-foreground">{scheduleLabel(template)}</TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {formatMoney(template.planned_amount, "USD")}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {template.remind_days_before === null || template.remind_days_before === undefined
+                    ? "—"
+                    : `${String(template.remind_days_before)}d`}
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex flex-wrap justify-end gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={actionPending}
+                      onClick={() => {
+                        markPaidMutation.mutate(template.id);
+                      }}
+                    >
+                      Mark paid
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      disabled={actionPending}
+                      onClick={() => {
+                        clearPaidMutation.mutate(template.id);
+                      }}
+                    >
+                      Clear paid
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      disabled={actionPending}
+                      onClick={() => {
+                        setEditTarget(template);
+                      }}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      disabled={actionPending}
+                      onClick={() => {
+                        setDeleteTarget(template);
+                      }}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        {listQuery.data ? (
+          <p className="text-xs text-muted-foreground">
+            Showing {items.length} of {listQuery.data.total}
+            {listQuery.data.total > LIST_PARAMS.limit
+              ? ` (first ${String(LIST_PARAMS.limit)} only)`
+              : ""}
+          </p>
+        ) : null}
+      </QueryState>
+
+      <PaymentDueFormDialog open={createOpen} onOpenChange={setCreateOpen} mode="create" />
+      <PaymentDueFormDialog
+        open={editTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditTarget(null);
+          }
+        }}
+        mode="edit"
+        template={editTarget}
+      />
+
+      <Dialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteTarget(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete payment due?</DialogTitle>
+            <DialogDescription>
+              Soft-deletes “{deleteTarget?.name ?? "this due"}”. You can recreate it later if
+              needed.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setDeleteTarget(null);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={deleteMutation.isPending || !deleteTarget}
+              onClick={() => {
+                if (deleteTarget) {
+                  deleteMutation.mutate(deleteTarget.id);
+                }
+              }}
+            >
+              {deleteMutation.isPending ? "Deleting…" : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/modules/web/src/types/api.d.ts
+++ b/modules/web/src/types/api.d.ts
@@ -1486,6 +1486,154 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/transaction-templates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Transaction Templates
+         * @description List tenant transaction templates with optional filters.
+         *
+         *     Args:
+         *         owner: Authenticated tenant from JWT.
+         *         pagination: Skip/limit window for the response page.
+         *         templates_service: Injected templates service.
+         *         category_id: Optional category filter.
+         *         is_active: Optional soft-active filter.
+         *
+         *     Returns:
+         *         Paginated ``TransactionTemplateResponse`` items owned by ``owner``.
+         */
+        get: operations["list_transaction_templates_api_v1_transaction_templates_get"];
+        put?: never;
+        /**
+         * Create Transaction Template
+         * @description Create a tenant-owned transaction template.
+         */
+        post: operations["create_transaction_template_api_v1_transaction_templates_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/transaction-templates/upcoming-dues": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Upcoming Dues
+         * @description List owner-scoped templates with a due in the upcoming reminder window.
+         *
+         *     Args:
+         *         owner: Authenticated tenant from JWT.
+         *         templates_service: Injected templates service.
+         *         filters: ``as_of`` / ``window_days`` / ``include_paid`` query bundle.
+         *
+         *     Returns:
+         *         Upcoming dues sorted by the model service (due date, then name/id).
+         *
+         *     Raises:
+         *         HTTPException: 422 when ``window_days`` is rejected by the service.
+         */
+        get: operations["list_upcoming_dues_api_v1_transaction_templates_upcoming_dues_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/transaction-templates/{template_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Transaction Template
+         * @description Retrieve a tenant-owned transaction template by id.
+         *
+         *     Raises:
+         *         HTTPException: 404 when missing or not owned by ``owner``.
+         */
+        get: operations["get_transaction_template_api_v1_transaction_templates__template_id__get"];
+        /**
+         * Update Transaction Template
+         * @description Update a tenant-owned transaction template.
+         *
+         *     Raises:
+         *         HTTPException: 404 when missing or not owned by ``owner``.
+         */
+        put: operations["update_transaction_template_api_v1_transaction_templates__template_id__put"];
+        post?: never;
+        /**
+         * Delete Transaction Template
+         * @description Soft-delete a tenant-owned transaction template.
+         *
+         *     Raises:
+         *         HTTPException: 404 when missing or not owned by ``owner``.
+         */
+        delete: operations["delete_transaction_template_api_v1_transaction_templates__template_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/transaction-templates/{template_id}/clear-paid": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Clear Template Paid
+         * @description Soft-delete the linked posting for the template due period.
+         *
+         *     Raises:
+         *         HTTPException: 404 / 409 / 422 from mapped service ValueErrors.
+         */
+        post: operations["clear_template_paid_api_v1_transaction_templates__template_id__clear_paid_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/transaction-templates/{template_id}/mark-paid": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mark Template Paid
+         * @description Post a linked EXPENSE/INCOME for the template due (mark paid).
+         *
+         *     Raises:
+         *         HTTPException: 404 / 409 / 422 from mapped service ValueErrors.
+         */
+        post: operations["mark_template_paid_api_v1_transaction_templates__template_id__mark_paid_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/transactions": {
         parameters: {
             query?: never;
@@ -2204,6 +2352,14 @@ export interface components {
             parent_id?: string | null;
         };
         /**
+         * ClearPaidRequest
+         * @description Optional body for ``POST …/clear-paid``.
+         */
+        ClearPaidRequest: {
+            /** As Of */
+            as_of?: string | null;
+        };
+        /**
          * CreditCardDetailsSchema
          * @description Credit card extension fields.
          *
@@ -2392,6 +2548,18 @@ export interface components {
             access_token?: string | null;
             /** Refresh Token */
             refresh_token: string;
+        };
+        /**
+         * MarkPaidRequest
+         * @description Optional body for ``POST …/mark-paid``.
+         */
+        MarkPaidRequest: {
+            /** Amount */
+            amount?: number | null;
+            /** As Of */
+            as_of?: string | null;
+            /** Transaction Ts */
+            transaction_ts?: string | null;
         };
         /**
          * MonthlyTrendItem
@@ -2610,6 +2778,17 @@ export interface components {
         PaginatedResponse_TransactionResponse_: {
             /** Items */
             items?: components["schemas"]["TransactionResponse"][];
+            /** Limit */
+            limit: number;
+            /** Skip */
+            skip: number;
+            /** Total */
+            total: number;
+        };
+        /** PaginatedResponse[TransactionTemplateResponse] */
+        PaginatedResponse_TransactionTemplateResponse_: {
+            /** Items */
+            items?: components["schemas"]["TransactionTemplateResponse"][];
             /** Limit */
             limit: number;
             /** Skip */
@@ -3083,6 +3262,109 @@ export interface components {
             updated_at?: string | null;
         };
         /**
+         * TransactionTemplateCreate
+         * @description Request body for ``POST /transaction-templates``.
+         */
+        TransactionTemplateCreate: {
+            /**
+             * Category Id
+             * Format: uuid
+             */
+            category_id: string;
+            /**
+             * Description
+             * @default
+             */
+            description: string;
+            /** Due Date */
+            due_date?: string | null;
+            /** From Account Id */
+            from_account_id?: string | null;
+            /** Name */
+            name: string;
+            /** Planned Amount */
+            planned_amount: number;
+            /** Planned Day */
+            planned_day: number;
+            /** Remind Days Before */
+            remind_days_before?: number | null;
+            /** Tags */
+            tags?: string[];
+            /**
+             * Use Month End
+             * @default false
+             */
+            use_month_end: boolean;
+        };
+        /**
+         * TransactionTemplateResponse
+         * @description Transaction-template resource returned by CRUD endpoints.
+         */
+        TransactionTemplateResponse: {
+            /**
+             * Category Id
+             * Format: uuid
+             */
+            category_id: string;
+            /** Created At */
+            created_at?: string | null;
+            /** Description */
+            description: string;
+            /** Due Date */
+            due_date?: string | null;
+            /** From Account Id */
+            from_account_id?: string | null;
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Is Active */
+            is_active: boolean;
+            /** Name */
+            name: string;
+            /** Planned Amount */
+            planned_amount: number;
+            /** Planned Day */
+            planned_day: number;
+            /** Remind Days Before */
+            remind_days_before?: number | null;
+            /** Tags */
+            tags?: string[];
+            /** Updated At */
+            updated_at?: string | null;
+            /** Use Month End */
+            use_month_end: boolean;
+        };
+        /**
+         * TransactionTemplateUpdate
+         * @description Partial update body for ``PUT /transaction-templates/{template_id}``.
+         */
+        TransactionTemplateUpdate: {
+            /** Category Id */
+            category_id?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Due Date */
+            due_date?: string | null;
+            /** From Account Id */
+            from_account_id?: string | null;
+            /** Is Active */
+            is_active?: boolean | null;
+            /** Name */
+            name?: string | null;
+            /** Planned Amount */
+            planned_amount?: number | null;
+            /** Planned Day */
+            planned_day?: number | null;
+            /** Remind Days Before */
+            remind_days_before?: number | null;
+            /** Tags */
+            tags?: string[] | null;
+            /** Use Month End */
+            use_month_end?: boolean | null;
+        };
+        /**
          * TransactionUpdate
          * @description Request body for ``PUT /transactions/{transaction_id}``.
          */
@@ -3135,6 +3417,45 @@ export interface components {
              * @default monthly
              */
             period: string;
+        };
+        /**
+         * UpcomingDueResponse
+         * @description Single upcoming-due row for in-app reminders.
+         */
+        UpcomingDueResponse: {
+            /**
+             * Due Date
+             * Format: date
+             */
+            due_date: string;
+            /**
+             * Is Paid
+             * @default false
+             */
+            is_paid: boolean;
+            /** Paid Transaction Id */
+            paid_transaction_id?: string | null;
+            /**
+             * Remind Start
+             * Format: date
+             */
+            remind_start: string;
+            template: components["schemas"]["TransactionTemplateResponse"];
+        };
+        /**
+         * UpcomingDuesResponse
+         * @description List payload for ``GET /transaction-templates/upcoming-dues``.
+         */
+        UpcomingDuesResponse: {
+            /**
+             * As Of
+             * Format: date
+             */
+            as_of: string;
+            /** Items */
+            items?: components["schemas"]["UpcomingDueResponse"][];
+            /** Window Days */
+            window_days: number;
         };
         /**
          * UserResponse
@@ -4813,6 +5134,278 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TrendsReportResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_transaction_templates_api_v1_transaction_templates_get: {
+        parameters: {
+            query?: {
+                /** @description Filter by category */
+                category_id?: string | null;
+                /** @description Filter by active status */
+                is_active?: boolean | null;
+                /** @description Number of records to skip */
+                skip?: number;
+                /** @description Maximum records to return */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedResponse_TransactionTemplateResponse_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_transaction_template_api_v1_transaction_templates_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TransactionTemplateCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TransactionTemplateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_upcoming_dues_api_v1_transaction_templates_upcoming_dues_get: {
+        parameters: {
+            query?: {
+                /** @description Window anchor date (UTC today when omitted) */
+                as_of?: string | null;
+                /** @description Inclusive days after as_of */
+                window_days?: number;
+                /** @description Include dues already marked paid */
+                include_paid?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpcomingDuesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_transaction_template_api_v1_transaction_templates__template_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TransactionTemplateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_transaction_template_api_v1_transaction_templates__template_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TransactionTemplateUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TransactionTemplateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_transaction_template_api_v1_transaction_templates__template_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    clear_template_paid_api_v1_transaction_templates__template_id__clear_paid_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ClearPaidRequest"] | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TransactionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    mark_template_paid_api_v1_transaction_templates__template_id__mark_paid_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["MarkPaidRequest"] | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TransactionResponse"];
                 };
             };
             /** @description Validation Error */

--- a/modules/web/src/types/domain.ts
+++ b/modules/web/src/types/domain.ts
@@ -37,6 +37,16 @@ export type TransactionBulkCreate = ApiSchemas["TransactionBulkCreate"];
 export type TransactionBulkResponse = ApiSchemas["TransactionBulkResponse"];
 export type PaginatedTransactions = ApiSchemas["PaginatedResponse_TransactionResponse_"];
 
+export type TransactionTemplateCreate = ApiSchemas["TransactionTemplateCreate"];
+export type TransactionTemplateUpdate = ApiSchemas["TransactionTemplateUpdate"];
+export type TransactionTemplateResponse = ApiSchemas["TransactionTemplateResponse"];
+export type PaginatedTransactionTemplates =
+  ApiSchemas["PaginatedResponse_TransactionTemplateResponse_"];
+export type UpcomingDueResponse = ApiSchemas["UpcomingDueResponse"];
+export type UpcomingDuesResponse = ApiSchemas["UpcomingDuesResponse"];
+export type MarkPaidRequest = ApiSchemas["MarkPaidRequest"];
+export type ClearPaidRequest = ApiSchemas["ClearPaidRequest"];
+
 export type MovementCreate = ApiSchemas["MovementCreate"];
 export type MovementUpdate = ApiSchemas["MovementUpdate"];
 export type MovementResponse = ApiSchemas["MovementResponse"];


### PR DESCRIPTION
**Branch:** `feat/PPT-074` · **Base:** `main` · **1 commit** · **21 files**

**Suggested title:** `feat/PPT-074: [web] Payment dues UI and dashboard Due soon panel`

## Summary

Ship the SPA surfaces for in-app payment due reminders (PPT-074 / #167) over the closed PPT-073 transaction-templates API. Authenticated users can manage recurring and one-off payment dues and see a dashboard **Due soon** panel, using BFF cookies + TanStack Query only (no TypeScript domain logic).

## Out of scope / Highlights

**Out of scope**

- Model/API implementation (PPT-071–073; already on main)
- Full docs / OpenAPI sync gate and epic hardening (PPT-075 / #168)
- Email / push / calendar notify channels
- Epic-wide a11y polish beyond including `/payment-dues` in the existing axe route list

**Highlights**

- Committed OpenAPI artifact regenerated so web types include `/transaction-templates*`
- Dashboard Due soon (14-day window) + mark paid from the panel
- `/payment-dues` list/create/edit/delete + mark/clear paid

## Changes

**Web / OpenAPI types**

- Regenerated `openapi/openapi.json` + `api.d.ts`; domain aliases for template/dues schemas
- New `transactionTemplates` API client, query keys/options, and template cache invalidation helpers

**Web / UI**

- `/payment-dues` page and form dialog (recurring vs one-off)
- Dashboard **Due soon** SnapshotPanel with mark-paid
- Nav + route wiring

**Tests / strata**

- Unit tests for client helpers, form mapping, query keys; dashboard/layout mocks updated
- a11y e2e route list includes `/payment-dues`
- `.strata/memory/project_state.md` updated for strict-mode pairing

## File changes

<details>
<summary>File changes (~21 files)</summary>

```
 .strata/memory/project_state.md                    |   20 +-
 modules/web/e2e/a11y.spec.ts                       |    1 +
 modules/web/openapi/openapi.json                   | 3980 ++++++++++++--------
 modules/web/src/App.test.tsx                       |   42 +-
 modules/web/src/App.tsx                            |    5 +
 modules/web/src/api/index.ts                       |   17 +-
 modules/web/src/api/invalidateLedger.ts            |   45 +
 modules/web/src/api/queries.ts                     |   55 +
 modules/web/src/api/queryKeys.test.ts              |   19 +
 modules/web/src/api/queryKeys.ts                   |   12 +
 modules/web/src/api/transactionTemplates.test.ts   |   79 +
 modules/web/src/api/transactionTemplates.ts        |  161 +
 .../web/src/components/layout/AppLayout.test.tsx   |   15 +
 modules/web/src/components/layout/navItems.ts      |    3 +-
 .../paymentDues/PaymentDueFormDialog.tsx           |  327 ++
 .../paymentDues/paymentDueFormState.test.ts        |   86 +
 .../components/paymentDues/paymentDueFormState.ts  |  179 +
 modules/web/src/pages/DashboardPage.tsx            |  108 +-
 modules/web/src/pages/PaymentDuesPage.tsx          |  290 ++
 modules/web/src/types/api.d.ts                     |  593 +++
 modules/web/src/types/domain.ts                    |   10 +
 21 files changed, 4552 insertions(+), 1495 deletions(-)
```

</details>

## Commits

- `acf90ab` feat/PPT-074: [web] Payment dues UI and dashboard Due soon panel

## Checks, tests, and validation already done

- Pre-commit on commit (web eslint/prettier/tsc/vitest-related, strata validate) — pass
- `pnpm --filter @papita/web exec vitest run` (templates client, form state, queryKeys, App/Dashboard, AppLayout) — pass
- `pnpm --filter @papita/web exec tsc --noEmit` — pass
- `pnpm --filter @papita/web run lint` — pass
- GitHub Actions CI on this PR — not observed yet

## QA / test plan

- [ ] Web CI green (`pnpm web:test:coverage` / lint / `check-types` / build)
- [ ] Manual: create recurring + one-off due on `/payment-dues`; confirm Due soon on `/dashboard`
- [ ] Manual: mark paid / clear paid refreshes dues + ledger lists
- [ ] Confirm BFF session still required (no JWTs in WebStorage)

## Risks

> [!CAUTION]
>
> ### Risks
>
> - OpenAPI artifact is large/regenerated — reviewers should confirm paths for `/transaction-templates*` and that unrelated contract drift is intentional from offline export
> - Mark-paid requires a usable pay-from account when the API/model enforces `from_account_id`; UI surfaces API errors rather than inventing defaults

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - Planned amounts display with USD formatting in the SPA (templates have no currency field)
> - Formal OpenAPI/docs index close-out remains PPT-075 / #168

## Web security checklist (PPT-056 / #121)

- [x] No JWTs / access tokens in `localStorage` / `sessionStorage` (BFF HttpOnly `papita_sid` only)
- [x] Cookie flags reviewed for the touched path (`HttpOnly` / `Secure` when not DEBUG / `SameSite`) — no cookie/auth path changes in this PR
- [x] CSRF: mutations send `X-Papita-CSRF`; token stays in memory (not WebStorage) — uses existing `apiFetch`
- [x] No secrets in `VITE_*` (public bundle only); gitleaks-aware for accidental embeds
- [ ] `pnpm web:audit` considered (or Dependabot `npm-web`); no known high prod vulns left untracked — CI soft audit still applies
- [x] CSP: nginx SPA headers reviewed when touching `docker/web/**` (PPT-063 / #128; Vite `:5173` has no CSP meta) — `docker/web/**` not touched

## References

- Closes #167
- Parent epic: #163 (PPT-070)
- Depends on closed #166 (PPT-073)

Made with [Cursor](https://cursor.com)