### PR TITLE
chore(agents): symlink project Cursor skills into .agents/skills

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,14 +1,40 @@
 # Agent adapters — symlink layout
 
-This directory exposes agent instruction files for Codex, Strata, and other multi-agent tools. **Do not edit copies here.**
+This directory exposes agent instruction files and shared project skills for Codex,
+Strata, Claude Code, and other multi-agent tools. **Do not edit copies here** for
+anything that is symlinked to `.cursor/`.
 
-| File        | Target                 |
+## Adapter files
+
+| Path        | Target                 |
 | ----------- | ---------------------- |
 | `AGENTS.md` | `../.cursor/AGENTS.md` |
 | `CLAUDE.md` | `../.cursor/CLAUDE.md` |
 
 **Canonical source:** [`.cursor/AGENTS.md`](../.cursor/AGENTS.md) and [`.cursor/CLAUDE.md`](../.cursor/CLAUDE.md).
 
+## Skills
+
+| Path under `.agents/skills/`                             | Kind                        | Notes                                       |
+| -------------------------------------------------------- | --------------------------- | ------------------------------------------- |
+| `create-issue` → `../../.cursor/skills/create-issue`     | Symlink                     | File GitHub issues (`/create-issue`)        |
+| `plan-issue` → `../../.cursor/skills/plan-issue`         | Symlink                     | Plan existing child vs epic (`/plan-issue`) |
+| `pr-description` → `../../.cursor/skills/pr-description` | Symlink                     | PR body drafts                              |
+| `supabase/` (local)                                      | Marketplace / local install | Gitignored — not committed                  |
+| `supabase-postgres-best-practices/` (local)              | Marketplace / local install | Gitignored — not committed                  |
+
+**Canonical source for the three project skills:** [`.cursor/skills/`](../.cursor/skills/). Edit only there; `.agents/skills/{create,plan,pr}-*` are committed symlinks. Other `.agents/skills/*` installs stay local (see root `.gitignore`).
+
+Skills are **independent** — do not chain `/create-issue` and `/plan-issue`.
+
+**Runtime notes**
+
+- Cursor loads skills from `.cursor/skills/` (and may also see `.agents/skills/` depending on product config).
+- Codex / Claude Code / other Agents tooling that reads `.agents/skills/` gets the same project skill content via symlink.
+- Cursor-only APIs inside a skill (e.g. `Task` subagents in `/plan-issue`) use the skill’s documented **parent fallback** when those APIs are unavailable.
+
+## Strata / Cursor
+
 **Strata:** `strata_check.sh` validates `.agents/AGENTS.md` and `.agents/CLAUDE.md`. Strict pairing accepts `.agents/**`, `.cursor/AGENTS.md`, `.cursor/CLAUDE.md`, or `.strata/**` alongside `modules/**` changes.
 
-**Cursor:** Code-style rules live separately in `.cursor/rules/gen-custom/`.
+**Cursor:** Code-style rules live separately in `.cursor/rules/gen-custom/`. Skill index: [`.cursor/README.md`](../.cursor/README.md).

--- a/.agents/skills/create-issue
+++ b/.agents/skills/create-issue
@@ -1,0 +1,1 @@
+../../.cursor/skills/create-issue

--- a/.agents/skills/plan-issue
+++ b/.agents/skills/plan-issue
@@ -1,0 +1,1 @@
+../../.cursor/skills/plan-issue

--- a/.agents/skills/pr-description
+++ b/.agents/skills/pr-description
@@ -1,0 +1,1 @@
+../../.cursor/skills/pr-description

--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -23,6 +23,11 @@ Code-style enforcement stays in [`.cursor/rules/gen-custom/`](rules/gen-custom/)
 
 ### Repo Cursor skills
 
+Canonical content lives under [`.cursor/skills/`](skills/). The same three project
+skills are **symlinked** into [`.agents/skills/`](../.agents/skills/) for Codex /
+Agents discovery (see [`.agents/README.md`](../.agents/README.md)). Native Supabase
+skills stay only under `.agents/skills/`.
+
 Skills are **independent** — invoke only the one the user asked for; do not chain
 `/create-issue` and `/plan-issue`.
 
