### PR TITLE
chore(cursor): add /plan-issue skill with Architect, PM/BA, and SME gates

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -23,10 +23,13 @@ Code-style enforcement stays in [`.cursor/rules/gen-custom/`](rules/gen-custom/)
 
 ### Repo Cursor skills
 
+Skills are **independent** — invoke only the one the user asked for; do not chain
+`/create-issue` and `/plan-issue`.
+
 | Skill                                       | Command         | Use when                                                                                             |
 | ------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------- |
 | [`create-issue/`](skills/create-issue/)     | `/create-issue` | File epic / program / child / bug from [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE/)       |
-| [`plan-issue/`](skills/plan-issue/)         | `/plan-issue`   | Plan a child vs its epic: dep go/no-go → Architect → PM/BA roadmap → SME audit                       |
+| [`plan-issue/`](skills/plan-issue/)         | `/plan-issue`   | Plan an existing child vs its epic: dep go/no-go → Architect → PM/BA roadmap → SME audit             |
 | [`pr-description/`](skills/pr-description/) | (PR body draft) | Fill [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) from full branch diff |
 
 Index also: [`.cursor/README.md`](README.md) · rules: [`project_adapters.mdc`](rules/gen-custom/project_adapters.mdc) · [`github_issue_conventions.mdc`](rules/gen-custom/github_issue_conventions.mdc).

--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -21,6 +21,16 @@ Edit **only** `.cursor/AGENTS.md` and `.cursor/CLAUDE.md`. Do not duplicate adap
 
 Code-style enforcement stays in [`.cursor/rules/gen-custom/`](rules/gen-custom/).
 
+### Repo Cursor skills
+
+| Skill                                       | Command         | Use when                                                                                             |
+| ------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------- |
+| [`create-issue/`](skills/create-issue/)     | `/create-issue` | File epic / program / child / bug from [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE/)       |
+| [`plan-issue/`](skills/plan-issue/)         | `/plan-issue`   | Plan a child vs its epic: dep go/no-go → Architect → PM/BA roadmap → SME audit                       |
+| [`pr-description/`](skills/pr-description/) | (PR body draft) | Fill [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) from full branch diff |
+
+Index also: [`.cursor/README.md`](README.md) · rules: [`project_adapters.mdc`](rules/gen-custom/project_adapters.mdc) · [`github_issue_conventions.mdc`](rules/gen-custom/github_issue_conventions.mdc).
+
 ---
 
 ## What this repo is

