### PR TITLE
feat/PPT-078: [model] Provenance schema and ingestion upsert bridge

### DIFF
--- a/.strata/memory/MEMORY.md
+++ b/.strata/memory/MEMORY.md
@@ -4,9 +4,9 @@ Pure hot index: live pointers + the generated rules-by-trigger table. Keep ≤80
 
 ## Live pointers
 
-- [Project state](project_state.md) — PPT-070 / #163 closed (dues #164–#168 on main); see Part VIII index.
-- [Active issues](../issues/ACTIVE.md) — refresh against GitHub; prefer project_state for in-flight PR.
-- [Open backlog](../issues/OPEN.md) — PPT-070 children when starting dues work.
+- [Project state](project_state.md) — PPT-078 / #172 in progress (provenance bridge); PPT-070 closed.
+- [Active issues](../issues/ACTIVE.md) — prefer project_state for in-flight PR (PPT-078).
+- [Open backlog](../issues/OPEN.md) — PPT-076 epic children after #172.
 - Closed work — GitHub issues + `git log` (no `.strata/issues/archive/`).
 
 ## Rules by trigger
@@ -24,3 +24,4 @@ Pure hot index: live pointers + the generated rules-by-trigger table. Keep ≤80
 | Add transactions/movements/bulk UI in `modules/web`          | [web-ledger-ui-no-domain.md](learnings/web-ledger-ui-no-domain.md)           |
 | Add or refactor SPA forms / Zod / RHF / mutation errors      | [web-forms-ux-kit.md](learnings/web-forms-ux-kit.md)                         |
 | Add Playwright / web-e2e / Vitest coverage for `modules/web` | [web-e2e-ppt056.md](learnings/web-e2e-ppt056.md)                             |
+| Add ingest uniqueness / ledger upsert conflict keys          | [ingestion-provenance-sidecar.md](learnings/ingestion-provenance-sidecar.md) |

--- a/.strata/memory/learnings/INDEX.md
+++ b/.strata/memory/learnings/INDEX.md
@@ -4,13 +4,14 @@ Operation-keyed behavioral rules: one lesson per file, fired by trigger, origin 
 
 <!-- GENERATED at /strata:save from learnings/ frontmatter — do not hand-edit; edit learning files instead -->
 
-| Trigger                                                       | Applies when                                                 | Origin  | File                                                               |
-| ------------------------------------------------------------- | ------------------------------------------------------------ | ------- | ------------------------------------------------------------------ |
-| before changing auth, register, login, users passwords, JWT   | modules/api/\*\*/auth\*, security\*, supabase\*; model users | failure | [supabase-auth-ownership.md](supabase-auth-ownership.md)           |
-| before changing local register/login or AUTH_AUTO_CONFIRM     | modules/api/\*\*/supabase\*, auth\*, bff_auth\*; env local   | failure | [local-supabase-email-confirm.md](local-supabase-email-confirm.md) |
-| before committing changes under modules/api/src               | modules/api/\*\*                                             | failure | [api-pre-commit-lint.md](api-pre-commit-lint.md)                   |
-| before git commit when modules/ or bin/ changed               | modules/\*\*, bin/\*\*                                       | success | [strata-strict-pairing.md](strata-strict-pairing.md)               |
-| before adding or wiring modules/ingestor\* packages           | modules/ingestor-core/\*\*, modules/ingestors/\*\*, bin/make | success | [ingestor-scaffold-ci-split.md](ingestor-scaffold-ci-split.md)     |
-| before parsing DataFrames with optional int/date into DTOs    | modules/model/\*\*/datautils\*, api schemas / list paths     | failure | [pandas-optional-int-nan.md](pandas-optional-int-nan.md)           |
-| before wiring or changing /reports endpoints or ReportService | modules/api/\*\*/reports\*, modules/model/\*\*/reports.py    | success | [report-tenant-scoping.md](report-tenant-scoping.md)               |
-| before adding transactions, movements, or bulk create UI      | modules/web/\*\*/transactions\*, movements\*; api/txns/movs  | success | [web-ledger-ui-no-domain.md](web-ledger-ui-no-domain.md)           |
+| Trigger                                                        | Applies when                                                 | Origin  | File                                                               |
+| -------------------------------------------------------------- | ------------------------------------------------------------ | ------- | ------------------------------------------------------------------ |
+| before changing auth, register, login, users passwords, JWT    | modules/api/\*\*/auth\*, security\*, supabase\*; model users | failure | [supabase-auth-ownership.md](supabase-auth-ownership.md)           |
+| before changing local register/login or AUTH_AUTO_CONFIRM      | modules/api/\*\*/supabase\*, auth\*, bff_auth\*; env local   | failure | [local-supabase-email-confirm.md](local-supabase-email-confirm.md) |
+| before committing changes under modules/api/src                | modules/api/\*\*                                             | failure | [api-pre-commit-lint.md](api-pre-commit-lint.md)                   |
+| before git commit when modules/ or bin/ changed                | modules/\*\*, bin/\*\*                                       | success | [strata-strict-pairing.md](strata-strict-pairing.md)               |
+| before adding or wiring modules/ingestor\* packages            | modules/ingestor-core/\*\*, modules/ingestors/\*\*, bin/make | success | [ingestor-scaffold-ci-split.md](ingestor-scaffold-ci-split.md)     |
+| before adding ingest uniqueness or ledger upsert conflict keys | modules/model/\*\*/ingestion\*, upsert.py, alembic/\*\*      | success | [ingestion-provenance-sidecar.md](ingestion-provenance-sidecar.md) |
+| before parsing DataFrames with optional int/date into DTOs     | modules/model/\*\*/datautils\*, api schemas / list paths     | failure | [pandas-optional-int-nan.md](pandas-optional-int-nan.md)           |
+| before wiring or changing /reports endpoints or ReportService  | modules/api/\*\*/reports\*, modules/model/\*\*/reports.py    | success | [report-tenant-scoping.md](report-tenant-scoping.md)               |
+| before adding transactions, movements, or bulk create UI       | modules/web/\*\*/transactions\*, movements\*; api/txns/movs  | success | [web-ledger-ui-no-domain.md](web-ledger-ui-no-domain.md)           |

--- a/.strata/memory/learnings/ingestion-provenance-sidecar.md
+++ b/.strata/memory/learnings/ingestion-provenance-sidecar.md
@@ -9,4 +9,6 @@ origin: success
 composite FK to `(id, transaction_ts)`, partial unique `WHERE source_ref IS NOT NULL`, and
 sidecar-first re-ingest that reuses id/`transaction_ts` and reactivates soft-deleted rows.
 Extend `PostgreSQLUpserter` with `conflict_index_elements` / `conflict_index_where` /
-`immutable_update_columns` when bulk conflict targets are not the PK.
+`immutable_update_columns` when bulk conflict targets are not the PK. For `alembic check`,
+`include_object` must ignore FKs reflected onto monthly `transactions_y*m*` partitions and
+known DB-only CHECKs (`chk_transaction_kind_accounts`, etc.).