@@ -32,7 +37,7 @@ Skills are **independent** — invoke only the one the user asked for; do not ch
 | [`plan-issue/`](skills/plan-issue/)         | `/plan-issue`   | Plan an existing child vs its epic: dep go/no-go → Architect → PM/BA roadmap → SME audit             |
 | [`pr-description/`](skills/pr-description/) | (PR body draft) | Fill [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) from full branch diff |
 
-Index also: [`.cursor/README.md`](README.md) · rules: [`project_adapters.mdc`](rules/gen-custom/project_adapters.mdc) · [`github_issue_conventions.mdc`](rules/gen-custom/github_issue_conventions.mdc).
+Index also: [`.cursor/README.md`](README.md) · [`.agents/README.md`](../.agents/README.md) · rules: [`project_adapters.mdc`](rules/gen-custom/project_adapters.mdc) · [`github_issue_conventions.mdc`](rules/gen-custom/github_issue_conventions.mdc).
 
 ---
 
@@ -84,7 +89,7 @@ save-ma-money/
 ├── docker/                     # README (GHCR SSOT PPT-067), database/, api/, redis/, web/, docker-compose.yml
 ├── docs/design/ · docs/issues/ # human design program (PPT-031) + web epic Part VII
 ├── .cursor/                    # adapters, gen-custom rules, skills
-├── .agents/                    # symlinks to .cursor/ adapters (Codex)
+├── .agents/                    # symlinks to .cursor/ adapters + skills (Codex/Agents)
 ├── .strata/                    # agent memory (hot/warm/cold tiers)
 └── .github/workflows/          # CI (quality, security, migrations, strata, web-ci, publish)
 ```

--- a/.cursor/CLAUDE.md
+++ b/.cursor/CLAUDE.md
@@ -21,7 +21,7 @@ Project memory is repo-owned under `.strata/` (strata format, `layout_version: 3
 | Design docs   | `docs/design/` (PPT-031 program), `docs/issues/` (briefs incl. PPT-046 Part VII)                                                                                                                                                   |
 | Agent memory  | `.strata/` — use strata plugin commands below                                                                                                                                                                                      |
 | Adapters      | Canonical: `.cursor/AGENTS.md` + `.cursor/CLAUDE.md`; Strata validates `.agents/` symlinks                                                                                                                                         |