--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -262,7 +262,8 @@ Before opening or marking ready for review (commands in [`.github/CI.md`](../.gi
 8. Omit regenerated artifacts (`docs/coverage.xml`, badge SVGs) unless CI requires them
 9. Fill [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) for the PR body (skill: `.cursor/skills/pr-description/`)
 10. New GitHub issues: use [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE/) (epic / program / child / bug) per [github_issue_conventions](rules/gen-custom/github_issue_conventions.mdc); agent skill: [`.cursor/skills/create-issue/`](skills/create-issue/) (`/create-issue`)
-11. Optional CI opt-outs on PRs: durable `skip-*` labels only ([`.github/CI.md` § PR skip labels](../.github/CI.md#pr-skip-labels)) — never invent `PPT-*` labels
+11. Plan a child issue vs its epic (dependency go/no-go first): [`.cursor/skills/plan-issue/`](skills/plan-issue/) (`/plan-issue`)
+12. Optional CI opt-outs on PRs: durable `skip-*` labels only ([`.github/CI.md` § PR skip labels](../.github/CI.md#pr-skip-labels)) — never invent `PPT-*` labels
 
 Do not create git commits unless the user explicitly asks.
 

--- a/.cursor/CLAUDE.md
+++ b/.cursor/CLAUDE.md
@@ -10,17 +10,18 @@ Project memory is repo-owned under `.strata/` (strata format, `layout_version: 3
 
 ## Claude Code quick context
 
-| Topic        | Summary                                                                                                                                                                                                                            |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Repo         | Python 3.12 Poetry + Node 22/pnpm monorepo — financial transaction data                                                                                                                                                            |
-| Packages     | `papita_txnsmodel`; `papita_txnsapi` (MVP routers); `@papita/web` (`modules/web` — presentation only, **no JS domain logic**)                                                                                                      |
-| DB           | PostgreSQL / schema `papita_transactions` only                                                                                                                                                                                     |
-| API status   | Runnable app: health, auth, accounts, categories, transactions, movements, reports (+ budgets 501) ([#42](https://github.com/Elmorralito/save-ma-money/issues/42))                                                                 |
-| Web epic     | PPT-046 / [#112](https://github.com/Elmorralito/save-ma-money/issues/112) — setup [`modules/web/README.md`](../modules/web/README.md); index [`docs/issues` Part VII](../docs/issues/README.md#part-vii--ppt-046-web-spa-epic-112) |
-| Active work  | PPT-032 epic [#42](https://github.com/Elmorralito/save-ma-money/issues/42) close-out; open post-MVP PPT-043 Redis [#83](https://github.com/Elmorralito/save-ma-money/issues/83) (PPT-044/#89 + PPT-045/#93 closed)                 |
-| Design docs  | `docs/design/` (PPT-031 program), `docs/issues/` (briefs incl. PPT-046 Part VII)                                                                                                                                                   |
-| Agent memory | `.strata/` — use strata plugin commands below                                                                                                                                                                                      |
-| Adapters     | Canonical: `.cursor/AGENTS.md` + `.cursor/CLAUDE.md`; Strata validates `.agents/` symlinks                                                                                                                                         |
+| Topic         | Summary                                                                                                                                                                                                                            |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Repo          | Python 3.12 Poetry + Node 22/pnpm monorepo — financial transaction data                                                                                                                                                            |
+| Packages      | `papita_txnsmodel`; `papita_txnsapi` (MVP routers); `@papita/web` (`modules/web` — presentation only, **no JS domain logic**)                                                                                                      |
+| DB            | PostgreSQL / schema `papita_transactions` only                                                                                                                                                                                     |
+| API status    | Runnable app: health, auth, accounts, categories, transactions, movements, reports (+ budgets 501) ([#42](https://github.com/Elmorralito/save-ma-money/issues/42))                                                                 |
+| Web epic      | PPT-046 / [#112](https://github.com/Elmorralito/save-ma-money/issues/112) — setup [`modules/web/README.md`](../modules/web/README.md); index [`docs/issues` Part VII](../docs/issues/README.md#part-vii--ppt-046-web-spa-epic-112) |
+| Active work   | PPT-032 epic [#42](https://github.com/Elmorralito/save-ma-money/issues/42) close-out; open post-MVP PPT-043 Redis [#83](https://github.com/Elmorralito/save-ma-money/issues/83) (PPT-044/#89 + PPT-045/#93 closed)                 |
+| Design docs   | `docs/design/` (PPT-031 program), `docs/issues/` (briefs incl. PPT-046 Part VII)                                                                                                                                                   |
+| Agent memory  | `.strata/` — use strata plugin commands below                                                                                                                                                                                      |
+| Adapters      | Canonical: `.cursor/AGENTS.md` + `.cursor/CLAUDE.md`; Strata validates `.agents/` symlinks                                                                                                                                         |
+| Cursor skills | `/create-issue`, `/plan-issue`, PR body via `.cursor/skills/` — see [AGENTS.md § Repo Cursor skills](AGENTS.md#repo-cursor-skills)                                                                                                 |
 
 ---
 
@@ -45,9 +46,10 @@ Capture hook logs failed shell commands to `.strata/inbox/` automatically when t
 ## Where Claude should look first
 
 1. [`.strata/MANIFEST.md`](../.strata/MANIFEST.md) — memory routing (always for memory ops)
-2. [`.cursor/AGENTS.md`](AGENTS.md) — build, test, layers, env, API routers, PR checklist
+2. [`.cursor/AGENTS.md`](AGENTS.md) — build, test, layers, env, API routers, PR checklist, Cursor skills
 3. [`.strata/docs/ARCHITECTURE.md`](../.strata/docs/ARCHITECTURE.md) — module codemap
 4. Task-specific warm docs per MANIFEST table (`docs/design/`, `docs/issues/`, API endpoint spec)
+5. Before implementing a child issue: [`.cursor/skills/plan-issue/`](skills/plan-issue/) (`/plan-issue`) when dependency readiness or an action plan is needed
 
 Do not bulk-load cold archives or all learnings — load on demand per MANIFEST load order.
 

--- a/.cursor/CLAUDE.md
+++ b/.cursor/CLAUDE.md
@@ -21,7 +21,7 @@ Project memory is repo-owned under `.strata/` (strata format, `layout_version: 3
 | Design docs   | `docs/design/` (PPT-031 program), `docs/issues/` (briefs incl. PPT-046 Part VII)                                                                                                                                                   |
 | Agent memory  | `.strata/` — use strata plugin commands below                                                                                                                                                                                      |
 | Adapters      | Canonical: `.cursor/AGENTS.md` + `.cursor/CLAUDE.md`; Strata validates `.agents/` symlinks                                                                                                                                         |
-| Cursor skills | `/create-issue`, `/plan-issue`, PR body via `.cursor/skills/` — see [AGENTS.md § Repo Cursor skills](AGENTS.md#repo-cursor-skills)                                                                                                 |
+| Cursor skills | Independent: `/create-issue` **or** `/plan-issue` (do not chain); PR body via `.cursor/skills/` — [AGENTS.md § Repo Cursor skills](AGENTS.md#repo-cursor-skills)                                                                   |
 
 ---
 

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -8,6 +8,7 @@ Agent operational instructions are **canonical in this directory**.
 | `CLAUDE.md`              | Thin Claude Code adapter → `AGENTS.md`                                                        |
 | `rules/gen-custom/*.mdc` | Always-applied / glob code-style and conventions                                              |
 | `skills/create-issue/`   | `/create-issue` — GitHub issues from ISSUE_TEMPLATE                                           |
+| `skills/plan-issue/`     | `/plan-issue` — dep go/no-go; Architect → PM/BA → SME subagent gates                          |
 | `skills/pr-description/` | PR body drafts from [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) |
 
 **Strata / Codex entry point:** [`.agents/AGENTS.md`](../.agents/AGENTS.md) and [`.agents/CLAUDE.md`](../.agents/CLAUDE.md) symlink here. `strata_check.sh` validates those paths. Edit files in **`.cursor/`** only.

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -7,8 +7,8 @@ Agent operational instructions are **canonical in this directory**.
 | `AGENTS.md`              | Operational guide — build, test, API status, CI                                               |
 | `CLAUDE.md`              | Thin Claude Code adapter → `AGENTS.md`                                                        |
 | `rules/gen-custom/*.mdc` | Always-applied / glob code-style and conventions                                              |
-| `skills/create-issue/`   | `/create-issue` — GitHub issues from ISSUE_TEMPLATE                                           |
-| `skills/plan-issue/`     | `/plan-issue` — dep go/no-go; Architect → PM/BA → SME subagent gates                          |
+| `skills/create-issue/`   | `/create-issue` — file GitHub issues from ISSUE_TEMPLATE (isolated)                           |
+| `skills/plan-issue/`     | `/plan-issue` — plan existing child vs epic; Architect → PM/BA → SME (isolated)               |
 | `skills/pr-description/` | PR body drafts from [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) |
 
 **Strata / Codex entry point:** [`.agents/AGENTS.md`](../.agents/AGENTS.md) and [`.agents/CLAUDE.md`](../.agents/CLAUDE.md) symlink here. `strata_check.sh` validates those paths. Edit files in **`.cursor/`** only.

--- a/.cursor/rules/gen-custom/github_issue_conventions.mdc
+++ b/.cursor/rules/gen-custom/github_issue_conventions.mdc
@@ -101,8 +101,10 @@ Prefer those files when creating or editing issues via `gh issue create` / `gh i
 **Agent automation:**
 
 - Issues: [`.cursor/skills/create-issue/`](../skills/create-issue/) (`/create-issue`)
-- Issue plans: [`.cursor/skills/plan-issue/`](../skills/plan-issue/) (`/plan-issue`) — dependency readiness before implementation plans
+- Issue plans: [`.cursor/skills/plan-issue/`](../skills/plan-issue/) (`/plan-issue`) — dependency readiness before implementation plans (Architect → PM/BA → SME)
 - PR bodies: [`.cursor/skills/pr-description/`](../skills/pr-description/) + [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md)
+
+Prefer `/plan-issue` on a **child** after `/create-issue` (or when picking up an open child) so Depends on / Blocks and layering are checked before coding. Briefs index: [`docs/issues/README.md`](../../docs/issues/README.md).
 
 ### Program issue skeleton (summary)
 

--- a/.cursor/rules/gen-custom/github_issue_conventions.mdc
+++ b/.cursor/rules/gen-custom/github_issue_conventions.mdc
@@ -101,6 +101,7 @@ Prefer those files when creating or editing issues via `gh issue create` / `gh i
 **Agent automation:**
 
 - Issues: [`.cursor/skills/create-issue/`](../skills/create-issue/) (`/create-issue`)
+- Issue plans: [`.cursor/skills/plan-issue/`](../skills/plan-issue/) (`/plan-issue`) — dependency readiness before implementation plans
 - PR bodies: [`.cursor/skills/pr-description/`](../skills/pr-description/) + [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md)
 
 ### Program issue skeleton (summary)

--- a/.cursor/rules/gen-custom/github_issue_conventions.mdc
+++ b/.cursor/rules/gen-custom/github_issue_conventions.mdc
@@ -98,13 +98,13 @@ GitHub issue chooser templates live under [`.github/ISSUE_TEMPLATE/`](../../.git
 
 Prefer those files when creating or editing issues via `gh issue create` / `gh issue edit`. Do not invent alternate section orders.
 
-**Agent automation:**
+**Agent automation (independent skills — do not chain):**
 
-- Issues: [`.cursor/skills/create-issue/`](../skills/create-issue/) (`/create-issue`)
-- Issue plans: [`.cursor/skills/plan-issue/`](../skills/plan-issue/) (`/plan-issue`) — dependency readiness before implementation plans (Architect → PM/BA → SME)
+- Issues: [`.cursor/skills/create-issue/`](../skills/create-issue/) (`/create-issue`) — file from ISSUE_TEMPLATE only
+- Issue plans: [`.cursor/skills/plan-issue/`](../skills/plan-issue/) (`/plan-issue`) — plan an existing child vs epic (Architect → PM/BA → SME); not part of create-issue
 - PR bodies: [`.cursor/skills/pr-description/`](../skills/pr-description/) + [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md)
 
-Prefer `/plan-issue` on a **child** after `/create-issue` (or when picking up an open child) so Depends on / Blocks and layering are checked before coding. Briefs index: [`docs/issues/README.md`](../../docs/issues/README.md).
+Briefs index: [`docs/issues/README.md`](../../docs/issues/README.md).
 
 ### Program issue skeleton (summary)
 

--- a/.cursor/rules/gen-custom/project_adapters.mdc
+++ b/.cursor/rules/gen-custom/project_adapters.mdc
@@ -17,6 +17,7 @@ Strata-validated symlinks: [`.agents/AGENTS.md`](../../.agents/AGENTS.md) → `.
 | Skill | Use when |
 | ----- | -------- |
 | [`create-issue/`](../skills/create-issue/) | New GitHub issues from ISSUE_TEMPLATE (`/create-issue`) |
+| [`plan-issue/`](../skills/plan-issue/) | Child + epic plan: dep go/no-go, Architect → PM/BA → SME gates (`/plan-issue`) |
 | [`pr-description/`](../skills/pr-description/) | Paste-ready PR bodies from [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md) |
 
 ### When something changes

--- a/.cursor/rules/gen-custom/project_adapters.mdc
+++ b/.cursor/rules/gen-custom/project_adapters.mdc
@@ -16,8 +16,8 @@ Strata-validated symlinks: [`.agents/AGENTS.md`](../../.agents/AGENTS.md) → `.
 
 | Skill | Use when |
 | ----- | -------- |
-| [`create-issue/`](../skills/create-issue/) | New GitHub issues from ISSUE_TEMPLATE (`/create-issue`) |
-| [`plan-issue/`](../skills/plan-issue/) | Child + epic plan: dep go/no-go, Architect → PM/BA → SME gates (`/plan-issue`) |
+| [`create-issue/`](../skills/create-issue/) | New GitHub issues from ISSUE_TEMPLATE (`/create-issue`) — isolated; do not chain `/plan-issue` |
+| [`plan-issue/`](../skills/plan-issue/) | Plan an existing child vs epic (`/plan-issue`) — isolated; do not chain `/create-issue` |
 | [`pr-description/`](../skills/pr-description/) | Paste-ready PR bodies from [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md) |
 
 ### When something changes

--- a/.cursor/rules/gen-custom/project_adapters.mdc
+++ b/.cursor/rules/gen-custom/project_adapters.mdc
@@ -25,6 +25,7 @@ Strata-validated symlinks: [`.agents/AGENTS.md`](../../.agents/AGENTS.md) → `.
 | Change | Update |
 | ------ | ------ |
 | API routers, auth, setup, CI, PR checklist | `.cursor/AGENTS.md` (+ thin notes in `CLAUDE.md` if needed) |
+| New/changed Cursor skills under `.cursor/skills/` | `.cursor/AGENTS.md` skills table, `.cursor/README.md`, `project_adapters.mdc`, `github_issue_conventions.mdc` when issue-related; `docs/issues/README.md` / root `README.md` docs hub when operators should discover them |
 | Code-style / structure / migrations / issue titles | Matching `gen-custom/*.mdc` |
 | Architecture decisions, backlog, learnings | `.strata/` via `/strata:capture` / `/strata:save` |
 | `modules/**` or `bin/**` code | Pair with `.strata/` (strata strict mode) |

--- a/.cursor/rules/gen-custom/project_structure.mdc
+++ b/.cursor/rules/gen-custom/project_structure.mdc
@@ -117,6 +117,7 @@ Canonical B0 API start: `make api-up` (uvicorn in-container). nginx SPA: `make w
 | Design program | `docs/design/` (`ARCHITECTURE.md`, `README.md`) |
 | Issue briefs | `docs/issues/README.md` (merged SSOT; no separate PPT-044/045 brief files) |
 | Agent ops | `.cursor/AGENTS.md` |
+| Agent Cursor skills | `.cursor/skills/` (`create-issue`, `plan-issue`, `pr-description`) — index in `.cursor/README.md` / `project_adapters.mdc` |
 | Agent memory | `.strata/MANIFEST.md` |
 
 ### Dependency Management

--- a/.cursor/skills/create-issue/SKILL.md
+++ b/.cursor/skills/create-issue/SKILL.md
@@ -198,9 +198,9 @@ Prefer `--repo Elmorralito/save-ma-money` (or the current `gh` remote) so the is
 
 Return the issue **URL** and number. Do not close or edit other issues unless asked.
 
-After creating a **child** (or when the user asks what to do next), offer
-[`.cursor/skills/plan-issue/`](../plan-issue/) (`/plan-issue`) to check Depends on
-readiness and produce an Architect → PM/BA → SME action plan before implementation.
+This skill is **independent** of `/plan-issue`. Do not invoke, chain, or suggest
+`plan-issue` as part of create-issue. Stop after the issue URL unless the user
+explicitly asks for something else.
 
 ## Rules
 
@@ -219,4 +219,3 @@ readiness and produce an Architect → PM/BA → SME action plan before implemen
 - [reference.md](reference.md) — field checklist by type + example titles
 - Conventions: `.cursor/rules/gen-custom/github_issue_conventions.mdc`
 - Briefs index: `docs/issues/README.md`
-- Plan before implement: [../plan-issue/](../plan-issue/) (`/plan-issue`)

--- a/.cursor/skills/create-issue/SKILL.md
+++ b/.cursor/skills/create-issue/SKILL.md
@@ -198,6 +198,10 @@ Prefer `--repo Elmorralito/save-ma-money` (or the current `gh` remote) so the is
 
 Return the issue **URL** and number. Do not close or edit other issues unless asked.
 
+After creating a **child** (or when the user asks what to do next), offer
+[`.cursor/skills/plan-issue/`](../plan-issue/) (`/plan-issue`) to check Depends on
+readiness and produce an Architect → PM/BA → SME action plan before implementation.
+
 ## Rules
 
 - Interactive first: type → fields → optional context → draft → **gh auth** → confirm → create.
@@ -215,3 +219,4 @@ Return the issue **URL** and number. Do not close or edit other issues unless as
 - [reference.md](reference.md) — field checklist by type + example titles
 - Conventions: `.cursor/rules/gen-custom/github_issue_conventions.mdc`
 - Briefs index: `docs/issues/README.md`
+- Plan before implement: [../plan-issue/](../plan-issue/) (`/plan-issue`)

--- a/.cursor/skills/plan-issue/SKILL.md
+++ b/.cursor/skills/plan-issue/SKILL.md
@@ -17,10 +17,13 @@ Turn a **child issue + parent epic** into a dependency-aware implementation plan
 
 This skill lives at `.cursor/skills/plan-issue/` (repo-only).
 
-**Linked from:** [`.cursor/AGENTS.md`](../../AGENTS.md) · [`.cursor/README.md`](../../README.md) ·
+**Independent of `/create-issue`.** Do not invoke, chain, or require issue creation
+as part of this skill. Plan only against an existing child + epic the user names.
+
+**Indexed from:** [`.cursor/AGENTS.md`](../../AGENTS.md) · [`.cursor/README.md`](../../README.md) ·
 [`project_adapters.mdc`](../../rules/gen-custom/project_adapters.mdc) ·
 [`github_issue_conventions.mdc`](../../rules/gen-custom/github_issue_conventions.mdc) ·
-[`docs/issues/README.md`](../../../docs/issues/README.md) · sibling [`../create-issue/`](../create-issue/).
+[`docs/issues/README.md`](../../../docs/issues/README.md).
 
 ## Inputs
 

--- a/.cursor/skills/plan-issue/SKILL.md
+++ b/.cursor/skills/plan-issue/SKILL.md
@@ -17,6 +17,11 @@ Turn a **child issue + parent epic** into a dependency-aware implementation plan
 
 This skill lives at `.cursor/skills/plan-issue/` (repo-only).
 
+**Linked from:** [`.cursor/AGENTS.md`](../../AGENTS.md) · [`.cursor/README.md`](../../README.md) ·
+[`project_adapters.mdc`](../../rules/gen-custom/project_adapters.mdc) ·
+[`github_issue_conventions.mdc`](../../rules/gen-custom/github_issue_conventions.mdc) ·
+[`docs/issues/README.md`](../../../docs/issues/README.md) · sibling [`../create-issue/`](../create-issue/).
+
 ## Inputs
 
 Require (ask if missing):

--- a/.cursor/skills/plan-issue/SKILL.md
+++ b/.cursor/skills/plan-issue/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: plan-issue
+description: >
+  Reviews a GitHub child issue against its parent epic, checks Depends on /
+  Blocks readiness, drafts strategy, runs a stack-specialized Architect
+  subagent, generates a roadmap action plan via a PM/BA subagent, then runs
+  a SME technical-expert subagent audit before presenting (plan only — no
+  code). Use when the user asks to plan an issue, strategy for a PPT child,
+  /plan-issue, or whether an issue is blocked by dependencies.
+disable-model-invocation: true
+---
+
+# Plan issue (project)
+
+Turn a **child issue + parent epic** into a dependency-aware implementation plan.
+**Plan only** — do not implement code unless the user explicitly asks after the plan.
+
+This skill lives at `.cursor/skills/plan-issue/` (repo-only).
+
+## Inputs
+
+Require (ask if missing):
+
+| Input       | Examples                                          |
+| ----------- | ------------------------------------------------- |
+| Child issue | `#166`, URL, or `PPT-073`                         |
+| Parent epic | `#163`, URL, or from child's **Parent epic** line |
+
+Optional: sibling issues listed under Depends on / Blocks.
+
+Resolve via `gh issue view <N> --repo Elmorralito/save-ma-money` (or origin remote).
+
+## Progress checklist
+
+```
+Plan-issue progress:
+- [ ] 1. Intake — fetch child + epic; extract goal, AC, depends/blocks, OOS
+- [ ] 2. Dependency readiness — verify each Depends on (issue state + repo evidence)
+- [ ] 3. Go / no-go — can address now, or must finish a dependency first
+- [ ] 4. Repo current state — cite paths for this child's domain
+- [ ] 5. Strategy v1 — numbered points S# + risk register
+- [ ] 6. Architect subagent (stack-specialized) → merge into Strategy v2
+- [ ] 7. PM/BA subagent — roadmap action plan from Strategy v2 (or NO-GO stub)
+- [ ] 8. Parent light merge → SME/tech-expert **subagent** audit
+- [ ] 9. Apply audit fixes (re-audit once if FAIL); then present to human
+```
+
+## Repo constraints (always apply)
+
+### Scope & hierarchy
+
+- **Child = deliverable boundary.** Plan only what the child issue’s tasks, AC, and out-of-scope allow.
+- **Epic = context, not a work order.** Use it for intent, layering rules, dependency graph, deferred items, and epic-level OOS — not to pull sibling PPT work into this plan.
+- **Do not expand** into sibling PPT issues unless go/no-go is **NO-GO** and you redirect planning to the blocking dependency (or the user asks to plan that sibling).
+- **Depends on / Blocks** from the child body are authoritative for sequencing; reconcile with the epic’s mermaid/order table when they disagree (call it out as a risk / open question).
+- Titles and PPT ids follow `.cursor/rules/gen-custom/github_issue_conventions.mdc` (`{semantic}/PPT-{NNN}: [{domain}] …`; children reuse parent `EPIC: PPT-*` label).
+
+### Domain → primary paths
+
+Match the child’s `[domain]` (and issue labels) to where the plan may touch code:
+
+| Domain          | Package / import   | Primary paths                                                          | Plan must respect                                                                                |
+| --------------- | ------------------ | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `[model]`       | `papita_txnsmodel` | `modules/model/src/`, `modules/model/tests/`, `modules/model/alembic/` | SQLModel + services/repos; schema `papita_transactions`; soft delete via `active` / `deleted_at` |
+| `[api]`         | `papita_txnsapi`   | `modules/api/src/`, `modules/api/tests/`                               | Routers under `routers/v1/`; schemas; deps — **no** domain rules in routers                      |
+| Web / SPA       | `@papita/web`      | `modules/web/` (`src/`, `openapi/`, `e2e/`)                            | UI + TanStack Query + BFF cookies only — **no** TS port of model services                        |
+| `[infra]` / ops | —                  | `bin/`, `docker/`, `.github/`, `Makefile`                              | Only if the child is ops/ci-scoped                                                               |
+
+Cross-cutting OpenAPI sync / docs gates often live on a later sibling (e.g. PPT-075) — do not absorb them unless this child’s AC explicitly requires them.
+
+### Layering rules (non-negotiable in plans)
+
+- **API layer rule:** routers validate auth, map request/response schemas, enforce `owner` / tenant scoping, and **delegate** to `papita_txnsmodel` `*Service` methods. Reject plan tasks that “add business logic in the router.”
+- **Model owns domain:** create/update/query/mark-paid/upcoming-window rules stay in model services/repos; API and web consume them.
+- **Web domain boundary:** presentation, forms, Query keys, BFF session (`papita_sid` / CSRF) — never reimplement `UsersService` or other model methods in JS (see `modules/web/README.md` § Domain boundary).
+- **Auth posture:** Supabase owns identity for real runs; `AUTH_PROVIDER=local` is B0/pytest only. Plans that touch auth should say Bearer vs BFF cookie and align with existing `get_current_owner` patterns — do not invent a new auth stack.
+- **Secrets:** never put credentials, tokens, or private URLs in the plan; name env vars only (e.g. `DATABASE_URL`, `SUPABASE_*`).
+
+### Platform (B0 / B1)
+
+- **B0 (default acceptance):** Docker Postgres (+ Compose API/Redis when the step needs them). Canonical API: `make api-up` / stack: `make api-all`. Domain children validate here unless the issue says otherwise.
+- **Auth smoke:** `make auth-smoke` when the step touches auth; not required for pure CRUD wiring that reuses existing deps.
+- **B1 pooler (`:6543`):** optional hosted Postgres connectivity — **not** an Auth or epic gate. Alembic/migrations use direct `:5432` (`DATABASE_URL_MIGRATIONS`) when migrations are in scope.
+- **Supabase PG/pooler** is not a substitute for B0 acceptance of model/API work.
+
+### Evidence over invention
+
+- Prefer **issue bodies + inspected repo paths** over memory. Cite files/symbols when claiming a dependency is `ready`.
+- Label **assumptions** explicitly; if a contract is unverified, use dependency status `unknown` / `partial` and an open question — do not invent green readiness.
+- When patterns already exist (list query `Depends`, `_require_uuid`, owner filters, OpenAPI commit path), **plan to match them** instead of proposing a parallel style.
+
+## Step 1 — Intake
+
+From the child and epic, extract:
+
+- Goal / summary, tasks, acceptance criteria
+- **Depends on** and **Blocks** (issue numbers + PPT ids)
+- Out of scope
+- Domain (`api` / `model` / web / infra) and step number in the epic graph
+
+## Step 2 — Dependency readiness (required)
+
+For **each** hard dependency in **Depends on** (and soft deps that gate this step):
+
+1. `gh issue view` — state (`OPEN` / `CLOSED`), title, AC summary.
+2. Inspect the repo for the dependency's claimed deliverables (services, migrations, routers, schemas). Cite paths.
+3. Classify each dependency:
+
+| Status    | Meaning                                                       |
+| --------- | ------------------------------------------------------------- |
+| `ready`   | Closed **or** open but contracts exist in-repo and are usable |
+| `partial` | Some contracts exist; gaps block parts of the child           |
+| `blocked` | Missing or unfinished; child cannot honestly start            |
+| `unknown` | Cannot verify — state what evidence is missing                |
+
+Also note what this child **Blocks** (downstream) so the plan leaves a clean handoff surface.
+
+### Go / no-go (emit before strategy)
+
+Pick exactly one:
+
+1. **GO** — dependencies are `ready` (or `partial` with a documented workaround that stays in-scope). Proceed to plan the child.
+2. **NO-GO** — at least one hard dependency is `blocked` / insufficient. **Do not** produce a full implementation plan for the child as if it were startable. Instead:
+   - Name the blocking issue(s)
+   - Summarize what must land first
+   - Offer a **minimal plan for the top blocker** (or stop after readiness report if the user only asked about the child)
+3. **GO WITH HOLDS** — can start scaffolding/tests/docs that do not call missing APIs; list holds explicitly.
+
+Never invent green dependency status.
+
+## Step 3 — Analysis
+
+Short analysis:
+
+- What “done” means for this child vs epic close-out
+- Prerequisite contracts (methods, DTOs, error modes) from deps
+- Gaps between issue text and repo reality
+- Seed list of candidate risks (refine into the register in Step 4)
+
+## Step 4 — Strategy v1 → Architect subagent → Strategy v2
+
+### 4a — Strategy v1 (parent)
+
+Must cover: approach, endpoint/surface or schema/service touchpoints, mapping to existing layers, auth/owner (if API), tests on B0, explicit non-goals, and a **risk register**.
+
+Number every strategy point as `S1`, `S2`, … so the Architect can validate point-by-point.
+
+### Risk register (create in Strategy; carry forward)
+
+Identify risks while drafting Strategy (not only at the end). For **each** risk, set disposition to exactly one of:
+
+| Disposition     | When to use                                  | Required fields                                            |
+| --------------- | -------------------------------------------- | ---------------------------------------------------------- |
+| `mitigate`      | Controllable in this child's plan            | Mitigation action + which work-breakdown task owns it      |
+| `open_question` | Needs a human decision before or during impl | Question, options/default if any, when it must be answered |
+| `accept`        | Known residual; out of scope or deferred     | Why acceptable + deferral target (PPT/issue) if any        |
+
+Use stable ids (`R1`, `R2`, …). Cover at least: dependency/contract fragility, scope bleed, tenancy/auth, test/B0 gaps, and any domain-specific unknowns. Table shape: [reference.md](reference.md) § Risk register.
+
+### 4b — Architect subagent (required when a strategy exists)
+
+Independent **stack-specialized Architect** reviews Strategy v1. Does **not** replace the later SME audit.
+
+1. Select specialization from child domain/stack ([architect-subagent.md](architect-subagent.md) § Stack selection). If unclear → `BLOCKED: missing stack`; ask human.
+2. Invoke `Task` (`generalPurpose`, `run_in_background: false`) with the prompt template in [architect-subagent.md](architect-subagent.md).
+3. Expect: architectural overview + per-`S#` status (`sound` / `weak` / `incorrect` / `missing` / `out_of_scope`) + Strategy v2 patch list + risk addenda.
+4. Merge into **Strategy v2**. On `UNSOUND`, fix and re-invoke Architect **once**. Record unresolved disagreements as `open_question` risks — do not silently drop `incorrect` findings.
+
+**Fallback:** same report schema with label `Architect review: … (parent fallback — subagent unavailable)`.
+
+### 4c — Parent merge checklist (after Architect)
+
+Before freezing Strategy v2, confirm:
+
+1. Scope creep into siblings / epic addressed
+2. Missing AC, edge cases, error paths covered or risked
+3. Dependency / sequencing gaps honest vs go/no-go
+4. Owner scoping / cross-tenant risk (API/data)
+5. Test / B0 implications present
+6. Architect patch list applied or explicitly deferred as open questions
+7. Risk register complete (including Architect addenda)
+8. Mitigations actionable / open questions have decision points
+
+Emit **Strategy v2** + what changed (include Architect verdict + role/stack).
+
+## Step 5 — Action plan via PM/BA subagent (only if GO or GO WITH HOLDS)
+
+Independent **Product Manager / BA engineer** subagent turns Strategy v2 into a **roadmap-shaped** action plan. Parent does not author the WBS when `Task` is available.
+
+### 5a — Preconditions
+
+- Strategy v2 frozen after Architect (SOUND or SOUND WITH GAPS with patches applied).
+- Do **not** invoke if strategy is UNSOUND / `BLOCKED: missing stack`, or go/no-go is **NO-GO** without a strategy.
+
+### 5b — Invoke PM/BA subagent
+
+1. Read [pm-ba-subagent.md](pm-ba-subagent.md).
+2. Call `Task` (`generalPurpose`, `run_in_background: false`, description e.g. `PM BA action plan`).
+3. Pass: child/epic context, AC, OOS, go/no-go, dependency table, Architect summary, Strategy v2, current-state paths.
+4. Expect: roadmap phases/milestones + `T#` WBS + AC/`S#` traceability + risk/human decisions + DoD + downstream handoff.
+5. Verdict: `READY_FOR_SME_AUDIT` | `READY_WITH_HOLDS` | `BLOCKED`.
+
+**Fallback:** parent writes the plan with the same schema and labels `Action plan: … (parent fallback — PM/BA subagent unavailable)`.
+
+### 5c — Parent light merge
+
+Before SME audit, verify:
+
+- Scope lock (in-child only)
+- Every child AC maps to a task + DoD evidence
+- Risks carried (`mitigate`→`T#`, `open_question`→Human decisions, `accept`→residual)
+- No re-architecture that contradicts Strategy v2 / Architect (reject or convert to `open_question`)
+- Concrete paths/names retained from strategy
+
+### 5d — NO-GO stub (parent; no PM/BA child plan)
+
+If **NO-GO**, skip PM/BA for the child and emit:
+
+1. Dependency readiness table
+2. Blocker summary + risks that reinforce the block
+3. Recommended next issue to plan/implement
+4. Optional: run Architect → PM/BA on the **blocker** only
+
+## Step 6 — Pre-presentation audit via SME subagent (required before human)
+
+**Do not present** the plan to the human until the independent audit finishes.
+
+### Why a subagent
+
+The planner must not be the sole auditor. Launch a **separate** agent whose role is **Expert subject-matter expert and technical expert** so checklist A–N and risk carry-through get an independent review. This is supported via Cursor `Task` (`generalPurpose`) — see [audit-subagent.md](audit-subagent.md).
+
+### Parent must
+
+1. Keep the draft private (Strategy v2 + PM/BA action plan after light merge, or NO-GO stub).
+2. Read [audit-subagent.md](audit-subagent.md) and invoke `Task`:
+   - `subagent_type`: `generalPurpose`
+   - `description`: short title e.g. `SME plan audit`
+   - `run_in_background`: `false`
+   - `prompt`: filled template from `audit-subagent.md` (full draft including PM/BA roadmap + child/epic ids + claimed go/no-go + repo root)
+3. Wait for the subagent report (`PASS` | `PASS WITH HOLDS` | `FAIL` + A–N table).
+4. Apply fixes to the draft. On `FAIL`, re-invoke the subagent **once** with the revised draft.
+5. Present only after that loop. Never claim `Audit: PASS` if the last subagent verdict was `FAIL`.
+
+**Fallback:** if `Task` is unavailable, parent runs the same checklist/report format and labels `Audit: … (parent fallback — subagent unavailable)`.
+
+Checklist definitions: [reference.md](reference.md) § Pre-presentation audit. Prompt + interpretation table: [audit-subagent.md](audit-subagent.md).
+
+Include in the presented output (never omit):
+
+- `Audit: PASS` | `PASS WITH HOLDS` | parent-fallback variant
+- `Auditor: SME/technical-expert subagent` (or fallback note)
+- Holds / critical blockers from the auditor (if any)
+
+## Output rules
+
+- Lead with the **go/no-go** verdict and dependency table.
+- Include **Architect** (verdict + stack), **PM/BA** (verdict + roadmap author), and **SME audit** results.
+- Surface the **risk register** and any **open questions** for human readiness before the work breakdown.
+- Present **only after** Step 6 (or Step 6 with declared holds).
+- Keep epic context visible; do not expand scope into other PPT steps.
+- Do not write production code, open PRs, or close issues as part of this skill.
+- Never put secrets, tokens, or credentialed URLs in the plan.

--- a/.cursor/skills/plan-issue/architect-subagent.md
+++ b/.cursor/skills/plan-issue/architect-subagent.md
@@ -1,0 +1,139 @@
+# plan-issue — architect subagent
+
+## Possibility
+
+**YES.** Same pattern as [audit-subagent.md](audit-subagent.md): Cursor `Task` + `subagent_type: generalPurpose`, with role and **stack specialization** encoded in the prompt. There is no built-in “architect” agent type.
+
+**Not suitable:** `bugbot` / `security-review` (fixed prompts); `explore` alone (no structured strategy validation); parent-only critique as the sole architecture gate.
+
+**Does not replace** the SME pre-presentation audit. Architect improves **Strategy**; SME auditor gates the **human-ready action plan**.
+
+## Placement
+
+```text
+Strategy v1 (parent)
+  → Architect subagent (stack-specialized)
+  → Strategy v2 (parent merges deltas + risk addenda)
+  → Action plan (parent)
+  → SME audit subagent
+  → Present to human
+```
+
+Skip the Architect subagent only when go/no-go is **NO-GO** and you stop at a readiness report with no strategy (or when planning only the blocker — then run Architect on the **blocker** strategy).
+
+## Stack selection (parent sets role)
+
+Derive from child `[domain]`, labels, issue body, and paths. Set **primary** stack; list secondary as consulting lenses.
+
+| Signal                            | Architect specialization (primary)                                        |
+| --------------------------------- | ------------------------------------------------------------------------- |
+| `[model]` / Alembic / DTO-service | Postgres · SQLModel · Alembic · service/repository layering               |
+| `[api]` / FastAPI routers         | FastAPI · Pydantic v2 · auth/owner scoping · OpenAPI contracts            |
+| Web / SPA / `modules/web`         | React · Vite · TanStack Query · BFF cookie session (no TS domain logic)   |
+| `[infra]` / Docker / Actions      | Docker · Compose · GH Actions · registry/ops                              |
+| Mixed child                       | Primary = dominant deliverable domain; secondary stacks listed explicitly |
+
+If stack cannot be determined → do **not** invoke. Emit `BLOCKED: missing stack` and ask the human/planner what to specialize on.
+
+## Parent: how to invoke
+
+1. Draft **Strategy v1** (approach, touchpoints, layering, tests/B0, non-goals, risk register). Number strategy points as `S1`, `S2`, … for the auditor.
+2. Select stack specialization (table above).
+3. Read this file; call `Task`:
+   - `subagent_type`: `generalPurpose`
+   - `model`: `inherit` (unless user named an allowed model)
+   - `description`: e.g. `API architect review` / `Model architect review` (≤5 words, stack-specific)
+   - `run_in_background`: `false`
+   - `prompt`: filled template below
+4. Merge report into **Strategy v2** (apply patch list; add suggested risks as new `R#`).
+5. On Architect `FAIL` / many `incorrect` points: fix Strategy and re-invoke **once**.
+6. Proceed to action plan only after Strategy v2 absorbs the review (or documents accepted disagreements as `open_question` risks).
+
+**Fallback:** if `Task` unavailable, parent runs the same output schema and labels `Architect review: … (parent fallback — subagent unavailable)`.
+
+## Subagent prompt template
+
+Copy into the `Task` `prompt` parameter. Replace `{{…}}`.
+
+```text
+You are an Architect specialized in: {{STACK_SPECIALIZATION}}.
+Secondary consulting lenses (optional): {{SECONDARY_STACKS_OR_NONE}}.
+
+You are reviewing strategy for the save-ma-money monorepo. You did NOT author this strategy.
+Your job: architectural overview + validate EACH numbered strategy point. Do not implement code. Do not write the full action plan.
+
+## Context
+- Child issue: {{CHILD_ISSUE_URL_OR_NUMBER}} ({{CHILD_TITLE}})
+- Parent epic: {{EPIC_URL_OR_NUMBER}} ({{EPIC_TITLE}})
+- Domain / step: {{DOMAIN}} / {{STEP}}
+- Go/no-go claimed: {{GO|GO_WITH_HOLDS|NO_GO}}
+- Dependency readiness summary: {{DEP_TABLE_OR_BULLETS}}
+- Workspace root: {{REPO_ROOT}}
+
+## Strategy under review (v1 or candidate)
+{{STRATEGY_MARKDOWN_WITH_S_IDS}}
+
+## Monorepo constraints (enforce for this stack)
+- Child = deliverable boundary; epic = context only.
+- Model owns domain rules (papita_txnsmodel); API routers = auth + schema map + owner scoping only.
+- Web = UI + TanStack Query + BFF cookies; no TS port of model services.
+- Schema papita_transactions; soft delete active/deleted_at.
+- B0 Docker Postgres default acceptance; Supabase Auth ≠ Supabase PG gate.
+- Prefer repo/issue evidence; label assumptions.
+
+## Required work
+1. Confirm your specialization matches the issue; if wrong/missing, return BLOCKED: missing stack.
+2. Skim repo paths relevant to contested strategy claims (cite evidence). Do not implement.
+3. Write a short architectural overview (fit, contracts, tenancy/auth, deps, B0/tests).
+4. Validate EVERY strategy point S1..Sn with status: sound | weak | incorrect | missing | out_of_scope.
+5. Propose Strategy v2 patch list (deltas only) and risk register addenda (new R# suggestions).
+6. Return ONLY the report format below.
+
+## Output format (mandatory)
+
+# Architect strategy review
+
+**Verdict:** SOUND | SOUND WITH GAPS | UNSOUND | BLOCKED: missing stack
+**Architect role:** {{STACK_SPECIALIZATION}} (subagent)
+**Secondary lenses:** {{SECONDARY_STACKS_OR_NONE}}
+
+## Architectural overview
+- Fit to layering: …
+- Contract direction (who owns rules): …
+- Tenancy / auth: …
+- Dependency honesty: …
+- Test / B0 implications: …
+- Risk register alignment: …
+
+## Per-point validation
+| ID | Status | Evidence | Required change |
+| -- | ------ | -------- | --------------- |
+| S1 | sound\|weak\|incorrect\|missing\|out_of_scope | path or assumption | … |
+| S2 | … | … | … |
+
+## Strategy v2 patch list
+1. …
+2. …
+
+## Risk addenda (suggested)
+| ID | Risk | Disposition | Note |
+| -- | ---- | ----------- | ---- |
+| R… | … | mitigate\|open_question\|accept | … |
+
+## Critical architectural blockers
+- … (empty if none)
+
+## Notes for planner
+- Short bullets only; do not paste a full rewritten strategy document.
+```
+
+## Parent: interpreting results
+
+| Verdict                  | Parent action                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `SOUND`                  | Merge any minor notes; emit Strategy v2; continue to action plan                                                         |
+| `SOUND WITH GAPS`        | Apply patch list + risk addenda; Strategy v2 must address gaps                                                           |
+| `UNSOUND`                | Apply patches; re-invoke Architect **once**; if still UNSOUND, continue only with explicit `open_question` risks / holds |
+| `BLOCKED: missing stack` | Stop; clarify stack with human; do not invent specialization                                                             |
+
+Disagreement with the architect: allowed only if recorded as an `open_question` (human decides) — do not silently drop `incorrect` / blocker findings.

--- a/.cursor/skills/plan-issue/audit-subagent.md
+++ b/.cursor/skills/plan-issue/audit-subagent.md
@@ -1,0 +1,104 @@
+# plan-issue — audit subagent
+
+## Possibility
+
+Yes. Cursor’s `Task` tool can run a **separate agent** that did not author the plan. Use `subagent_type: generalPurpose` with an explicit **Expert SME / technical expert** role. There is no dedicated “auditor” agent type; role + checklist in the prompt is the supported pattern.
+
+**Not suitable:** `bugbot` / `security-review` (fixed single-shot prompts), `explore` alone (too shallow for A–N + risk carry-through), parent self-check as the _only_ audit (lacks independent review).
+
+## Parent: how to invoke
+
+1. Finish Strategy v2 + action plan (or NO-GO stub). **Do not** show the human yet.
+2. Read this file and the A–N table in [reference.md](reference.md).
+3. Call `Task` with:
+   - `subagent_type`: `generalPurpose`
+   - `model`: `inherit` (unless the user named an allowed model)
+   - `description`: `SME plan audit` (or similar, ≤5 words, distinct)
+   - `run_in_background`: `false` (must block until the audit returns)
+   - `prompt`: fill the template below (include full draft plan + issue/epic ids + dependency table)
+4. Apply findings (fix draft). Optionally re-invoke **once** after fixes.
+5. Present to human with `Audit: PASS` / `PASS WITH HOLDS` and note that audit was via subagent.
+
+Parent may spot-check repo paths the auditor flags, but must **not** skip the subagent or rewrite the auditor’s fail list away without fixing the draft.
+
+## Subagent prompt template
+
+Copy into the `Task` `prompt` parameter. Replace `{{…}}` placeholders.
+
+```text
+You are an Expert subject-matter expert and technical expert for the save-ma-money monorepo (papita_txnsmodel / papita_txnsapi / @papita/web).
+
+Role: independent pre-presentation auditor. You did NOT write the plan. Your job is to find gaps, false readiness, layering violations, weak risks, and human-unreadiness — not to rewrite the plan or implement code.
+
+## Context
+- Child issue: {{CHILD_ISSUE_URL_OR_NUMBER}} ({{CHILD_TITLE}})
+- Parent epic: {{EPIC_URL_OR_NUMBER}} ({{EPIC_TITLE}})
+- Go/no-go claimed by planner: {{GO|GO_WITH_HOLDS|NO_GO}}
+- Workspace root: {{REPO_ROOT}}
+
+## Draft under audit
+{{FULL_DRAFT_PLAN_MARKDOWN}}
+
+## Repo constraints (enforce)
+- Child = deliverable boundary; epic = context only.
+- API: routers = auth + schema map + owner scoping; business logic only in papita_txnsmodel.
+- Web: UI + TanStack Query + BFF cookies; no TS domain logic.
+- Model: schema papita_transactions; soft delete active/deleted_at.
+- B0 Docker Postgres is default acceptance; do not treat Supabase PG/pooler as the gate.
+- Prefer evidence from issue bodies + repo over assumptions.
+
+## Required work
+1. Optionally verify contested dependency claims with gh issue view and quick repo inspection (cite paths). Do not implement features.
+2. Score checklist A–N (see below). For each item: PASS or FAIL with one concrete reason and a suggested fix.
+3. Especially stress-test: dependency readiness honesty, risk register dispositions, risk→task / open_question→Human decisions carry-through, layering, tenancy.
+4. Return ONLY the audit report format below — no rewritten full plan.
+
+## Checklist A–N
+A Verdict integrity — go/no-go matches dependency table; no fake ready
+B Scope lock — tasks in-child only (unless NO-GO redirect)
+C AC coverage — each child AC → task + DoD evidence
+D Dep contracts — only existing/held services/schemas
+E Layering — no business logic in API/web
+F Tenancy/auth — owner scoping where data is exposed
+G Tests & B0 — non-empty; deferrals named by PPT/issue
+H Concrete paths — routes/files/methods cited
+I Assumptions — labeled; not silent facts
+J Secrets — none in draft
+K Iteration trace — v2 fixes reflected in final plan
+L Risk register — every risk has mitigate | open_question | accept
+M Risk → action — mitigations→tasks; open questions→Human decisions
+N Human-ready — verdict, questions, residual risks, first task obvious
+
+## Output format (mandatory)
+
+# SME technical audit
+
+**Verdict:** PASS | PASS WITH HOLDS | FAIL
+**Auditor role:** Expert SME / technical expert (subagent)
+
+## Checklist
+| ID | Result | Finding | Suggested fix |
+| -- | ------ | ------- | ------------- |
+| A | PASS/FAIL | … | … |
+| … | … | … | … |
+| N | PASS/FAIL | … | … |
+
+## Critical blockers
+- … (empty if none)
+
+## Audit holds (human decisions needed)
+- … (empty if none)
+
+## Residual notes for planner
+- Short bullets only; do not paste a new full plan.
+```
+
+## Parent: interpreting results
+
+| Subagent verdict  | Parent action                                                                                                                                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `PASS`            | Present draft; `Audit: PASS` (via SME subagent)                                                                                                                          |
+| `PASS WITH HOLDS` | Present draft + holds; or fix holds if trivial, then present                                                                                                             |
+| `FAIL`            | Apply suggested fixes; re-invoke subagent **once** with revised draft; if still FAIL → present with `Audit: PASS WITH HOLDS` listing remaining fails (do not claim PASS) |
+
+If `Task` / subagent is unavailable in the environment, fall back to parent self-audit using the same checklist and report format, and state: `Audit: … (parent fallback — subagent unavailable)`.

--- a/.cursor/skills/plan-issue/pm-ba-subagent.md
+++ b/.cursor/skills/plan-issue/pm-ba-subagent.md
@@ -1,0 +1,166 @@
+# plan-issue — PM / BA action-plan subagent
+
+## Possibility
+
+**YES.** Same pattern as [architect-subagent.md](architect-subagent.md) and [audit-subagent.md](audit-subagent.md): Cursor `Task` + `subagent_type: generalPurpose`, with **Product Manager + BA engineer** role encoded in the prompt. There is no built-in “PM” agent type.
+
+**Not suitable:** `bugbot` / `security-review`; asking the Architect to write the full WBS; asking the SME auditor to author the plan it will audit; parent-only WBS as the sole delivery plan when `Task` is available.
+
+**Does not replace** Architect (strategy) or SME audit (final gate). PM/BA turns Strategy v2 into a **roadmap-shaped action plan**.
+
+## Placement
+
+```text
+Strategy v2 (post-Architect merge)
+  → PM/BA subagent generates action plan (roadmap)
+  → Parent light merge (scope / AC / layering check)
+  → SME audit subagent
+  → Present to human
+```
+
+Skip only when go/no-go is **NO-GO** with no child strategy (parent emits NO-GO stub). If planning the **blocker** instead, run PM/BA on that blocker’s Strategy v2.
+
+**Do not invoke** if Strategy is still `UNSOUND` or Architect returned `BLOCKED: missing stack` without resolution.
+
+## Role
+
+**Product Manager and Business Analyst (BA) engineer** for this PPT child slice.
+
+| Does                                                                        | Does not                                                               |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Phased roadmap + ordered `T#` WBS                                           | Re-architect or override Architect `incorrect` without `open_question` |
+| Map every child AC → tasks + DoD evidence                                   | Expand into sibling PPT work                                           |
+| Carry risks: mitigate→tasks, open_question→Human decisions, accept→residual | Claim SME `Audit: PASS`                                                |
+| Preserve Strategy v2 technical alignments (paths, contracts, non-goals)     | Invent green dependency readiness                                      |
+| Define milestones and what unblocks **Blocks** downstream                   | Implement code                                                         |
+
+## Parent: how to invoke
+
+1. Freeze **Strategy v2** (Architect SOUND or SOUND WITH GAPS with patches applied).
+2. Gather: child/epic ids, AC, OOS, go/no-go, dependency table, Architect verdict summary, current-state path bullets.
+3. Read this file; call `Task`:
+   - `subagent_type`: `generalPurpose`
+   - `model`: `inherit` (unless user named an allowed model)
+   - `description`: e.g. `PM BA action plan` (≤5 words)
+   - `run_in_background`: `false`
+   - `prompt`: filled template below (include Strategy v2 + template sections from [reference.md](reference.md))
+4. **Light merge:** check scope lock, AC coverage, layering (no business logic in API/web), risk carry-through. Fix only clear defects or send back once.
+5. Hand merged draft to SME audit ([audit-subagent.md](audit-subagent.md)).
+
+**Fallback:** if `Task` unavailable, parent writes the plan using the same output schema and labels `Action plan: … (parent fallback — PM/BA subagent unavailable)`.
+
+## Subagent prompt template
+
+Copy into the `Task` `prompt` parameter. Replace `{{…}}`.
+
+```text
+You are a Product Manager and Business Analyst (BA) engineer for the save-ma-money monorepo.
+
+Role: turn an Architect-approved Strategy v2 into a roadmap-oriented action plan for ONE child issue. You did NOT invent the architecture. Preserve technical alignments from the strategy. Do not implement code. Do not perform the SME audit.
+
+## Context
+- Child issue: {{CHILD_ISSUE_URL_OR_NUMBER}} ({{CHILD_TITLE}})
+- Parent epic: {{EPIC_URL_OR_NUMBER}} ({{EPIC_TITLE}})
+- Domain / step: {{DOMAIN}} / {{STEP}}
+- Go/no-go: {{GO|GO_WITH_HOLDS|NO_GO}}
+- Holds (if any): {{HOLDS_OR_NONE}}
+- Dependency readiness: {{DEP_TABLE_OR_BULLETS}}
+- Architect verdict / role: {{ARCHITECT_VERDICT}} / {{STACK_SPECIALIZATION}}
+- Workspace root: {{REPO_ROOT}}
+
+## Child acceptance criteria & out of scope
+AC:
+{{CHILD_AC_LIST}}
+
+Out of scope:
+{{CHILD_OOS}}
+
+## Strategy v2 (source of truth for technical alignment)
+{{FULL_STRATEGY_V2_MARKDOWN}}
+
+## Current-state findings (from planner)
+{{PATH_BULLETS}}
+
+## Monorepo constraints
+- Child = deliverable boundary; epic = context only.
+- Model owns domain; API = auth + schema map + owner scoping; web = UI + TanStack Query + BFF cookies.
+- B0 Docker Postgres default acceptance.
+- Prefer concrete paths/names from Strategy v2; label assumptions.
+- No secrets, tokens, or credentialed URLs.
+
+## Required work
+1. If go/no-go is NO-GO or Strategy is missing/unsound, return BLOCKED with reason — do not fabricate a full child WBS.
+2. Produce a roadmap-like plan: phases/milestones, then ordered tasks T1..Tn.
+3. Map every child AC to tasks + DoD evidence; map each Strategy S# to at least one task or an explicit deferral.
+4. Fold the risk register: mitigate→T#; open_question→Human decisions; accept→residual.
+5. Stay in-child scope; name deferred sibling PPT work explicitly.
+6. Follow the output format below (align with plan-issue reference action-plan sections).
+
+## Output format (mandatory)
+
+# PM/BA action plan
+
+**Verdict:** READY_FOR_SME_AUDIT | READY_WITH_HOLDS | BLOCKED
+**Author role:** Product Manager / BA engineer (subagent)
+
+## Roadmap
+| Phase | Milestone | Outcome | Exit criteria |
+| ----- | --------- | ------- | ------------- |
+| P0 | … | … | … |
+| P1 | … | … | … |
+
+## Go / no-go (echo)
+**Verdict:** {{echo}}
+**Holds:** …
+
+## 1. Objective
+…
+
+## 2. Prerequisites / blockers
+…
+
+## 3. Current-state findings
+(reuse/refine planner bullets; cite paths)
+
+## 4. Target design
+(align to Strategy v2 — do not redesign)
+
+## 5. Risk register & human decisions
+| ID | Risk | Disposition | Mitigation / question / accept | Owner |
+| -- | ---- | ----------- | ------------------------------ | ----- |
+| R# | … | … | … | T# / Human |
+
+### Human decisions
+| ID | Question | Options / default | Needed by |
+| -- | -------- | ----------------- | --------- |
+| R# | … | … | before T# |
+
+## 6. Work breakdown
+| Task | Phase | Work | Files / surface | AC / S# | Size | Risks |
+| ---- | ----- | ---- | --------------- | ------- | ---- | ----- |
+| T1 | P0 | … | `…` | AC1, S1 | S/M/L | R1 |
+
+## 7. Test plan
+…
+
+## 8. Definition of done
+| AC | Evidence |
+| -- | -------- |
+| … | … |
+
+## 9. Downstream handoff
+(what Blocks consumers need)
+
+## Notes for planner
+- Short bullets; flag any place Strategy was ambiguous.
+```
+
+## Parent: interpreting results
+
+| Verdict               | Parent action                                                                     |
+| --------------------- | --------------------------------------------------------------------------------- |
+| `READY_FOR_SME_AUDIT` | Light merge → SME audit                                                           |
+| `READY_WITH_HOLDS`    | Keep holds visible; merge → SME audit (or resolve trivial holds first)            |
+| `BLOCKED`             | Do not claim a full plan; fix strategy/deps or switch to NO-GO / blocker planning |
+
+If PM/BA proposes layering that contradicts Strategy v2 / Architect, reject in light merge or convert to `open_question` — do not silently accept a re-architecture.

--- a/.cursor/skills/plan-issue/reference.md
+++ b/.cursor/skills/plan-issue/reference.md
@@ -1,0 +1,194 @@
+# plan-issue — reference
+
+## Risk register (Strategy → action plan)
+
+Create during **Strategy v1**, refine in **v2**, copy into the action plan. Every row needs a disposition.
+
+```markdown
+### Risk register
+
+| ID  | Risk | Impact | Disposition                         | Mitigation / open question / accept note | Owner (task or human) |
+| --- | ---- | ------ | ----------------------------------- | ---------------------------------------- | --------------------- |
+| R1  | …    | H/M/L  | mitigate \| open_question \| accept | …                                        | T3 / Human before T1  |
+```
+
+**Rules**
+
+- `mitigate` → owner is a work-breakdown task id (`T#`) that implements the mitigation.
+- `open_question` → owner is **Human**; state when it must be answered (e.g. before T1, before merge).
+- `accept` → note residual impact + deferral PPT/issue if deferred.
+- Do not drop Strategy risks when writing the action plan; only reclassify with a reason.
+
+## Detailed action-plan template
+
+**Author:** PM/BA subagent ([pm-ba-subagent.md](pm-ba-subagent.md)), then parent light merge. Use when go/no-go is **GO** or **GO WITH HOLDS**.
+
+```markdown
+# Plan: {semantic}/PPT-{NNN} — #{issue}
+
+## Go / no-go
+
+**Verdict:** GO | GO WITH HOLDS | NO-GO
+**Child:** #{n} · **Epic:** #{e}
+
+### Dependency readiness
+
+| Dep | PPT     | Issue state | Repo evidence | Status                        |
+| --- | ------- | ----------- | ------------- | ----------------------------- |
+| …   | PPT-0xx | OPEN/CLOSED | `path/…`      | ready/partial/blocked/unknown |
+
+**Holds (if any):** …
+
+## Roadmap (PM/BA)
+
+| Phase | Milestone | Outcome | Exit criteria |
+| ----- | --------- | ------- | ------------- |
+| P0    | …         | …       | …             |
+
+**PM/BA verdict:** READY_FOR_SME_AUDIT | READY_WITH_HOLDS
+**Author:** Product Manager / BA engineer (Task generalPurpose)
+
+## 1. Objective
+
+One paragraph: problem → outcome for this PPT.
+
+## 2. Prerequisites / blockers
+
+Checklist; stop conditions if a dep regresses.
+
+## 3. Current-state findings
+
+Bullets with file paths.
+
+## 4. Target design
+
+- Surface (routes/schemas **or** model tables/services **or** web screens)
+- Service / layer calls and ownership rules
+- Error → HTTP (or UI) mapping when relevant
+- OpenAPI / docs impact for **this** step vs deferred siblings
+
+## 4b. Architect review (Strategy gate)
+
+**Verdict:** SOUND | SOUND WITH GAPS | UNSOUND | BLOCKED: missing stack
+**Architect role:** {stack specialization} (Task generalPurpose)
+**Strategy points:** S# validation summarized or linked from architect report
+
+## 5. Risk register & human decisions
+
+(Paste Strategy v2 register, including Architect risk addenda; PM/BA may refine owners.)
+
+### Human decisions (from `open_question` rows)
+
+| ID  | Question | Options / default | Needed by |
+| --- | -------- | ----------------- | --------- |
+| R#  | …        | …                 | before T# |
+
+### Residual (`accept`)
+
+- R#: … (deferred to #… / PPT-… if any)
+
+## 6. Work breakdown (action plan)
+
+Ordered tasks by roadmap phase: files · AC/`S#` · complexity (S/M/L) · linked `R#`.
+
+| Task | Phase | Work | Files | AC / S# | Size  | Risks addressed |
+| ---- | ----- | ---- | ----- | ------- | ----- | --------------- |
+| T1   | P0    | …    | `…`   | …       | S/M/L | R1              |
+
+## 7. Test plan
+
+Unit/API/e2e as appropriate; B0 how-to; what is deferred to a later PPT; tests that cover `mitigate` risks.
+
+## 8. Definition of done
+
+Map each child acceptance criterion → concrete evidence (tests, endpoints, migrations).
+Confirm each `mitigate` risk has evidence or an explicit residual note.
+
+## 9. Downstream handoff
+
+What **Blocks** consumers need (stable contracts, OpenAPI fields, fixtures).
+
+## 10. Pre-presentation audit
+
+**Result:** PASS | PASS WITH HOLDS
+**Auditor:** SME/technical-expert subagent (Task generalPurpose)
+**Holds (if any):** …
+```
+
+## Pre-presentation audit (detail)
+
+**Required:** run via SME/technical-expert **subagent** — see [audit-subagent.md](audit-subagent.md). Parent must not be the sole auditor. Private revise → subagent audit → (optional one re-audit) → then present.
+
+| ID  | Check             | Fail if                                                                       |
+| --- | ----------------- | ----------------------------------------------------------------------------- |
+| A   | Verdict integrity | Go/no-go contradicts dependency statuses or invents `ready`                   |
+| B   | Scope lock        | Tasks belong to a sibling PPT or epic close-out, not this child               |
+| C   | AC coverage       | Any child acceptance criterion lacks a task and DoD evidence line             |
+| D   | Dep contracts     | Plan calls missing service/schema/migration without a hold or NO-GO           |
+| E   | Layering          | Business rules placed in API routers or TypeScript                            |
+| F   | Tenancy / auth    | List/get/mutate endpoints omit owner scoping discussion                       |
+| G   | Tests & B0        | No tests, or “test later” without naming the deferral issue                   |
+| H   | Concrete paths    | Vague verbs only (“wire up”, “add endpoints”) with no paths/names             |
+| I   | Assumptions       | Unlabeled guesses treated as repo facts                                       |
+| J   | Secrets           | Any credential, token, or private URL in the draft                            |
+| K   | Iteration trace   | Critique fixed something in v2 but final plan still has the old gap           |
+| L   | Risk register     | Strategy risks missing, or any risk lacks mitigate / open_question / accept   |
+| M   | Risk → action     | `mitigate` not linked to a task; `open_question` missing from Human decisions |
+| N   | Human-ready       | Reader cannot tell verdict, open questions, residual risks, or first task     |
+
+**Pass rule:** subagent returns `PASS`, or `PASS WITH HOLDS` / remaining fails listed under **Audit holds** with a human decision needed. Do not claim PASS after a subagent `FAIL`.
+
+## NO-GO stub
+
+```markdown
+# Plan blocked: #{child} waiting on #{blocker}
+
+## Go / no-go
+
+**Verdict:** NO-GO
+
+### Dependency readiness
+
+(table as above)
+
+## Why blocked
+
+…
+
+## Risks reinforcing the block
+
+| ID  | Risk | Disposition                          | Note |
+| --- | ---- | ------------------------------------ | ---- |
+| R1  | …    | open_question \| mitigate on blocker | …    |
+
+## Recommended next step
+
+Plan or implement #{blocker} ({PPT}) first.
+
+## Optional — plan for blocker only
+
+(same action-plan template scoped to the blocker, including its risk register)
+
+## Pre-presentation audit
+
+**Result:** PASS | PASS WITH HOLDS
+**Auditor:** SME/technical-expert subagent (Task generalPurpose)
+**Holds (if any):** …
+```
+
+## Subagent gates (separation)
+
+| Gate      | When                              | Role                          | Produces / validates                 |
+| --------- | --------------------------------- | ----------------------------- | ------------------------------------ |
+| Architect | After Strategy v1                 | Stack-specialized architect   | Each `S#` + fit → Strategy v2        |
+| PM/BA     | After Strategy v2                 | Product Manager / BA engineer | Roadmap + `T#` WBS + AC traceability |
+| SME audit | After PM/BA plan (+ parent merge) | Expert SME / technical expert | Checklist A–N + human readiness      |
+
+Details: [architect-subagent.md](architect-subagent.md), [pm-ba-subagent.md](pm-ba-subagent.md), [audit-subagent.md](audit-subagent.md).
+
+## Example trigger
+
+User: `/plan-issue` for https://github.com/Elmorralito/save-ma-money/issues/166
+Epic: https://github.com/Elmorralito/save-ma-money/issues/163
+
+Agent: fetch both → verify #165 → Strategy v1 → **Architect** → Strategy v2 → **PM/BA roadmap plan** → parent merge → **SME auditor** → present with all three gate results.

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -872,8 +872,8 @@ pre-commit run --all-files
 - Keep the branch current with `main` (`git fetch origin && git merge origin/main` — Branch sync CI gate)
 - Keep PR scope focused
 - Use the PR body template: [`.github/PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md)
-- New issues: use [`.github/ISSUE_TEMPLATE/`](./ISSUE_TEMPLATE/) (epic / program / child / bug); agent: [`.cursor/skills/create-issue/`](../.cursor/skills/create-issue/) (`/create-issue`)
-- Plan a child vs its epic before coding: [`.cursor/skills/plan-issue/`](../.cursor/skills/plan-issue/) (`/plan-issue`)
+- New issues: use [`.github/ISSUE_TEMPLATE/`](./ISSUE_TEMPLATE/) (epic / program / child / bug); agent: [`.cursor/skills/create-issue/`](../.cursor/skills/create-issue/) (`/create-issue`) — do not chain `/plan-issue`
+- Plan an existing child vs its epic (separate skill): [`.cursor/skills/plan-issue/`](../.cursor/skills/plan-issue/) (`/plan-issue`) — do not chain `/create-issue`
 
 Full agent-oriented checklist: [`.agents/AGENTS.md` — PR checklist](../.agents/AGENTS.md#pr-checklist).
 

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -872,7 +872,8 @@ pre-commit run --all-files
 - Keep the branch current with `main` (`git fetch origin && git merge origin/main` — Branch sync CI gate)
 - Keep PR scope focused
 - Use the PR body template: [`.github/PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md)
-- New issues: use [`.github/ISSUE_TEMPLATE/`](./ISSUE_TEMPLATE/) (epic / program / child / bug)
+- New issues: use [`.github/ISSUE_TEMPLATE/`](./ISSUE_TEMPLATE/) (epic / program / child / bug); agent: [`.cursor/skills/create-issue/`](../.cursor/skills/create-issue/) (`/create-issue`)
+- Plan a child vs its epic before coding: [`.cursor/skills/plan-issue/`](../.cursor/skills/plan-issue/) (`/plan-issue`)
 
 Full agent-oriented checklist: [`.agents/AGENTS.md` — PR checklist](../.agents/AGENTS.md#pr-checklist).
 

--- a/.github/ISSUE_TEMPLATE/03-child-issue.md
+++ b/.github/ISSUE_TEMPLATE/03-child-issue.md
@@ -11,6 +11,7 @@ Must link Parent epic. Keep scope to one step in the epic implementation order.
 Business logic stays in papita_txnsmodel; API children wire routers/schemas/deps only.
 Labels: apply the **parent epic’s** `EPIC: PPT-*` track label (do not create a label for this child’s PPT id).
 References: #42 children (#43–#50), e.g. #45 scaffold.
+Before implementing: Cursor `/plan-issue` (.cursor/skills/plan-issue/) vs Parent epic — dep go/no-go first.
 -->
 
 **Parent epic:** [#42](https://github.com/Elmorralito/save-ma-money/issues/42) · **Program:** [#28](https://github.com/Elmorralito/save-ma-money/issues/28) · **Step:** <!-- N --> · **PPT-{NNN}**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,3 +7,6 @@ contact_links:
   - name: Issue title conventions
     url: https://github.com/Elmorralito/save-ma-money/blob/main/.cursor/rules/gen-custom/github_issue_conventions.mdc
     about: "Title form: semantic/PPT-NNN: [domain] Title in sentence case."
+  - name: Plan a child issue (Cursor /plan-issue)
+    url: https://github.com/Elmorralito/save-ma-money/blob/main/.cursor/skills/plan-issue/SKILL.md
+    about: Dependency go/no-go, Architect → PM/BA roadmap → SME audit before implementing a child.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Each package has its own README with layer-specific setup, architecture, and ref
 | [`.strata/docs/ARCHITECTURE.md`](./.strata/docs/ARCHITECTURE.md)                         | Live implementation codemap (complements design doc)                                                                                                   |
 | [`.github/CI.md`](./.github/CI.md)                                                       | CI workflows, pre-commit, PR checklist                                                                                                                 |
 | [`AGENTS.md`](./.agents/AGENTS.md)                                                       | Agent and contributor operational guide                                                                                                                |
-| [`.cursor/skills/`](./.cursor/skills/)                                                   | Cursor agent skills — `/create-issue`, `/plan-issue`, PR descriptions ([index](./.cursor/README.md))                                                   |
+| [`.cursor/skills/`](./.cursor/skills/)                                                   | Cursor agent skills (independent) — `/create-issue`, `/plan-issue`, PR descriptions ([index](./.cursor/README.md))                                     |
 | [CHANGELOG.md](./CHANGELOG.md)                                                           | Issue tracker and merged PR summaries                                                                                                                  |
 
 **`ARCHITECTURE.md` parts (quick links):**

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Each package has its own README with layer-specific setup, architecture, and ref
 | [`.strata/docs/ARCHITECTURE.md`](./.strata/docs/ARCHITECTURE.md)                         | Live implementation codemap (complements design doc)                                                                                                   |
 | [`.github/CI.md`](./.github/CI.md)                                                       | CI workflows, pre-commit, PR checklist                                                                                                                 |
 | [`AGENTS.md`](./.agents/AGENTS.md)                                                       | Agent and contributor operational guide                                                                                                                |
+| [`.cursor/skills/`](./.cursor/skills/)                                                   | Cursor agent skills — `/create-issue`, `/plan-issue`, PR descriptions ([index](./.cursor/README.md))                                                   |
 | [CHANGELOG.md](./CHANGELOG.md)                                                           | Issue tracker and merged PR summaries                                                                                                                  |
 
 **`ARCHITECTURE.md` parts (quick links):**

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -4,7 +4,12 @@ Canonical in-repo copies of GitHub issue bodies and decision briefs for the Papi
 
 **New GitHub issues:** use the chooser templates under [`.github/ISSUE_TEMPLATE/`](../../.github/ISSUE_TEMPLATE/) — epic (`01-epic.md`), program issue (`02-program-issue.md`), child under epic (`03-child-issue.md`), bug (`04-bug-report.md`). Shape references: [#42](https://github.com/Elmorralito/save-ma-money/issues/42), [#52](https://github.com/Elmorralito/save-ma-money/issues/52), [#89](https://github.com/Elmorralito/save-ma-money/issues/89), [#93](https://github.com/Elmorralito/save-ma-money/issues/93), children of #42.
 
-**Agent skills (Cursor):** file issues with [`.cursor/skills/create-issue/`](../../.cursor/skills/create-issue/) (`/create-issue`); plan a child against its epic (dependency go/no-go → Architect → PM/BA → SME audit) with [`.cursor/skills/plan-issue/`](../../.cursor/skills/plan-issue/) (`/plan-issue`). Title/body conventions: [`.cursor/rules/gen-custom/github_issue_conventions.mdc`](../../.cursor/rules/gen-custom/github_issue_conventions.mdc).
+**Agent skills (Cursor, independent — do not chain):**
+
+- File issues: [`.cursor/skills/create-issue/`](../../.cursor/skills/create-issue/) (`/create-issue`)
+- Plan an existing child vs epic: [`.cursor/skills/plan-issue/`](../../.cursor/skills/plan-issue/) (`/plan-issue`)
+
+Title/body conventions: [`.cursor/rules/gen-custom/github_issue_conventions.mdc`](../../.cursor/rules/gen-custom/github_issue_conventions.mdc).
 
 Live issue status (open/closed, closing PR summaries) is mirrored in the root [CHANGELOG.md](../../CHANGELOG.md), updated by the [Auto Updates](../../.github/workflows/auto-updates.yml) workflow.
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -4,17 +4,21 @@ Canonical in-repo copies of GitHub issue bodies and decision briefs for the Papi
 
 **New GitHub issues:** use the chooser templates under [`.github/ISSUE_TEMPLATE/`](../../.github/ISSUE_TEMPLATE/) — epic (`01-epic.md`), program issue (`02-program-issue.md`), child under epic (`03-child-issue.md`), bug (`04-bug-report.md`). Shape references: [#42](https://github.com/Elmorralito/save-ma-money/issues/42), [#52](https://github.com/Elmorralito/save-ma-money/issues/52), [#89](https://github.com/Elmorralito/save-ma-money/issues/89), [#93](https://github.com/Elmorralito/save-ma-money/issues/93), children of #42.
 
+**Agent skills (Cursor):** file issues with [`.cursor/skills/create-issue/`](../../.cursor/skills/create-issue/) (`/create-issue`); plan a child against its epic (dependency go/no-go → Architect → PM/BA → SME audit) with [`.cursor/skills/plan-issue/`](../../.cursor/skills/plan-issue/) (`/plan-issue`). Title/body conventions: [`.cursor/rules/gen-custom/github_issue_conventions.mdc`](../../.cursor/rules/gen-custom/github_issue_conventions.mdc).
+
 Live issue status (open/closed, closing PR summaries) is mirrored in the root [CHANGELOG.md](../../CHANGELOG.md), updated by the [Auto Updates](../../.github/workflows/auto-updates.yml) workflow.
 
 **Operator / design SSOT (not duplicated here):**
 
-| Doc                                                        | Role                                                   |
-| ---------------------------------------------------------- | ------------------------------------------------------ |
-| [`modules/api/README.md`](../../modules/api/README.md)     | API reference, setup, endpoint catalog                 |
-| [`modules/web/README.md`](../../modules/web/README.md)     | Web SPA setup (Node 22 + pnpm; no JS domain logic)     |
-| [`docs/design/ARCHITECTURE.md`](../design/ARCHITECTURE.md) | Design body (schema, mapping, auth Part VI, migration) |
-| [`docs/design/README.md`](../design/README.md)             | Design program index + gates                           |
-| [`environments/README.md`](../../environments/README.md)   | `PAPITA_ENV` / secrets layout                          |
+| Doc                                                              | Role                                                             |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------- |
+| [`modules/api/README.md`](../../modules/api/README.md)           | API reference, setup, endpoint catalog                           |
+| [`modules/web/README.md`](../../modules/web/README.md)           | Web SPA setup (Node 22 + pnpm; no JS domain logic)               |
+| [`docs/design/ARCHITECTURE.md`](../design/ARCHITECTURE.md)       | Design body (schema, mapping, auth Part VI, migration)           |
+| [`docs/design/README.md`](../design/README.md)                   | Design program index + gates                                     |
+| [`environments/README.md`](../../environments/README.md)         | `PAPITA_ENV` / secrets layout                                    |
+| [`.cursor/AGENTS.md`](../../.cursor/AGENTS.md)                   | Agent ops + Cursor skills index (`/create-issue`, `/plan-issue`) |
+| [`.cursor/skills/plan-issue/`](../../.cursor/skills/plan-issue/) | Plan child issues vs epic before implementation                  |
 
 ## Table of contents
 


### PR DESCRIPTION
**Branch:** `chore/plan-issue-cursor-skill` · **Base:** `main` · **1 commit** · **9 files**

**Suggested title:** `chore(cursor): add /plan-issue skill with Architect, PM/BA, and SME gates`

## Summary

Adds a repo Cursor skill (`/plan-issue`) so agents can plan a child GitHub issue against its parent epic with dependency go/no-go, a stack-specialized Architect strategy review, a PM/BA roadmap action plan, and an independent SME pre-presentation audit before showing the plan to a human. Indexes the skill from AGENTS, README, and conventions next to `create-issue` / `pr-description`.

## Out of scope / Highlights

**Out of scope**

- No production API/model/web runtime changes
- Does not implement issue work (plan-only skill)
- No new PPT program issue filed for this tooling

**Highlights**

- Three `Task`/`generalPurpose` gates with distinct roles (Architect → PM/BA → SME)
- Explicit dependency readiness before strategy/action planning
- Fallbacks documented when subagents are unavailable

## Changes

**Cursor skills / agent ops**

- New `.cursor/skills/plan-issue/` workflow: intake, Depends on readiness, Strategy v1→Architect→v2, PM/BA WBS, SME A–N audit
- Supporting prompt templates: `architect-subagent.md`, `pm-ba-subagent.md`, `audit-subagent.md`, `reference.md`
- Wired into `.cursor/AGENTS.md`, `.cursor/README.md`, `github_issue_conventions.mdc`, `project_adapters.mdc`

## File changes

<details>
<summary>File changes (9 files)</summary>

```
 .cursor/AGENTS.md                                  |   3 +-
 .cursor/README.md                                  |   1 +
 .cursor/rules/gen-custom/github_issue_conventions.mdc  |   1 +
 .cursor/rules/gen-custom/project_adapters.mdc      |   1 +
 .cursor/skills/plan-issue/SKILL.md                 | 262 +++++++++++++++++++++
 .cursor/skills/plan-issue/architect-subagent.md    | 139 +++++++++++
 .cursor/skills/plan-issue/audit-subagent.md        | 104 ++++++++
 .cursor/skills/plan-issue/pm-ba-subagent.md        | 166 +++++++++++++
 .cursor/skills/plan-issue/reference.md             | 194 +++++++++++++++
 9 files changed, 870 insertions(+), 1 deletion(-)
```

</details>

## Commits

- `63365cd` chore(cursor): add /plan-issue skill with Architect, PM/BA, and SME gates

## Checks, tests, and validation already done

- Local pre-commit on commit — pass (trailing-whitespace + prettier auto-fixed then re-committed)
- Rebase onto `origin/main` — already up to date
- CI on this PR — not yet observed at create time

## QA / test plan

- [ ] Skim `/plan-issue` SKILL.md progress checklist for clarity
- [ ] Confirm skill discovery from AGENTS / README / project_adapters links
- [ ] Optional: run `/plan-issue` on a sample child+epic and confirm Architect → PM/BA → SME order

## Risks

> [!CAUTION]
>
> ### Risks
>
> - None identified (docs/agent-skill only; no runtime deploy path)

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - Subagent gates require Cursor `Task`; skill documents parent fallbacks if unavailable
> - Skill quality depends on issue bodies having accurate Depends on / Blocks links

## References

- Skill path: `.cursor/skills/plan-issue/`
- Related skills: `.cursor/skills/create-issue/`, `.cursor/skills/pr-description/`

Made with [Cursor](https://cursor.com)