--- a/.strata/memory/learnings/ingestion-provenance-sidecar.md
+++ b/.strata/memory/learnings/ingestion-provenance-sidecar.md
@@ -1,0 +1,12 @@
+---
+trigger: before adding ingest uniqueness or ledger upsert conflict keys
+applies-when: modules/model/**/ingestion*, modules/model/**/upsert.py, modules/model/alembic/**
+origin: success
+---
+
+**Lesson:** Do not put `(owner_id, ingestion_source, source_ref)` uniqueness on partitioned
+`transactions` (PK is `(id, transaction_ts)`). Use a non-partitioned provenance sidecar with
+composite FK to `(id, transaction_ts)`, partial unique `WHERE source_ref IS NOT NULL`, and
+sidecar-first re-ingest that reuses id/`transaction_ts` and reactivates soft-deleted rows.
+Extend `PostgreSQLUpserter` with `conflict_index_elements` / `conflict_index_where` /
+`immutable_update_columns` when bulk conflict targets are not the PK.

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -14,33 +14,25 @@ Capture with `/strata:capture` only for work in flight.
 
 ### Last completed (this session)
 
-- **PPT-070 / #163:** epic closed — in-app payment dues delivered (children #164–#168;
-  PRs [#197](https://github.com/Elmorralito/save-ma-money/pull/197)–[#207](https://github.com/Elmorralito/save-ma-money/pull/207)).
-  Index: [`docs/issues/README.md` Part VIII](../../docs/issues/README.md#part-viii--ppt-070-payment-due-date-reminders-163).
-- **PPT-075 / #168:** docs/OpenAPI/B0 close-out ([PR #207](https://github.com/Elmorralito/save-ma-money/pull/207)).
-- **PPT-074 / #167:** SPA dues + Due soon ([PR #206](https://github.com/Elmorralito/save-ma-money/pull/206)).
-- **PPT-073 / #166:** `/transaction-templates` API ([PR #205](https://github.com/Elmorralito/save-ma-money/pull/205)).
-- **PPT-072 / #165** · **PPT-071 / #164:** model services + schema.
-
-### Last completed (this session) — ops
-
-- **PPT-067 publish-dev path gate** landed (#194). Closed Node 25 Dependabot #192 (stay on 22).
-- **PPT-066 / #131** — `py-model-v*` cutover (PSR `tag_format` + dual-trigger publish; SSOT
-  [`.github/CI.md` § Release tagging](../../.github/CI.md#release-tagging-ppt-066)).
+- **PPT-077 / #171:** ingestor-core + email package scaffolds on main (#211).
+- **PPT-070 / #163:** epic closed — payment dues #164–#168
+  (PRs [#197](https://github.com/Elmorralito/save-ma-money/pull/197)–[#207](https://github.com/Elmorralito/save-ma-money/pull/207)).
 
 ### In progress (ACTIVE)
 
-- None for PPT-070. Optional follow-up: SQLModel CHECK metadata drift so Migration Check
-  can run without `skip-migrations` (unrelated to dues epic MVP).
+- **PPT-078 / #172:** model provenance sidecar + ingestion upsert bridge on `feat/PPT-078`
+  (non-partitioned `transaction_ingestion_provenance`, thin DLQ, `IngestionBridgeService`).
+  Parent epic **PPT-076 / #170**. Downstream: #173 / #176 / #177.
 
 ### Open (backlog)
 
+- **PPT-076** remaining children after #172 (contracts, email plugin, Prefect, etc.).
 - **PPT-066 follow-up:** after 1–2 releases, drop legacy `model-v*` publish trigger.
 - Alembic/`alembic check` SQLModel CHECK alignment (`chk_financing_share`, etc.).
 
 ### Next action
 
-- Do not re-add closed GH issues into `.strata/issues/`
+- Land PPT-078 / #172; keep ingest uniqueness off the partitioned `transactions` parent.
 
 ### Uncommitted / staging notes
 

--- a/docs/interrogate_badge.svg
+++ b/docs/interrogate_badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="20" role="img" aria-label="interrogate: 98.1%">
-    <title>interrogate: 98.1%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="20" role="img" aria-label="interrogate: 97.7%">
+    <title>interrogate: 97.7%</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -15,8 +15,8 @@
     <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
         <text aria-hidden="true" x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" fill="#fff" textLength="610">interrogate</text>
-        <text aria-hidden="true" x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">98.1%</text>
-        <text x="1160" y="140" transform="scale(.1)" fill="#fff" textLength="370" data-interrogate="result">98.1%</text>
+        <text aria-hidden="true" x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">97.7%</text>
+        <text x="1160" y="140" transform="scale(.1)" fill="#fff" textLength="370" data-interrogate="result">97.7%</text>
     </g>
     <g id="logo-shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/modules/model/alembic/env.py
+++ b/modules/model/alembic/env.py
@@ -62,9 +62,39 @@ target_metadata = SQLModel.metadata
 logger = logging.getLogger("alembic.env")
 
 
+# DB-only CHECK constraints (DDL in migrations / partition helpers; not on SQLModel tables).
+_KNOWN_DB_ONLY_CHECK_CONSTRAINTS = frozenset(
+    {
+        "chk_transaction_kind_accounts",
+        "chk_financing_share",
+        "accounts_ledger_side_matches_kind",
+    }
+)
+
+
+def _fk_refers_to_transactions_partition(object_) -> bool:
+    """Return True when a reflected FK targets a monthly transactions partition."""
+    referred = getattr(object_, "referred_table", None)
+    if referred is not None and is_transactions_partition_table(getattr(referred, "name", None) or ""):
+        return True
+    for element in getattr(object_, "elements", ()) or ():
+        column = getattr(element, "column", None)
+        table = getattr(column, "table", None) if column is not None else None
+        if table is not None and is_transactions_partition_table(getattr(table, "name", None) or ""):
+            return True
+    return False
+
+
 def include_object(object_, name, type_, reflected, compare_to):
-    """Ignore monthly child partitions when autogenerating or running alembic check."""
+    """Ignore partition noise and known DB-only CHECKs during alembic check/autogenerate."""
     if type_ == "table" and is_transactions_partition_table(name):
+        return False
+    # FK to a partitioned parent is reflected once per child partition; keep the parent FK only.
+    if type_ == "foreign_key_constraint" and _fk_refers_to_transactions_partition(object_):
+        return False
+    if type_ == "unique_constraint" and _fk_refers_to_transactions_partition(object_):
+        return False
+    if type_ == "check_constraint" and name in _KNOWN_DB_ONLY_CHECK_CONSTRAINTS:
         return False
     return True
 

--- a/modules/model/alembic/versions/2026_08_11_1400-k8f9a0b1c2d3_ppt_078_ingestion_provenance.py
+++ b/modules/model/alembic/versions/2026_08_11_1400-k8f9a0b1c2d3_ppt_078_ingestion_provenance.py
@@ -1,0 +1,170 @@
+# pylint: disable=C0103
+"""Add ingestion provenance sidecar and thin DLQ (PPT-078 / #172).
+
+Revision ID: k8f9a0b1c2d3
+Revises: j7e8f9a0b1c2
+Create Date: 2026-08-11 14:00:00.000000+00:00
+
+Non-partitioned registry for idempotent ingest. Uniqueness cannot live on the
+partitioned ``transactions`` parent (PK is ``(id, transaction_ts)``).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from papita_txnsmodel.model.contstants import (
+    INGESTION_DEAD_LETTERS__TABLENAME,
+    SCHEMA_NAME,
+    TRANSACTION_INGESTION_PROVENANCE__TABLENAME,
+    TRANSACTIONS__TABLENAME,
+    USERS__TABLENAME,
+)
+
+revision: str = "k8f9a0b1c2d3"
+down_revision: Union[str, Sequence[str], None] = "j7e8f9a0b1c2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INGESTION_SOURCE_ENUM = "ingestion_source"
+_UQ_PROV = "uq_txn_ingest_prov_owner_source_ref"
+_FK_PROV_TXN = "fk_txn_ingest_prov_transaction"
+_FK_PROV_OWNER = "fk_txn_ingest_prov_owner_id"
+_FK_DLQ_OWNER = "fk_ingestion_dead_letters_owner_id"
+_IX_PROV_OWNER = "ix_txn_ingest_prov_owner_id"
+_IX_PROV_TXN = "ix_txn_ingest_prov_transaction_id"
+_IX_DLQ_OWNER_SOURCE = "ix_ingestion_dead_letters_owner_source"
+
+
+def _ingestion_source_type(*, create_type: bool = False) -> postgresql.ENUM:
+    """Return the shared Postgres enum type for ingestion_source columns."""
+    return postgresql.ENUM(
+        "MANUAL",
+        "CSV",
+        "EMAIL",
+        "API",
+        name=_INGESTION_SOURCE_ENUM,
+        schema=SCHEMA_NAME,
+        create_type=create_type,
+    )
+
+
+def upgrade() -> None:
+    """Create ingestion_source enum, provenance sidecar, and dead-letter table."""
+    # Idempotent: Alembic/SQLAlchemy may otherwise emit CREATE TYPE twice in one txn.
+    op.execute(sa.text(f"""
+            DO $$ BEGIN
+                CREATE TYPE {SCHEMA_NAME}.{_INGESTION_SOURCE_ENUM}
+                    AS ENUM ('MANUAL', 'CSV', 'EMAIL', 'API');
+            EXCEPTION
+                WHEN duplicate_object THEN NULL;
+            END $$;
+            """))
+    ingestion_source = _ingestion_source_type(create_type=False)
+
+    op.create_table(
+        TRANSACTION_INGESTION_PROVENANCE__TABLENAME,
+        sa.Column("active", sa.Boolean(), nullable=False),
+        sa.Column("deleted_at", sa.TIMESTAMP(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(), nullable=False),
+        sa.Column("updated_at", sa.TIMESTAMP(), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("owner_id", sa.Uuid(), nullable=False),
+        sa.Column("transaction_id", sa.Uuid(), nullable=False),
+        sa.Column("transaction_ts", sa.TIMESTAMP(), nullable=False),
+        sa.Column("ingestion_source", ingestion_source, nullable=False),
+        sa.Column("source_ref", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            [f"{SCHEMA_NAME}.{USERS__TABLENAME}.id"],
+            name=_FK_PROV_OWNER,
+        ),
+        sa.ForeignKeyConstraint(
+            ["transaction_id", "transaction_ts"],
+            [f"{SCHEMA_NAME}.{TRANSACTIONS__TABLENAME}.id", f"{SCHEMA_NAME}.{TRANSACTIONS__TABLENAME}.transaction_ts"],
+            name=_FK_PROV_TXN,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        _IX_PROV_OWNER,
+        TRANSACTION_INGESTION_PROVENANCE__TABLENAME,
+        ["owner_id"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        _IX_PROV_TXN,
+        TRANSACTION_INGESTION_PROVENANCE__TABLENAME,
+        ["transaction_id"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        _UQ_PROV,
+        TRANSACTION_INGESTION_PROVENANCE__TABLENAME,
+        ["owner_id", "ingestion_source", "source_ref"],
+        unique=True,
+        schema=SCHEMA_NAME,
+        postgresql_where=sa.text("source_ref IS NOT NULL"),
+    )
+
+    op.create_table(
+        INGESTION_DEAD_LETTERS__TABLENAME,
+        sa.Column("active", sa.Boolean(), nullable=False),
+        sa.Column("deleted_at", sa.TIMESTAMP(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(), nullable=False),
+        sa.Column("updated_at", sa.TIMESTAMP(), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("owner_id", sa.Uuid(), nullable=False),
+        sa.Column("ingestion_source", ingestion_source, nullable=False),
+        sa.Column("raw_payload", sa.Text(), nullable=False),
+        sa.Column("error_message", sa.Text(), nullable=False),
+        sa.Column("source_ref", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            [f"{SCHEMA_NAME}.{USERS__TABLENAME}.id"],
+            name=_FK_DLQ_OWNER,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        _IX_DLQ_OWNER_SOURCE,
+        INGESTION_DEAD_LETTERS__TABLENAME,
+        ["owner_id", "ingestion_source"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+
+
+def downgrade() -> None:
+    """Drop dead-letter and provenance tables, then the ingestion_source enum."""
+    op.drop_index(
+        _IX_DLQ_OWNER_SOURCE,
+        table_name=INGESTION_DEAD_LETTERS__TABLENAME,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_table(INGESTION_DEAD_LETTERS__TABLENAME, schema=SCHEMA_NAME)
+
+    op.drop_index(
+        _UQ_PROV,
+        table_name=TRANSACTION_INGESTION_PROVENANCE__TABLENAME,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        _IX_PROV_TXN,
+        table_name=TRANSACTION_INGESTION_PROVENANCE__TABLENAME,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        _IX_PROV_OWNER,
+        table_name=TRANSACTION_INGESTION_PROVENANCE__TABLENAME,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_table(TRANSACTION_INGESTION_PROVENANCE__TABLENAME, schema=SCHEMA_NAME)
+
+    op.execute(sa.text(f"DROP TYPE IF EXISTS {SCHEMA_NAME}.{_INGESTION_SOURCE_ENUM}"))

--- a/modules/model/src/papita_txnsmodel/access/ingestion/__init__.py
+++ b/modules/model/src/papita_txnsmodel/access/ingestion/__init__.py
@@ -1,0 +1,14 @@
+"""Access layer for ingestion provenance and dead-letter rows (PPT-078)."""
+
+from papita_txnsmodel.access.ingestion.dto import IngestionDeadLetterDTO, TransactionIngestionProvenanceDTO
+from papita_txnsmodel.access.ingestion.repository import (
+    IngestionDeadLetterRepository,
+    TransactionIngestionProvenanceRepository,
+)
+
+__all__ = [
+    "IngestionDeadLetterDTO",
+    "IngestionDeadLetterRepository",
+    "TransactionIngestionProvenanceDTO",
+    "TransactionIngestionProvenanceRepository",
+]

--- a/modules/model/src/papita_txnsmodel/access/ingestion/dto.py
+++ b/modules/model/src/papita_txnsmodel/access/ingestion/dto.py
@@ -1,0 +1,34 @@
+"""DTOs for ingestion provenance sidecar and dead letters (PPT-078 / #172)."""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+
+from pydantic import Field
+
+from papita_txnsmodel.access.users.dto import OwnedTableDTO
+from papita_txnsmodel.model.enums import IngestionSource
+from papita_txnsmodel.model.ingestion import IngestionDeadLetter, TransactionIngestionProvenance
+
+
+class TransactionIngestionProvenanceDTO(OwnedTableDTO):
+    """DTO for the non-partitioned ingestion idempotency registry."""
+
+    __dao_type__ = TransactionIngestionProvenance
+
+    transaction_id: uuid.UUID
+    transaction_ts: datetime.datetime
+    ingestion_source: IngestionSource
+    source_ref: str | None = Field(default=None, max_length=255)
+
+
+class IngestionDeadLetterDTO(OwnedTableDTO):
+    """DTO for thin ingest failure / dead-letter storage."""
+
+    __dao_type__ = IngestionDeadLetter
+
+    ingestion_source: IngestionSource
+    raw_payload: str = ""
+    error_message: str = ""
+    source_ref: str | None = Field(default=None, max_length=255)

--- a/modules/model/src/papita_txnsmodel/access/ingestion/repository.py
+++ b/modules/model/src/papita_txnsmodel/access/ingestion/repository.py
@@ -1,0 +1,51 @@
+"""Repositories for ingestion provenance and dead letters (PPT-078 / #172)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from papita_txnsmodel.access.base.repository import OwnedTableRepository
+from papita_txnsmodel.access.ingestion.dto import IngestionDeadLetterDTO, TransactionIngestionProvenanceDTO
+from papita_txnsmodel.model.enums import IngestionSource
+from papita_txnsmodel.model.ingestion import TransactionIngestionProvenance
+from papita_txnsmodel.utils.classutils import MetaSingleton
+
+if TYPE_CHECKING:
+    from papita_txnsmodel.access.users.dto import UsersDTO
+
+
+class TransactionIngestionProvenanceRepository(OwnedTableRepository, metaclass=MetaSingleton):
+    """Owner-scoped access to ``transaction_ingestion_provenance``."""
+
+    __expected_dto__ = TransactionIngestionProvenanceDTO
+
+    def get_by_source_ref(
+        self,
+        *,
+        owner: UsersDTO,
+        ingestion_source: IngestionSource,
+        source_ref: str,
+        include_deleted: bool = True,
+        **kwargs,
+    ) -> TransactionIngestionProvenanceDTO | None:
+        """Return the provenance row for an idempotency key, including soft-deleted rows."""
+        if not source_ref:
+            return None
+        dao = TransactionIngestionProvenance
+        frame = self.get_records(
+            dao.owner_id == owner.id,
+            dao.ingestion_source == ingestion_source,
+            dao.source_ref == source_ref,
+            owner=owner,
+            dto_type=TransactionIngestionProvenanceDTO,
+            include_deleted=include_deleted,
+            limit=1,
+            **kwargs,
+        )
+        return self._dataframe_row_to_dto(frame, TransactionIngestionProvenanceDTO, **kwargs)
+
+
+class IngestionDeadLetterRepository(OwnedTableRepository, metaclass=MetaSingleton):
+    """Owner-scoped access to ``ingestion_dead_letters``."""
+
+    __expected_dto__ = IngestionDeadLetterDTO

--- a/modules/model/src/papita_txnsmodel/database/upsert.py
+++ b/modules/model/src/papita_txnsmodel/database/upsert.py
@@ -79,12 +79,14 @@ class Upserter(metaclass=abc.ABCMeta):
 
     _insert: Callable
     _pks: set[str]
+    _conflict_index_where: Any | None
+    _immutable_update_columns: set[str]
     _upsert_method: Callable[[Any, Engine | Connection, Sequence[str], Iterator], int]
     _table_cols: Sequence[str]
     _table_name: str = ""
 
     @classmethod
-    def upsert(
+    def upsert(  # pylint: disable=too-many-arguments
         cls,
         *,
         schema_name: str,
@@ -93,6 +95,9 @@ class Upserter(metaclass=abc.ABCMeta):
         df: pd.DataFrame,
         db_session: Session,
         on_conflict_do: OnUpsertConflictDo = OnUpsertConflictDo.NOTHING,
+        conflict_index_elements: Sequence[str] | None = None,
+        conflict_index_where: Any | None = None,
+        immutable_update_columns: Sequence[str] | None = None,
         **to_sql_kwargs,
     ) -> int:
         """
@@ -105,6 +110,9 @@ class Upserter(metaclass=abc.ABCMeta):
             df (pd.DataFrame): DataFrame containing the data to upsert.
             db_session (DBSession): SQLAlchemy session object.
             on_conflict_do (OnUpsertConflictDo): Action to take on conflict.
+            conflict_index_elements: Alternate unique columns for ON CONFLICT (defaults to ``pks``).
+            conflict_index_where: Optional partial-index predicate for ON CONFLICT.
+            immutable_update_columns: Columns excluded from ON CONFLICT DO UPDATE SET.
             **to_sql_kwargs: Additional arguments for the `to_sql` method.
 
         Returns:
@@ -114,7 +122,12 @@ class Upserter(metaclass=abc.ABCMeta):
             AssertionError: If the SQL dialect is not supported.
         """
         assert db_session.bind.dialect.name == cls.__supported_dialect__, "Dialect not supported."
-        cls._pks = set(list(pks))
+        conflict_keys = list(conflict_index_elements) if conflict_index_elements is not None else list(pks)
+        if not conflict_keys:
+            raise ValueError("Upsert requires primary keys or conflict_index_elements.")
+        cls._pks = set(conflict_keys)
+        cls._conflict_index_where = conflict_index_where
+        cls._immutable_update_columns = set(immutable_update_columns or ())
         cls._upsert_method = getattr(cls, f"_on_conflict_do_{on_conflict_do.value.lower()}")
         match table:
             case str():
@@ -307,7 +320,10 @@ class PostgreSQLUpserter(Upserter):
         except Exception:
             data_ = [dict(zip(keys, row)) for row in data_iter]
 
-        stmt = cls._insert(getattr(table, "table", table)).values(data_).on_conflict_do_nothing(index_elements=cls._pks)
+        conflict_kwargs: dict[str, Any] = {"index_elements": list(cls._pks)}
+        if getattr(cls, "_conflict_index_where", None) is not None:
+            conflict_kwargs["index_where"] = cls._conflict_index_where
+        stmt = cls._insert(getattr(table, "table", table)).values(data_).on_conflict_do_nothing(**conflict_kwargs)
         result = conn.execute(stmt)
         try:
             return result.rowcount
@@ -334,10 +350,14 @@ class PostgreSQLUpserter(Upserter):
             data_ = [dict(zip(keys, row)) for row in data_iter]
 
         stmt = cls._insert(getattr(table, "table", table)).values(data_)
-        stmt = stmt.on_conflict_do_update(
-            index_elements=cls._pks,
-            set_={key: getattr(stmt.excluded, key) for key in set(stmt.excluded.keys()) - set(cls._pks)},
-        )
+        excluded_from_set = set(cls._pks) | getattr(cls, "_immutable_update_columns", set())
+        conflict_kwargs: dict[str, Any] = {
+            "index_elements": list(cls._pks),
+            "set_": {key: getattr(stmt.excluded, key) for key in set(stmt.excluded.keys()) - excluded_from_set},
+        }
+        if getattr(cls, "_conflict_index_where", None) is not None:
+            conflict_kwargs["index_where"] = cls._conflict_index_where
+        stmt = stmt.on_conflict_do_update(**conflict_kwargs)
         result = conn.execute(stmt)
         try:
             return result.rowcount
@@ -360,7 +380,7 @@ class DuckDBUpserter(PostgreSQLUpserter):
         _warn_duckdb_upserter_deprecated()
 
     @classmethod
-    def upsert(
+    def upsert(  # pylint: disable=too-many-arguments
         cls,
         *,
         schema_name: str,
@@ -369,6 +389,9 @@ class DuckDBUpserter(PostgreSQLUpserter):
         df: pd.DataFrame,
         db_session: Session,
         on_conflict_do: OnUpsertConflictDo = OnUpsertConflictDo.NOTHING,
+        conflict_index_elements: Sequence[str] | None = None,
+        conflict_index_where: Any | None = None,
+        immutable_update_columns: Sequence[str] | None = None,
         **to_sql_kwargs,
     ) -> int:
         """[DEPRECATED]
@@ -381,6 +404,9 @@ class DuckDBUpserter(PostgreSQLUpserter):
             df (pd.DataFrame): DataFrame containing the data to upsert.
             db_session (DBSession): SQLAlchemy session object.
             on_conflict_do (OnUpsertConflictDo): Action to take on conflict.
+            conflict_index_elements: Alternate unique columns for ON CONFLICT.
+            conflict_index_where: Optional partial-index predicate for ON CONFLICT.
+            immutable_update_columns: Columns excluded from ON CONFLICT DO UPDATE SET.
             **to_sql_kwargs: Additional arguments for the `to_sql` method.
 
         Returns:
@@ -394,6 +420,9 @@ class DuckDBUpserter(PostgreSQLUpserter):
             df=df,
             db_session=db_session,
             on_conflict_do=on_conflict_do,
+            conflict_index_elements=conflict_index_elements,
+            conflict_index_where=conflict_index_where,
+            immutable_update_columns=immutable_update_columns,
             **to_sql_kwargs,
         )
 

--- a/modules/model/src/papita_txnsmodel/model/__init__.py
+++ b/modules/model/src/papita_txnsmodel/model/__init__.py
@@ -12,5 +12,6 @@ from .account_financing import *  # noqa: F403,F401
 from .accounts import *  # noqa: F403,F401
 from .base import *  # noqa: F403,F401
 from .categories import *  # noqa: F403,F401
+from .ingestion import *  # noqa: F403,F401
 from .transactions import *  # noqa: F403,F401
 from .users import *  # noqa: F403,F401

--- a/modules/model/src/papita_txnsmodel/model/contstants.py
+++ b/modules/model/src/papita_txnsmodel/model/contstants.py
@@ -13,6 +13,8 @@ USERS__TABLENAME = "users"
 CATEGORIES__TABLENAME = "categories"
 TRANSACTION_TEMPLATES__TABLENAME = "transaction_templates"
 TRANSACTIONS__TABLENAME = "transactions"
+TRANSACTION_INGESTION_PROVENANCE__TABLENAME = "transaction_ingestion_provenance"
+INGESTION_DEAD_LETTERS__TABLENAME = "ingestion_dead_letters"
 ACCOUNT_FINANCING__TABLENAME = "account_financing"
 
 BANKING_ACCOUNT_DETAILS__TABLENAME = "banking_account_details"

--- a/modules/model/src/papita_txnsmodel/model/enums.py
+++ b/modules/model/src/papita_txnsmodel/model/enums.py
@@ -77,6 +77,15 @@ class TransactionStatus(str, Enum):
     CANCELLED = "CANCELLED"
 
 
+class IngestionSource(str, Enum):
+    """How a posted transaction entered the ledger (PPT-078 provenance)."""
+
+    MANUAL = "MANUAL"
+    CSV = "CSV"
+    EMAIL = "EMAIL"
+    API = "API"
+
+
 class RealEstateOwnership(str, Enum):
     """Real estate ownership mode."""
 

--- a/modules/model/src/papita_txnsmodel/model/ingestion.py
+++ b/modules/model/src/papita_txnsmodel/model/ingestion.py
@@ -1,0 +1,83 @@
+"""Ingestion provenance sidecar and dead-letter tables (PPT-078 / #172)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, Column
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy import ForeignKeyConstraint, Index, String, Text, text
+from sqlmodel import Field
+
+from .base import SCHEMA_NAME, BaseSQLModel
+from .contstants import (
+    INGESTION_DEAD_LETTERS__TABLENAME,
+    TRANSACTION_INGESTION_PROVENANCE__TABLENAME,
+    TRANSACTIONS__TABLENAME,
+    USERS__TABLENAME,
+)
+from .enums import IngestionSource
+
+
+class TransactionIngestionProvenance(BaseSQLModel, table=True):  # type: ignore
+    """Non-partitioned idempotency / provenance registry for ingested transactions.
+
+    Uniqueness lives here (not on partitioned ``transactions``) via a partial unique
+    index on ``(owner_id, ingestion_source, source_ref)`` where ``source_ref`` is set.
+    Soft-deleted rows still occupy the unique slot so re-ingest reactivates in place.
+    """
+
+    __tablename__ = TRANSACTION_INGESTION_PROVENANCE__TABLENAME
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["transaction_id", "transaction_ts"],
+            [f"{SCHEMA_NAME}.{TRANSACTIONS__TABLENAME}.id", f"{SCHEMA_NAME}.{TRANSACTIONS__TABLENAME}.transaction_ts"],
+            name="fk_txn_ingest_prov_transaction",
+        ),
+        Index(
+            "uq_txn_ingest_prov_owner_source_ref",
+            "owner_id",
+            "ingestion_source",
+            "source_ref",
+            unique=True,
+            postgresql_where=text("source_ref IS NOT NULL"),
+        ),
+        Index("ix_txn_ingest_prov_owner_id", "owner_id"),
+        Index("ix_txn_ingest_prov_transaction_id", "transaction_id"),
+        {"schema": SCHEMA_NAME},
+    )
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    owner_id: uuid.UUID = Field(foreign_key=f"{USERS__TABLENAME}.id", nullable=False, index=True)
+    transaction_id: uuid.UUID = Field(nullable=False)
+    transaction_ts: datetime = Field(sa_column=Column(TIMESTAMP, nullable=False))
+    ingestion_source: IngestionSource = Field(
+        sa_column=Column(
+            SAEnum(IngestionSource, name="ingestion_source", schema=SCHEMA_NAME, create_type=False),
+            nullable=False,
+        )
+    )
+    source_ref: str | None = Field(default=None, max_length=255, sa_type=String(255), nullable=True)
+
+
+class IngestionDeadLetter(BaseSQLModel, table=True):  # type: ignore
+    """Minimal store for raw ingest payloads that failed parse/validation (PPT-078)."""
+
+    __tablename__ = INGESTION_DEAD_LETTERS__TABLENAME
+    __table_args__ = (
+        Index("ix_ingestion_dead_letters_owner_source", "owner_id", "ingestion_source"),
+        {"schema": SCHEMA_NAME},
+    )
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    owner_id: uuid.UUID = Field(foreign_key=f"{USERS__TABLENAME}.id", nullable=False, index=True)
+    ingestion_source: IngestionSource = Field(
+        sa_column=Column(
+            SAEnum(IngestionSource, name="ingestion_source", schema=SCHEMA_NAME, create_type=False),
+            nullable=False,
+        )
+    )
+    raw_payload: str = Field(sa_type=Text, nullable=False, default="")
+    error_message: str = Field(sa_type=Text, nullable=False, default="")
+    source_ref: str | None = Field(default=None, max_length=255, sa_type=String(255), nullable=True)

--- a/modules/model/src/papita_txnsmodel/model/ingestion.py
+++ b/modules/model/src/papita_txnsmodel/model/ingestion.py
@@ -49,7 +49,8 @@ class TransactionIngestionProvenance(BaseSQLModel, table=True):  # type: ignore
     )
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
-    owner_id: uuid.UUID = Field(foreign_key=f"{USERS__TABLENAME}.id", nullable=False, index=True)
+    # Indexes live in ``__table_args__`` (avoid duplicate Field(index=True) autogen names).
+    owner_id: uuid.UUID = Field(foreign_key=f"{USERS__TABLENAME}.id", nullable=False)
     transaction_id: uuid.UUID = Field(nullable=False)
     transaction_ts: datetime = Field(sa_column=Column(TIMESTAMP, nullable=False))
     ingestion_source: IngestionSource = Field(
@@ -71,7 +72,7 @@ class IngestionDeadLetter(BaseSQLModel, table=True):  # type: ignore
     )
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
-    owner_id: uuid.UUID = Field(foreign_key=f"{USERS__TABLENAME}.id", nullable=False, index=True)
+    owner_id: uuid.UUID = Field(foreign_key=f"{USERS__TABLENAME}.id", nullable=False)
     ingestion_source: IngestionSource = Field(
         sa_column=Column(
             SAEnum(IngestionSource, name="ingestion_source", schema=SCHEMA_NAME, create_type=False),

--- a/modules/model/src/papita_txnsmodel/services/__init__.py
+++ b/modules/model/src/papita_txnsmodel/services/__init__.py
@@ -19,6 +19,11 @@ from papita_txnsmodel.services.balance_reports import BalanceReportsService
 from papita_txnsmodel.services.balance_views import refresh_balance_materialized_views
 from papita_txnsmodel.services.categories import CategoriesService
 from papita_txnsmodel.services.dues import UpcomingDueDTO
+from papita_txnsmodel.services.ingestion import (
+    IngestionBridgeService,
+    IngestTransactionRequest,
+    IngestTransactionResult,
+)
 from papita_txnsmodel.services.owner_period_balances import OwnerPeriodBalancesService
 from papita_txnsmodel.services.owner_yearly_balances import OwnerYearlyBalancesService
 from papita_txnsmodel.services.reports import ReportService
@@ -33,6 +38,9 @@ __all__ = [
     "BankingAccountDetailsService",
     "CategoriesService",
     "CreditCardAccountDetailsService",
+    "IngestTransactionRequest",
+    "IngestTransactionResult",
+    "IngestionBridgeService",
     "LoanAccountDetailsService",
     "OwnerPeriodBalancesService",
     "OwnerYearlyBalancesService",

--- a/modules/model/src/papita_txnsmodel/services/ingestion.py
+++ b/modules/model/src/papita_txnsmodel/services/ingestion.py
@@ -1,0 +1,333 @@
+"""Ingestion upsert bridge for trusted owner-scoped ledger writes (PPT-078 / #172).
+
+Keeps idempotency on the non-partitioned provenance sidecar. Re-ingest with the same
+``(owner, ingestion_source, source_ref)`` reuses the transaction id / ``transaction_ts``
+and reactivates soft-deleted rows in place.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from papita_txnsmodel.access.ingestion.dto import IngestionDeadLetterDTO, TransactionIngestionProvenanceDTO
+from papita_txnsmodel.access.ingestion.repository import (
+    IngestionDeadLetterRepository,
+    TransactionIngestionProvenanceRepository,
+)
+from papita_txnsmodel.access.transactions.dto import TransactionsDTO
+from papita_txnsmodel.access.transactions.repository import TransactionsRepository
+from papita_txnsmodel.access.users.dto import UsersDTO
+from papita_txnsmodel.model.enums import IngestionSource, TransactionKind, TransactionStatus
+from papita_txnsmodel.services.accounts import AccountsService
+from papita_txnsmodel.services.base import BaseService
+from papita_txnsmodel.services.categories import CategoriesService
+from papita_txnsmodel.services.transactions import TransactionsService, TransactionTemplatesService
+
+logger = logging.getLogger(__name__)
+
+IngestOutcome = Literal["created", "updated", "reactivated"]
+
+
+class IngestTransactionRequest(BaseModel):
+    """Model-local ingest payload (not an API schema). Trusted caller supplies ``owner``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ingestion_source: IngestionSource
+    source_ref: str | None = Field(default=None, max_length=255)
+    transaction_kind: TransactionKind
+    amount: float = Field(gt=0)
+    currency: str = Field(default="USD", min_length=3, max_length=3)
+    transaction_ts: datetime | None = None
+    from_account_id: uuid.UUID | None = None
+    to_account_id: uuid.UUID | None = None
+    category_id: uuid.UUID | None = None
+    template_id: uuid.UUID | None = None
+    status: TransactionStatus = TransactionStatus.COMPLETED
+    description: str = ""
+    reference_number: str | None = Field(default=None, max_length=64)
+    tags: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_kind_accounts(self) -> Self:
+        """Enforce LK-style account/category shape before touching the ledger."""
+        kind = self.transaction_kind
+        if kind == TransactionKind.INCOME:
+            if self.from_account_id is not None or self.to_account_id is None or self.category_id is None:
+                raise ValueError("INCOME requires to_account_id and category_id; from_account_id must be null.")
+        elif kind == TransactionKind.EXPENSE:
+            if self.to_account_id is not None or self.from_account_id is None or self.category_id is None:
+                raise ValueError("EXPENSE requires from_account_id and category_id; to_account_id must be null.")
+        elif kind == TransactionKind.TRANSFER:
+            if self.from_account_id is None or self.to_account_id is None or self.category_id is not None:
+                raise ValueError("TRANSFER requires from_account_id and to_account_id; category_id must be null.")
+        return self
+
+
+class IngestTransactionResult(BaseModel):
+    """Result of a single bridge ingest."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    outcome: IngestOutcome
+    transaction: TransactionsDTO
+    provenance: TransactionIngestionProvenanceDTO | None = None
+
+
+class IngestionBridgeService(BaseService):
+    """Trusted-owner bridge: validate → sidecar lookup → create/update/reactivate."""
+
+    dto_type: type[TransactionIngestionProvenanceDTO] = TransactionIngestionProvenanceDTO
+    repository_type: type[TransactionIngestionProvenanceRepository] = TransactionIngestionProvenanceRepository
+    # Any allows test doubles; production wires TransactionsService in ``_init_deps``.
+    transactions_service: Any | None = None
+    dead_letter_repository_type: type[IngestionDeadLetterRepository] = IngestionDeadLetterRepository
+
+    _dead_letter_repository: IngestionDeadLetterRepository | None = None
+
+    @model_validator(mode="after")
+    def _init_deps(self) -> Self:
+        """Wire nested services/repositories after BaseService validation."""
+        if self.transactions_service is None:
+            # Mirror TransactionTemplatesService: LinkedEntitiesService.create requires
+            # loaded account/category/template collaborators for non-null FKs.
+            txn_service = TransactionsService.model_validate({"connector": self.connector})
+            accounts = AccountsService.model_validate({"connector": self.connector})
+            categories = CategoriesService.model_validate({"connector": self.connector})
+            templates = TransactionTemplatesService.model_validate(
+                {
+                    "connector": self.connector,
+                    "accounts_service": accounts,
+                    # Reuse this txn service so templates wiring does not build a second one.
+                    "transactions_service": txn_service,
+                }
+            )
+            txn_service.load_link_services(
+                {
+                    "template_id": templates,
+                    "from_account_id": accounts,
+                    "to_account_id": accounts,
+                    "category_id": categories,
+                }
+            )
+            self.transactions_service = txn_service
+        self._dead_letter_repository = self.dead_letter_repository_type()
+        return self
+
+    def ingest_transaction(
+        self,
+        *,
+        owner: UsersDTO,
+        request: IngestTransactionRequest | dict[str, Any],
+        **kwargs,
+    ) -> IngestTransactionResult:
+        """Upsert a posted transaction with provenance idempotency when ``source_ref`` is set.
+
+        Args:
+            owner: Authenticated tenant (trusted; never taken from the payload).
+            request: Ingest fields (kind, amount, accounts, source identity).
+            **kwargs: Forwarded to transaction create/upsert (e.g. ``refresh_balances``).
+
+        Returns:
+            IngestTransactionResult with outcome and the ledger + provenance rows.
+
+        Raises:
+            ValueError: Invalid kind/account shape or missing owner.
+        """
+        if owner is None or owner.id is None:
+            raise ValueError("ingest_transaction requires a trusted owner with an id.")
+
+        payload = (
+            request
+            if isinstance(request, IngestTransactionRequest)
+            else IngestTransactionRequest.model_validate(request)
+        )
+        source_ref = (payload.source_ref or "").strip() or None
+        existing_prov = None
+        if source_ref is not None:
+            existing_prov = self._repository.get_by_source_ref(
+                owner=owner,
+                ingestion_source=payload.ingestion_source,
+                source_ref=source_ref,
+                include_deleted=True,
+            )
+
+        if existing_prov is not None:
+            # Sidecar lookup only runs when source_ref is set; narrow for type checkers.
+            if source_ref is None:
+                raise RuntimeError("Provenance hit requires a non-null source_ref.")
+            return self._reingest(
+                owner=owner,
+                payload=payload,
+                provenance=existing_prov,
+                source_ref=source_ref,
+                **kwargs,
+            )
+
+        return self._create_new(
+            owner=owner,
+            payload=payload,
+            source_ref=source_ref,
+            **kwargs,
+        )
+
+    def record_dead_letter(
+        self,
+        *,
+        owner: UsersDTO,
+        ingestion_source: IngestionSource,
+        raw_payload: str,
+        error_message: str,
+        source_ref: str | None = None,
+        **kwargs,
+    ) -> IngestionDeadLetterDTO:
+        """Persist a thin DLQ row for a failed ingest attempt."""
+        if owner is None or owner.id is None:
+            raise ValueError("record_dead_letter requires a trusted owner with an id.")
+        dto = IngestionDeadLetterDTO(
+            owner_id=owner.id,
+            ingestion_source=ingestion_source,
+            raw_payload=raw_payload,
+            error_message=error_message,
+            source_ref=(source_ref or "").strip() or None,
+        )
+        return self._dead_letter_repository.upsert_record(dto, owner=owner, **kwargs) or dto
+
+    def _create_new(
+        self,
+        *,
+        owner: UsersDTO,
+        payload: IngestTransactionRequest,
+        source_ref: str | None,
+        **kwargs,
+    ) -> IngestTransactionResult:
+        txn = self._build_transaction_dto(owner=owner, payload=payload, txn_id=None, transaction_ts=None)
+        created = self._normalize_transaction(
+            self.transactions_service.create(obj=txn, owner=owner, include_category=False, **kwargs)
+        )
+        provenance = None
+        if source_ref is not None:
+            provenance = self._upsert_provenance(
+                owner=owner,
+                transaction=created,
+                ingestion_source=payload.ingestion_source,
+                source_ref=source_ref,
+                provenance_id=None,
+                reactivate=False,
+            )
+        return IngestTransactionResult(outcome="created", transaction=created, provenance=provenance)
+
+    def _reingest(
+        self,
+        *,
+        owner: UsersDTO,
+        payload: IngestTransactionRequest,
+        provenance: TransactionIngestionProvenanceDTO,
+        source_ref: str,
+        **kwargs,
+    ) -> IngestTransactionResult:
+        was_inactive = not bool(getattr(provenance, "active", True))
+        existing_txn = TransactionsRepository().get_record_by_id(
+            provenance.transaction_id,
+            owner=owner,
+            dto_type=TransactionsDTO,
+            include_deleted=True,
+        )
+        if existing_txn is None:
+            raise RuntimeError(f"Provenance {provenance.id} points at missing transaction {provenance.transaction_id}.")
+        if not bool(getattr(existing_txn, "active", True)):
+            was_inactive = True
+
+        # Keep partition key + id stable; refresh mutable ledger fields from payload.
+        txn = self._build_transaction_dto(
+            owner=owner,
+            payload=payload,
+            txn_id=provenance.transaction_id,
+            transaction_ts=provenance.transaction_ts,
+        )
+        updated = self._normalize_transaction(
+            self.transactions_service.create(obj=txn, owner=owner, reactivate=True, include_category=False, **kwargs)
+        )
+        updated_prov = self._upsert_provenance(
+            owner=owner,
+            transaction=updated,
+            ingestion_source=payload.ingestion_source,
+            source_ref=source_ref,
+            provenance_id=provenance.id,
+            reactivate=True,
+        )
+        outcome: IngestOutcome = "reactivated" if was_inactive else "updated"
+        return IngestTransactionResult(outcome=outcome, transaction=updated, provenance=updated_prov)
+
+    def _upsert_provenance(
+        self,
+        *,
+        owner: UsersDTO,
+        transaction: TransactionsDTO,
+        ingestion_source: IngestionSource,
+        source_ref: str,
+        provenance_id: uuid.UUID | None,
+        reactivate: bool,
+    ) -> TransactionIngestionProvenanceDTO:
+        if transaction.id is None:
+            raise ValueError("Transaction must have an id before provenance upsert.")
+        dto = TransactionIngestionProvenanceDTO(
+            id=provenance_id or uuid.uuid4(),
+            owner_id=owner.id,
+            transaction_id=transaction.id,
+            transaction_ts=transaction.transaction_ts,
+            ingestion_source=ingestion_source,
+            source_ref=source_ref,
+            active=True,
+            deleted_at=None,
+        )
+        return self._repository.upsert_record(dto, owner=owner, reactivate=reactivate) or dto
+
+    @staticmethod
+    def _normalize_transaction(txn: TransactionsDTO | Any) -> TransactionsDTO:
+        """Collapse LinkedEntitiesService-hydrated relation DTOs back to UUIDs."""
+        if not isinstance(txn, TransactionsDTO):
+            txn = TransactionsDTO.model_validate(txn)
+        data = txn.model_dump(mode="python")
+        for key in ("from_account_id", "to_account_id", "category_id", "template_id", "owner_id"):
+            value = data.get(key)
+            if value is None or isinstance(value, uuid.UUID):
+                continue
+            if isinstance(value, dict) and value.get("id") is not None:
+                data[key] = value["id"]
+            elif hasattr(value, "id"):
+                data[key] = getattr(value, "id")
+        return TransactionsDTO.model_validate(data)
+
+    @staticmethod
+    def _build_transaction_dto(
+        *,
+        owner: UsersDTO,
+        payload: IngestTransactionRequest,
+        txn_id: uuid.UUID | None,
+        transaction_ts: datetime | None,
+    ) -> TransactionsDTO:
+        ts = transaction_ts if transaction_ts is not None else payload.transaction_ts
+        return TransactionsDTO(
+            id=txn_id or uuid.uuid4(),
+            owner_id=owner.id,
+            transaction_kind=payload.transaction_kind,
+            amount=payload.amount,
+            currency=payload.currency,
+            transaction_ts=ts if ts is not None else datetime.now(),
+            from_account_id=payload.from_account_id,
+            to_account_id=payload.to_account_id,
+            category_id=payload.category_id,
+            template_id=payload.template_id,
+            status=payload.status,
+            description=payload.description,
+            reference_number=payload.reference_number,
+            tags=list(payload.tags),
+            active=True,
+            deleted_at=None,
+        )

--- a/modules/model/tests/tests_papita_txnsmodel/database/test_upsert.py
+++ b/modules/model/tests/tests_papita_txnsmodel/database/test_upsert.py
@@ -111,6 +111,29 @@ class TestUpserter:
             mock_fallback.assert_called_once()
         Upserter.__supported_dialect__ = ""
 
+    def test_upsert_accepts_alternate_conflict_index(self, mock_session, sample_dataframe):
+        """PPT-078: conflict_index_elements / immutable columns configure ON CONFLICT."""
+        Upserter.__supported_dialect__ = "postgresql"
+        with patch.object(Upserter, "_upsert_fallback", return_value=1) as mock_fallback:
+            result = Upserter.upsert(
+                schema_name="test_schema",
+                table="test_table",
+                pks=["id"],
+                df=sample_dataframe,
+                db_session=mock_session,
+                conflict_index_elements=["owner_id", "ingestion_source", "source_ref"],
+                conflict_index_where="source_ref IS NOT NULL",
+                immutable_update_columns=["transaction_id", "transaction_ts"],
+            )
+            assert result == 1
+            mock_fallback.assert_called_once()
+        assert Upserter._pks == {"owner_id", "ingestion_source", "source_ref"}
+        assert Upserter._conflict_index_where == "source_ref IS NOT NULL"
+        assert Upserter._immutable_update_columns == {"transaction_id", "transaction_ts"}
+        Upserter.__supported_dialect__ = ""
+        Upserter._conflict_index_where = None
+        Upserter._immutable_update_columns = set()
+
     def test_upsert_handles_table_object(self, mock_session, sample_dataframe, mock_table):
         """Test that upsert correctly handles SQLAlchemy Table object."""
         Upserter.__supported_dialect__ = "postgresql"
@@ -246,6 +269,8 @@ class TestPostgreSQLUpserter:
     def test_on_conflict_do_update_executes_update_statement(self, mock_insert, mock_engine):
         """Test that _on_conflict_do_update executes PostgreSQL update statement."""
         PostgreSQLUpserter._pks = {"id"}
+        PostgreSQLUpserter._conflict_index_where = None
+        PostgreSQLUpserter._immutable_update_columns = set()
         mock_table = MagicMock()
         mock_table.table = mock_table
         mock_stmt = MagicMock()
@@ -263,6 +288,39 @@ class TestPostgreSQLUpserter:
 
         assert result == 2
         mock_engine.execute.assert_called_once()
+        _, kwargs = mock_stmt.on_conflict_do_update.call_args
+        assert "index_where" not in kwargs
+        assert set(kwargs["set_"]) == {"name", "value"}
+
+    @patch("papita_txnsmodel.database.upsert.PostgreSQLUpserter._insert")
+    def test_on_conflict_do_update_honors_immutable_and_partial_index(self, mock_insert, mock_engine):
+        """PPT-078: immutable columns and index_where are passed through."""
+        PostgreSQLUpserter._pks = {"owner_id", "source_ref"}
+        PostgreSQLUpserter._conflict_index_where = "source_ref IS NOT NULL"
+        PostgreSQLUpserter._immutable_update_columns = {"transaction_ts"}
+        mock_table = MagicMock()
+        mock_table.table = mock_table
+        mock_stmt = MagicMock()
+        mock_insert.return_value = mock_stmt
+        mock_stmt.values.return_value = mock_stmt
+        mock_stmt.excluded = MagicMock()
+        mock_stmt.excluded.keys.return_value = ["owner_id", "source_ref", "transaction_ts", "active"]
+        mock_stmt.on_conflict_do_update.return_value = mock_stmt
+        mock_result = MagicMock()
+        mock_result.rowcount = 1
+        mock_engine.execute.return_value = mock_result
+        data_iter = iter([{"owner_id": 1, "source_ref": "a", "transaction_ts": "t", "active": True}])
+
+        result = PostgreSQLUpserter._on_conflict_do_update(
+            mock_table, mock_engine, ["owner_id", "source_ref", "transaction_ts", "active"], data_iter
+        )
+
+        assert result == 1
+        _, kwargs = mock_stmt.on_conflict_do_update.call_args
+        assert kwargs["index_where"] == "source_ref IS NOT NULL"
+        assert set(kwargs["set_"]) == {"active"}
+        PostgreSQLUpserter._conflict_index_where = None
+        PostgreSQLUpserter._immutable_update_columns = set()
 
     @patch("papita_txnsmodel.database.upsert.PostgreSQLUpserter._insert")
     def test_on_conflict_do_update_returns_negative_one_on_error(self, mock_insert, mock_engine):

--- a/modules/model/tests/tests_papita_txnsmodel/integration/test_ppt078_ingestion_live_db.py
+++ b/modules/model/tests/tests_papita_txnsmodel/integration/test_ppt078_ingestion_live_db.py
@@ -1,0 +1,177 @@
+"""B0 live-DB tests for PPT-078 provenance sidecar + ingestion bridge."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import text
+
+from papita_txnsmodel.access.accounts.dto import AccountsDTO
+from papita_txnsmodel.access.categories.dto import CategoriesDTO
+from papita_txnsmodel.access.users.dto import UsersDTO
+from papita_txnsmodel.model.enums import AccountKind, CategoryKind, IngestionSource, LedgerSide, TransactionKind
+from papita_txnsmodel.services.accounts import AccountsService
+from papita_txnsmodel.services.categories import CategoriesService
+from papita_txnsmodel.services.ingestion import IngestTransactionRequest, IngestionBridgeService
+from papita_txnsmodel.services.transactions import TransactionsService
+
+from .conftest import requires_postgres
+
+_VALID_PASSWORD = "Password1!"
+
+
+def _user(user_id: uuid.UUID, label: str) -> UsersDTO:
+    return UsersDTO(
+        id=user_id,
+        username=f"ppt078_{label}",
+        email=f"ppt078_{label}@example.local",
+        password=_VALID_PASSWORD,
+        auth_provider="local",
+    )
+
+
+def _cleanup(engine, *, account_id: uuid.UUID, category_id: uuid.UUID, txn_id: uuid.UUID | None) -> None:
+    with engine.connect() as conn:
+        if txn_id is not None:
+            conn.execute(
+                text("DELETE FROM papita_transactions.transaction_ingestion_provenance WHERE transaction_id = :id"),
+                {"id": str(txn_id)},
+            )
+            conn.execute(
+                text("DELETE FROM papita_transactions.transactions WHERE id = :id"),
+                {"id": str(txn_id)},
+            )
+        conn.execute(
+            text("DELETE FROM papita_transactions.accounts WHERE id = :id"),
+            {"id": str(account_id)},
+        )
+        conn.execute(
+            text("DELETE FROM papita_transactions.categories WHERE id = :id"),
+            {"id": str(category_id)},
+        )
+        conn.commit()
+
+
+@requires_postgres
+class TestLiveDbPpt078IngestionBridge:
+    """Idempotent ingest + soft-delete reactivate against Docker Postgres (B0)."""
+
+    def test_idempotent_reingest_and_reactivate(
+        self, postgres_connector, ensure_integration_users, integration_owner_ids
+    ):
+        """Same source_ref updates in place; soft-deleted rows reactivate."""
+        owner = _user(integration_owner_ids["user_a"], "user_a")
+        accounts = AccountsService()
+        categories = CategoriesService()
+        bridge = IngestionBridgeService()
+        txns = TransactionsService()
+
+        account, _ = accounts.create_account(
+            obj=AccountsDTO(
+                name=f"PPT078 cash {uuid.uuid4().hex[:8]}",
+                description="ingest test",
+                owner_id=owner.id,
+                account_kind=AccountKind.OTHER_ASSET,
+                ledger_side=LedgerSide.ASSET,
+            ),
+            owner=owner,
+        )
+        category = categories.create(
+            obj=CategoriesDTO(
+                name=f"PPT078 groceries {uuid.uuid4().hex[:8]}",
+                description="ingest test",
+                category_kind=CategoryKind.EXPENSE,
+                owner_id=owner.id,
+            ),
+            owner=owner,
+        )
+        assert account.id is not None
+        assert category.id is not None
+
+        source_ref = f"csv:ppt078:{uuid.uuid4().hex}"
+        ts = datetime(2026, 8, 11, 15, 30, 0)
+        txn_id: uuid.UUID | None = None
+
+        try:
+            first = bridge.ingest_transaction(
+                owner=owner,
+                request=IngestTransactionRequest(
+                    ingestion_source=IngestionSource.CSV,
+                    source_ref=source_ref,
+                    transaction_kind=TransactionKind.EXPENSE,
+                    amount=11.25,
+                    from_account_id=account.id,
+                    category_id=category.id,
+                    transaction_ts=ts,
+                    description="first",
+                ),
+            )
+            assert first.outcome == "created"
+            assert first.provenance is not None
+            txn_id = first.transaction.id
+            assert txn_id is not None
+            assert first.transaction.transaction_ts == ts
+
+            second = bridge.ingest_transaction(
+                owner=owner,
+                request=IngestTransactionRequest(
+                    ingestion_source=IngestionSource.CSV,
+                    source_ref=source_ref,
+                    transaction_kind=TransactionKind.EXPENSE,
+                    amount=14.0,
+                    from_account_id=account.id,
+                    category_id=category.id,
+                    description="updated",
+                ),
+            )
+            assert second.outcome == "updated"
+            assert second.transaction.id == txn_id
+            assert second.transaction.transaction_ts == ts
+            assert second.transaction.amount == 14.0
+            assert second.provenance is not None
+            assert second.provenance.id == first.provenance.id
+
+            txns.delete(obj=second.transaction, owner=owner, hard=False)
+            revived = bridge.ingest_transaction(
+                owner=owner,
+                request=IngestTransactionRequest(
+                    ingestion_source=IngestionSource.CSV,
+                    source_ref=source_ref,
+                    transaction_kind=TransactionKind.EXPENSE,
+                    amount=16.5,
+                    from_account_id=account.id,
+                    category_id=category.id,
+                    description="revived",
+                ),
+            )
+            assert revived.outcome == "reactivated"
+            assert revived.transaction.id == txn_id
+            assert revived.transaction.active is True
+            assert revived.transaction.deleted_at is None
+            assert revived.transaction.amount == 16.5
+        finally:
+            _cleanup(
+                postgres_connector.engine,
+                account_id=account.id,
+                category_id=category.id,
+                txn_id=txn_id,
+            )
+
+    def test_provenance_unique_index_exists(
+        self, postgres_connector, ensure_integration_users, integration_owner_ids
+    ):
+        """Migration created the partial unique index on the sidecar."""
+        with postgres_connector.engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    """
+                    SELECT 1
+                    FROM pg_indexes
+                    WHERE schemaname = 'papita_transactions'
+                      AND indexname = 'uq_txn_ingest_prov_owner_source_ref'
+                    """
+                )
+            ).first()
+        assert row is not None

--- a/modules/model/tests/tests_papita_txnsmodel/services/test_ingestion_bridge.py
+++ b/modules/model/tests/tests_papita_txnsmodel/services/test_ingestion_bridge.py
@@ -1,0 +1,253 @@
+"""Unit tests for PPT-078 ingestion bridge (provenance + kind validation)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from papita_txnsmodel.access.ingestion.dto import TransactionIngestionProvenanceDTO
+from papita_txnsmodel.access.transactions.dto import TransactionsDTO
+from papita_txnsmodel.access.users.dto import UsersDTO
+from papita_txnsmodel.model.enums import IngestionSource, TransactionKind
+from papita_txnsmodel.services.ingestion import IngestTransactionRequest, IngestionBridgeService
+
+
+def _owner() -> UsersDTO:
+    return UsersDTO(
+        id=uuid.uuid4(),
+        username="ingest_owner",
+        email="ingest_owner@example.local",
+        password="Password1!",
+        auth_provider="local",
+    )
+
+
+class TestIngestTransactionRequest:
+    """Kind / account shape validation for the model-local ingest DTO."""
+
+    def test_expense_requires_from_account_and_category(self):
+        with pytest.raises(ValueError, match="EXPENSE"):
+            IngestTransactionRequest(
+                ingestion_source=IngestionSource.CSV,
+                source_ref="row-1",
+                transaction_kind=TransactionKind.EXPENSE,
+                amount=10.0,
+                to_account_id=uuid.uuid4(),
+                category_id=uuid.uuid4(),
+            )
+
+    def test_income_ok(self):
+        req = IngestTransactionRequest(
+            ingestion_source=IngestionSource.EMAIL,
+            source_ref="msg-1",
+            transaction_kind=TransactionKind.INCOME,
+            amount=25.0,
+            to_account_id=uuid.uuid4(),
+            category_id=uuid.uuid4(),
+        )
+        assert req.transaction_kind == TransactionKind.INCOME
+
+
+class TestIngestionBridgeService:
+    """Bridge create / re-ingest / reactivate paths with mocked repositories."""
+
+    def test_create_new_with_provenance(self):
+        owner = _owner()
+        account_id = uuid.uuid4()
+        category_id = uuid.uuid4()
+        txn_id = uuid.uuid4()
+        ts = datetime(2026, 8, 1, 12, 0, 0)
+
+        txn_service = MagicMock()
+        created = TransactionsDTO(
+            id=txn_id,
+            owner_id=owner.id,
+            transaction_kind=TransactionKind.EXPENSE,
+            amount=12.0,
+            from_account_id=account_id,
+            category_id=category_id,
+            transaction_ts=ts,
+        )
+        txn_service.create.return_value = created
+
+        prov_repo = MagicMock()
+        prov_repo.get_by_source_ref.return_value = None
+        prov_dto = TransactionIngestionProvenanceDTO(
+            id=uuid.uuid4(),
+            owner_id=owner.id,
+            transaction_id=txn_id,
+            transaction_ts=ts,
+            ingestion_source=IngestionSource.CSV,
+            source_ref="csv:1",
+        )
+        prov_repo.upsert_record.return_value = prov_dto
+
+        service = IngestionBridgeService(transactions_service=txn_service)
+        service._repository = prov_repo
+
+        result = service.ingest_transaction(
+            owner=owner,
+            request=IngestTransactionRequest(
+                ingestion_source=IngestionSource.CSV,
+                source_ref="csv:1",
+                transaction_kind=TransactionKind.EXPENSE,
+                amount=12.0,
+                from_account_id=account_id,
+                category_id=category_id,
+                transaction_ts=ts,
+            ),
+        )
+
+        assert result.outcome == "created"
+        assert result.transaction.id == txn_id
+        assert result.provenance is not None
+        assert result.provenance.source_ref == "csv:1"
+        txn_service.create.assert_called_once()
+        prov_repo.upsert_record.assert_called_once()
+
+    def test_reingest_updates_and_keeps_id(self):
+        owner = _owner()
+        account_id = uuid.uuid4()
+        category_id = uuid.uuid4()
+        txn_id = uuid.uuid4()
+        ts = datetime(2026, 8, 2, 9, 0, 0)
+        prov_id = uuid.uuid4()
+
+        existing_prov = TransactionIngestionProvenanceDTO(
+            id=prov_id,
+            owner_id=owner.id,
+            transaction_id=txn_id,
+            transaction_ts=ts,
+            ingestion_source=IngestionSource.CSV,
+            source_ref="csv:99",
+            active=True,
+        )
+        existing_txn = TransactionsDTO(
+            id=txn_id,
+            owner_id=owner.id,
+            transaction_kind=TransactionKind.EXPENSE,
+            amount=5.0,
+            from_account_id=account_id,
+            category_id=category_id,
+            transaction_ts=ts,
+            active=True,
+        )
+        updated_txn = existing_txn.model_copy(update={"amount": 7.5})
+
+        txn_service = MagicMock()
+        txn_service.create.return_value = updated_txn
+
+        prov_repo = MagicMock()
+        prov_repo.get_by_source_ref.return_value = existing_prov
+        prov_repo.upsert_record.return_value = existing_prov
+
+        txn_repo = MagicMock()
+        txn_repo.get_record_by_id.return_value = existing_txn
+
+        service = IngestionBridgeService(transactions_service=txn_service)
+        service._repository = prov_repo
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "papita_txnsmodel.services.ingestion.TransactionsRepository",
+                lambda: txn_repo,
+            )
+            result = service.ingest_transaction(
+                owner=owner,
+                request={
+                    "ingestion_source": "CSV",
+                    "source_ref": "csv:99",
+                    "transaction_kind": "EXPENSE",
+                    "amount": 7.5,
+                    "from_account_id": account_id,
+                    "category_id": category_id,
+                },
+            )
+
+        assert result.outcome == "updated"
+        assert result.transaction.id == txn_id
+        create_kwargs = txn_service.create.call_args.kwargs
+        assert create_kwargs["reactivate"] is True
+        assert create_kwargs["obj"].id == txn_id
+        assert create_kwargs["obj"].transaction_ts == ts
+
+    def test_reingest_reactivates_soft_deleted(self):
+        owner = _owner()
+        account_id = uuid.uuid4()
+        category_id = uuid.uuid4()
+        txn_id = uuid.uuid4()
+        ts = datetime(2026, 8, 3, 9, 0, 0)
+
+        existing_prov = TransactionIngestionProvenanceDTO(
+            id=uuid.uuid4(),
+            owner_id=owner.id,
+            transaction_id=txn_id,
+            transaction_ts=ts,
+            ingestion_source=IngestionSource.API,
+            source_ref="api:1",
+            active=False,
+            deleted_at=datetime(2026, 8, 4),
+        )
+        existing_txn = TransactionsDTO(
+            id=txn_id,
+            owner_id=owner.id,
+            transaction_kind=TransactionKind.EXPENSE,
+            amount=5.0,
+            from_account_id=account_id,
+            category_id=category_id,
+            transaction_ts=ts,
+            active=False,
+            deleted_at=datetime(2026, 8, 4),
+        )
+        revived = existing_txn.model_copy(update={"active": True, "deleted_at": None, "amount": 9.0})
+
+        txn_service = MagicMock()
+        txn_service.create.return_value = revived
+        prov_repo = MagicMock()
+        prov_repo.get_by_source_ref.return_value = existing_prov
+        prov_repo.upsert_record.return_value = existing_prov.model_copy(update={"active": True, "deleted_at": None})
+        txn_repo = MagicMock()
+        txn_repo.get_record_by_id.return_value = existing_txn
+
+        service = IngestionBridgeService(transactions_service=txn_service)
+        service._repository = prov_repo
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "papita_txnsmodel.services.ingestion.TransactionsRepository",
+                lambda: txn_repo,
+            )
+            result = service.ingest_transaction(
+                owner=owner,
+                request=IngestTransactionRequest(
+                    ingestion_source=IngestionSource.API,
+                    source_ref="api:1",
+                    transaction_kind=TransactionKind.EXPENSE,
+                    amount=9.0,
+                    from_account_id=account_id,
+                    category_id=category_id,
+                ),
+            )
+
+        assert result.outcome == "reactivated"
+
+    def test_record_dead_letter(self):
+        owner = _owner()
+        dlq_repo = MagicMock()
+        dlq_repo.upsert_record.side_effect = lambda dto, **kwargs: dto
+        service = IngestionBridgeService(transactions_service=MagicMock())
+        service._dead_letter_repository = dlq_repo
+
+        row = service.record_dead_letter(
+            owner=owner,
+            ingestion_source=IngestionSource.EMAIL,
+            raw_payload='{"bad": true}',
+            error_message="parse failed",
+            source_ref="msg-x",
+        )
+        assert row.error_message == "parse failed"
+        assert row.source_ref == "msg-x"
+        dlq_repo.upsert_record.assert_called_once()


### PR DESCRIPTION
**Branch:** `feat/PPT-078` · **Base:** `main` · **1 commit** · **19 files**

## Summary

Adds model-owned ingest provenance for PPT-078 / #172 so idempotent loads do not rely on a unique key on partitioned `transactions` (PK is `(id, transaction_ts)`). Ships a non-partitioned sidecar, thin DLQ, upsert conflict extensions, and a trusted-owner `IngestionBridgeService` that creates/updates/reactivates via sidecar-first lookup.

## Out of scope / Highlights

**Out of scope**

- API routers / OpenAPI (downstream)
- Prefetch/Prefect orchestration, Gmail OAuth, email parsers (PPT-076 later children)
- Ingestor-core contract packages (PPT-079 / related)

**Highlights**

- Partial unique `(owner_id, ingestion_source, source_ref) WHERE source_ref IS NOT NULL` on the sidecar
- Soft-delete **reactivate-in-place** (unique slot kept across soft-delete)
- Composite FK `(transaction_id, transaction_ts)` → partitioned ledger

## Changes

**Model / schema**

- `IngestionSource` enum (`MANUAL|CSV|EMAIL|API`)
- Tables: `transaction_ingestion_provenance`, `ingestion_dead_letters`
- Alembic revision `k8f9a0b1c2d3` (revises `j7e8f9a0b1c2`)

**Access / services**

- Ingestion DTOs + owned repositories (`get_by_source_ref`, include soft-deleted)
- `IngestionBridgeService` + `IngestTransactionRequest` (kind/account validation; trusted `owner` only)
- `record_dead_letter()` for thin failure storage

**Database**

- `PostgreSQLUpserter`: `conflict_index_elements`, `conflict_index_where`, `immutable_update_columns`

**Tests / strata**

- Unit + B0 live idempotency/reactivate coverage
- `.strata` project_state + learning for partitioned uniqueness sidecar

## File changes

<details>
<summary>File changes (~19 files)</summary>

```
 .strata/memory/MEMORY.md                           |   7 +-
 .strata/memory/learnings/INDEX.md                  |  21 +-
 .../learnings/ingestion-provenance-sidecar.md      |  12 +
 .strata/memory/project_state.md                    |  24 +-
 docs/interrogate_badge.svg                         |   8 +-
 ...00-k8f9a0b1c2d3_ppt_078_ingestion_provenance.py | 170 +++++++++++
 .../papita_txnsmodel/access/ingestion/__init__.py  |  14 +
 .../src/papita_txnsmodel/access/ingestion/dto.py   |  34 +++
 .../access/ingestion/repository.py                 |  51 ++++
 .../model/src/papita_txnsmodel/database/upsert.py  |  45 ++-
 .../model/src/papita_txnsmodel/model/__init__.py   |   1 +
 .../model/src/papita_txnsmodel/model/contstants.py |   2 +
 modules/model/src/papita_txnsmodel/model/enums.py  |   9 +
 .../model/src/papita_txnsmodel/model/ingestion.py  |  83 +++++
 .../src/papita_txnsmodel/services/__init__.py      |   8 +
 .../src/papita_txnsmodel/services/ingestion.py     | 333 +++++++++++++++++++++
 .../tests_papita_txnsmodel/database/test_upsert.py |  58 ++++
 .../integration/test_ppt078_ingestion_live_db.py   | 177 +++++++++++
 .../services/test_ingestion_bridge.py              | 253 ++++++++++++++++
 19 files changed, 1269 insertions(+), 41 deletions(-)
```

</details>

## Commits

- `729301f` feat/PPT-078: [model] Add provenance schema and ingestion upsert bridge

## Checks, tests, and validation already done

- `poetry run pytest` on PPT-078 unit + upsert + B0 live tests — **pass** (local)
- `./bin/bash/alembic.sh` upgrade / downgrade to `j7e8f9a0b1c2` / upgrade — **pass** (local B0)
- Pre-commit on commit (black/isort/flake8/pylint/mypy/interrogate/strata) — **pass**
- GitHub CI on this PR — **not yet observed** (post-create)

## QA / test plan

- [ ] Migration Check applies `k8f9a0b1c2d3` cleanly on CI Postgres
- [ ] Model unit + integration jobs green
- [ ] Confirm no API / OpenAPI contract drift (expected: none)
- [ ] Spot-check: re-ingest same `source_ref` keeps `id` + `transaction_ts`; soft-delete then re-ingest → `reactivated`

## Risks

> [!CAUTION]
>
> ### Risks
>
> - **Migration:** new enum + two tables + composite FK to partitioned `transactions`; downgrade drops them
> - **Idempotency semantics:** soft-deleted provenance rows still occupy the unique slot (`WHERE source_ref IS NOT NULL` without `deleted_at` filter) — intentional for reactivate-in-place
> - Downstream ingestors (#173+) must call the bridge with trusted `owner` (never take tenant from payload)

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - Null `source_ref` skips idempotency (always creates a new ledger row)
> - Thin DLQ stores raw payload text only — no retry worker in this PR
> - `IngestionBridgeService` wires LinkedEntity collaborators; callers should prefer the bridge over bare `TransactionsService.create` for ingest paths

## References

- Closes #172
- Parent epic: #170 (PPT-076)
- Depends on: #171 (PPT-077) — closed
- Blocks: #173, #176, #177

Made with [Cursor](https://cursor.com)