-| Cursor skills | Independent: `/create-issue` **or** `/plan-issue` (do not chain); PR body via `.cursor/skills/` — [AGENTS.md § Repo Cursor skills](AGENTS.md#repo-cursor-skills)                                                                   |
+| Cursor skills | Canonical `.cursor/skills/`; mirrored at `.agents/skills/` via symlink — [AGENTS.md § Repo Cursor skills](AGENTS.md#repo-cursor-skills) · [`.agents/README.md`](../.agents/README.md)                                              |
 
 ---
 

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -11,7 +11,7 @@ Agent operational instructions are **canonical in this directory**.
 | `skills/plan-issue/`     | `/plan-issue` — plan existing child vs epic; Architect → PM/BA → SME (isolated)               |
 | `skills/pr-description/` | PR body drafts from [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) |
 
-**Strata / Codex entry point:** [`.agents/AGENTS.md`](../.agents/AGENTS.md) and [`.agents/CLAUDE.md`](../.agents/CLAUDE.md) symlink here. `strata_check.sh` validates those paths. Edit files in **`.cursor/`** only.
+**Strata / Codex entry point:** [`.agents/AGENTS.md`](../.agents/AGENTS.md) and [`.agents/CLAUDE.md`](../.agents/CLAUDE.md) symlink here. Project skills are also symlinked at [`.agents/skills/{create,plan,pr}-*`](../.agents/skills/) → `.cursor/skills/` (see [`.agents/README.md`](../.agents/README.md)). `strata_check.sh` validates adapter paths. Edit skill bodies in **`.cursor/skills/`** only.
 
 - **MCP servers:** `mcp.json` when present (validated by `mcp-config-validate` pre-commit)
 - **Strata memory:** [`.strata/`](../.strata/) — see `AGENTS.md` and [`.strata/MANIFEST.md`](../.strata/MANIFEST.md)

--- a/.cursor/rules/gen-custom/project_adapters.mdc
+++ b/.cursor/rules/gen-custom/project_adapters.mdc
@@ -8,11 +8,11 @@ NOTE: Operational agent instructions are **canonical under `.cursor/`**:
 - [`.cursor/AGENTS.md`](../../.cursor/AGENTS.md) — build, test, architecture, API status, PR checklist
 - [`.cursor/CLAUDE.md`](../../.cursor/CLAUDE.md) — thin Claude adapter → AGENTS.md
 
-Strata-validated symlinks: [`.agents/AGENTS.md`](../../.agents/AGENTS.md) → `.cursor/AGENTS.md` (same for `CLAUDE.md`).
+Strata-validated symlinks: [`.agents/AGENTS.md`](../../.agents/AGENTS.md) → `.cursor/AGENTS.md` (same for `CLAUDE.md`). Project skills: [`.agents/skills/create-issue`](../../.agents/skills/create-issue) (etc.) → [`.cursor/skills/`](../skills/) — see [`.agents/README.md`](../../.agents/README.md).
 
 **Do not duplicate or edit adapter content in this rule file.** Code-style enforcement stays in sibling `gen-custom/*.mdc` rules. Project memory and routing live in [`.strata/MANIFEST.md`](../../.strata/MANIFEST.md).
 
-### Repo skills (under `.cursor/skills/`)
+### Repo skills (canonical under `.cursor/skills/`; symlinked into `.agents/skills/`)
 
 | Skill | Use when |
 | ----- | -------- |
@@ -25,7 +25,7 @@ Strata-validated symlinks: [`.agents/AGENTS.md`](../../.agents/AGENTS.md) → `.
 | Change | Update |
 | ------ | ------ |
 | API routers, auth, setup, CI, PR checklist | `.cursor/AGENTS.md` (+ thin notes in `CLAUDE.md` if needed) |
-| New/changed Cursor skills under `.cursor/skills/` | `.cursor/AGENTS.md` skills table, `.cursor/README.md`, `project_adapters.mdc`, `github_issue_conventions.mdc` when issue-related; `docs/issues/README.md` / root `README.md` docs hub when operators should discover them |
+| New/changed Cursor skills under `.cursor/skills/` | Edit under `.cursor/skills/` only; ensure `.agents/skills/<name>` symlink exists (see `.agents/README.md`); update `.cursor/AGENTS.md` skills table, `.cursor/README.md`, `project_adapters.mdc`, `github_issue_conventions.mdc` when issue-related; docs hubs when operators should discover them |
 | Code-style / structure / migrations / issue titles | Matching `gen-custom/*.mdc` |
 | Architecture decisions, backlog, learnings | `.strata/` via `/strata:capture` / `/strata:save` |
 | `modules/**` or `bin/**` code | Pair with `.strata/` (strata strict mode) |

--- a/.cursor/rules/gen-custom/project_structure.mdc
+++ b/.cursor/rules/gen-custom/project_structure.mdc
@@ -117,7 +117,7 @@ Canonical B0 API start: `make api-up` (uvicorn in-container). nginx SPA: `make w
 | Design program | `docs/design/` (`ARCHITECTURE.md`, `README.md`) |
 | Issue briefs | `docs/issues/README.md` (merged SSOT; no separate PPT-044/045 brief files) |
 | Agent ops | `.cursor/AGENTS.md` |
-| Agent Cursor skills | `.cursor/skills/` (`create-issue`, `plan-issue`, `pr-description`) — index in `.cursor/README.md` / `project_adapters.mdc` |
+| Agent Cursor skills | `.cursor/skills/` (`create-issue`, `plan-issue`, `pr-description`); symlinked at `.agents/skills/` — see `.agents/README.md` |
 | Agent memory | `.strata/MANIFEST.md` |
 
 ### Dependency Management

--- a/.cursor/skills/plan-issue/SKILL.md
+++ b/.cursor/skills/plan-issue/SKILL.md
@@ -21,6 +21,7 @@ This skill lives at `.cursor/skills/plan-issue/` (repo-only).
 as part of this skill. Plan only against an existing child + epic the user names.
 
 **Indexed from:** [`.cursor/AGENTS.md`](../../AGENTS.md) · [`.cursor/README.md`](../../README.md) ·
+[`.agents/skills/plan-issue`](../../../.agents/skills/plan-issue) (symlink) ·
 [`project_adapters.mdc`](../../rules/gen-custom/project_adapters.mdc) ·
 [`github_issue_conventions.mdc`](../../rules/gen-custom/github_issue_conventions.mdc) ·
 [`docs/issues/README.md`](../../../docs/issues/README.md).

--- a/.gitignore
+++ b/.gitignore
@@ -62,8 +62,12 @@ docs/coverage-codecov-sync.xml
 duckdb:*
 *.duckdb
 
-# Local agent skill installs (Cursor / strata adapters); keep AGENTS.md / CLAUDE.md
-.agents/skills/
+# Local/marketplace agent skill installs under .agents/skills/ (e.g. supabase).
+# Committed project skill symlinks → .cursor/skills/ are force-included below.
+.agents/skills/*
+!.agents/skills/create-issue
+!.agents/skills/plan-issue
+!.agents/skills/pr-description
 skills-lock.json
 
 .data/

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Each package has its own README with layer-specific setup, architecture, and ref
 | [`.strata/docs/ARCHITECTURE.md`](./.strata/docs/ARCHITECTURE.md)                         | Live implementation codemap (complements design doc)                                                                                                   |
 | [`.github/CI.md`](./.github/CI.md)                                                       | CI workflows, pre-commit, PR checklist                                                                                                                 |
 | [`AGENTS.md`](./.agents/AGENTS.md)                                                       | Agent and contributor operational guide                                                                                                                |
-| [`.cursor/skills/`](./.cursor/skills/)                                                   | Cursor agent skills (independent) — `/create-issue`, `/plan-issue`, PR descriptions ([index](./.cursor/README.md))                                     |
+| [`.cursor/skills/`](./.cursor/skills/)                                                   | Project agent skills (independent) — also via [`.agents/skills/`](./.agents/skills/) symlinks ([`.agents/README.md`](./.agents/README.md))             |
 | [CHANGELOG.md](./CHANGELOG.md)                                                           | Issue tracker and merged PR summaries                                                                                                                  |
 
 **`ARCHITECTURE.md` parts (quick links):**


### PR DESCRIPTION
**Branch:** `chore/agents-cursor-skills-symlinks` · **Base:** `main`

## Summary

Makes project Cursor skills (`create-issue`, `plan-issue`, `pr-description`) discoverable under `.agents/skills/` via symlinks to `.cursor/skills/`, matching the AGENTS/CLAUDE adapter pattern. Marketplace skills (e.g. supabase) stay local/gitignored.

## Changes

- Symlinks: `.agents/skills/{create-issue,plan-issue,pr-description}` → `../../.cursor/skills/...`
- `.gitignore`: allow those three; continue ignoring other `.agents/skills/*`
- Docs: `.agents/README.md`, AGENTS, CLAUDE, project_adapters, project_structure, root README

## Notes

- Skills remain independent (do not chain create-issue / plan-issue).
- Cursor-only APIs (e.g. `Task` in `/plan-issue`) still use each skill’s documented parent fallback outside Cursor.

## QA

- [x] `git ls-files -s` shows mode `120000` (symlink) for the three paths
- [x] `test -f .agents/skills/plan-issue/SKILL.md` resolves through symlink

Made with [Cursor](https://cursor.com)