### PR TITLE
feat/PPT-079: [ingestor] Core contracts, registries, and IngestionRunner

### DIFF
--- a/.strata/memory/MEMORY.md
+++ b/.strata/memory/MEMORY.md
@@ -4,9 +4,9 @@ Pure hot index: live pointers + the generated rules-by-trigger table. Keep ≤80
 
 ## Live pointers
 
-- [Project state](project_state.md) — PPT-078 / #172 in progress (provenance bridge); PPT-070 closed.
-- [Active issues](../issues/ACTIVE.md) — prefer project_state for in-flight PR (PPT-078).
-- [Open backlog](../issues/OPEN.md) — PPT-076 epic children after #172.
+- [Project state](project_state.md) — PPT-079 / #173 in progress (IngestionRunner contracts); PPT-078 closed.
+- [Active issues](../issues/ACTIVE.md) — prefer project_state for in-flight PR (PPT-079).
+- [Open backlog](../issues/OPEN.md) — PPT-076 epic children after #173.
 - Closed work — GitHub issues + `git log` (no `.strata/issues/archive/`).
 
 ## Rules by trigger
@@ -25,3 +25,4 @@ Pure hot index: live pointers + the generated rules-by-trigger table. Keep ≤80
 | Add or refactor SPA forms / Zod / RHF / mutation errors      | [web-forms-ux-kit.md](learnings/web-forms-ux-kit.md)                         |
 | Add Playwright / web-e2e / Vitest coverage for `modules/web` | [web-e2e-ppt056.md](learnings/web-e2e-ppt056.md)                             |
 | Add ingest uniqueness / ledger upsert conflict keys          | [ingestion-provenance-sidecar.md](learnings/ingestion-provenance-sidecar.md) |
+| Change IngestionRunner ack / DLQ / dry_run semantics         | [ingestor-runner-poison-ack.md](learnings/ingestor-runner-poison-ack.md)     |

--- a/.strata/memory/learnings/INDEX.md
+++ b/.strata/memory/learnings/INDEX.md
@@ -12,6 +12,7 @@ Operation-keyed behavioral rules: one lesson per file, fired by trigger, origin 
 | before git commit when modules/ or bin/ changed                | modules/\*\*, bin/\*\*                                       | success | [strata-strict-pairing.md](strata-strict-pairing.md)               |
 | before adding or wiring modules/ingestor\* packages            | modules/ingestor-core/\*\*, modules/ingestors/\*\*, bin/make | success | [ingestor-scaffold-ci-split.md](ingestor-scaffold-ci-split.md)     |
 | before adding ingest uniqueness or ledger upsert conflict keys | modules/model/\*\*/ingestion\*, upsert.py, alembic/\*\*      | success | [ingestion-provenance-sidecar.md](ingestion-provenance-sidecar.md) |
+| before changing IngestionRunner ack / DLQ / dry_run semantics  | modules/ingestor-core/\*\*/runner/\*\*, mapping/\*\*         | success | [ingestor-runner-poison-ack.md](ingestor-runner-poison-ack.md)     |
 | before parsing DataFrames with optional int/date into DTOs     | modules/model/\*\*/datautils\*, api schemas / list paths     | failure | [pandas-optional-int-nan.md](pandas-optional-int-nan.md)           |
 | before wiring or changing /reports endpoints or ReportService  | modules/api/\*\*/reports\*, modules/model/\*\*/reports.py    | success | [report-tenant-scoping.md](report-tenant-scoping.md)               |
 | before adding transactions, movements, or bulk create UI       | modules/web/\*\*/transactions\*, movements\*; api/txns/movs  | success | [web-ledger-ui-no-domain.md](web-ledger-ui-no-domain.md)           |

--- a/.strata/memory/learnings/ingestor-runner-poison-ack.md
+++ b/.strata/memory/learnings/ingestor-runner-poison-ack.md
@@ -1,0 +1,7 @@
+---
+trigger: before changing IngestionRunner ack / DLQ / dry_run semantics
+applies-when: modules/ingestor-core/**/runner/**, modules/ingestor-core/**/mapping/**
+origin: success
+---
+
+**Lesson:** On parse/validation failure, write DLQ then **ack** (poison-message) so sources do not redeliver forever into unbounded DLQ rows. Persist failures must **not** ack. Require non-empty `source_ref` for bridge idempotency. Honor `dry_run` / `fetch_limit` in the runner, not only in settings subclasses.

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -33,7 +33,9 @@ Capture with `/strata:capture` only for work in flight.
 
 ### Next action
 
-- Land PPT-079 / #173; keep plugins consuming contracts (do not redefine them).
+- Land PPT-079 / #173 ([PR #213](https://github.com/Elmorralito/save-ma-money/pull/213));
+  keep plugins consuming contracts (do not redefine them).
+  QC note: prettier blank-line fix in `modules/model/CHANGELOG.md` for `--all-files`.
 
 ### Uncommitted / staging notes
 

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -14,25 +14,26 @@ Capture with `/strata:capture` only for work in flight.
 
 ### Last completed (this session)
 
+- **PPT-078 / #172:** provenance sidecar + `IngestionBridgeService` on main (#212).
 - **PPT-077 / #171:** ingestor-core + email package scaffolds on main (#211).
 - **PPT-070 / #163:** epic closed — payment dues #164–#168
   (PRs [#197](https://github.com/Elmorralito/save-ma-money/pull/197)–[#207](https://github.com/Elmorralito/save-ma-money/pull/207)).
 
 ### In progress (ACTIVE)
 
-- **PPT-078 / #172:** model provenance sidecar + ingestion upsert bridge on `feat/PPT-078`
-  (non-partitioned `transaction_ingestion_provenance`, thin DLQ, `IngestionBridgeService`).
-  Parent epic **PPT-076 / #170**. Downstream: #173 / #176 / #177.
+- **PPT-079 / #173:** core contracts, registries, `IngestionRunner` on `feat/PPT-079`
+  (persist-then-ack; DLQ-then-ack poison semantics; `source_ref` required).
+  Parent epic **PPT-076 / #170**. Downstream: #174 / #175 / #176.
 
 ### Open (backlog)
 
-- **PPT-076** remaining children after #172 (contracts, email plugin, Prefect, etc.).
+- **PPT-076** remaining children after #173 (Gmail source, bank parsers, email flow, etc.).
 - **PPT-066 follow-up:** after 1–2 releases, drop legacy `model-v*` publish trigger.
 - Alembic/`alembic check` SQLModel CHECK alignment (`chk_financing_share`, etc.).
 
 ### Next action
 
-- Land PPT-078 / #172; keep ingest uniqueness off the partitioned `transactions` parent.
+- Land PPT-079 / #173; keep plugins consuming contracts (do not redefine them).
 
 ### Uncommitted / staging notes
 

--- a/modules/ingestor-core/CHANGELOG.md
+++ b/modules/ingestor-core/CHANGELOG.md
@@ -13,3 +13,8 @@ This file is **not** the monorepo issue tracker changelog. Root
 - Package scaffold for PPT-077 / [#171](https://github.com/Elmorralito/save-ma-money/issues/171)
   (`src/papita_ingestor_core`, smoke tests, path dependency on
   `papita-transactions-model`).
+- Core contracts for PPT-079 / [#173](https://github.com/Elmorralito/save-ma-money/issues/173):
+  DTOs, source/parser ABCs + registries, error taxonomy, bridge mapping,
+  `IngestionRunner` (persist-then-ack; DLQ-then-ack poison semantics),
+  `BaseIngestorSettings` (`fetch_limit` / `dry_run`), optional Prefect flow
+  factory (`poetry install -E prefect`).

--- a/modules/ingestor-core/README.md
+++ b/modules/ingestor-core/README.md
@@ -10,6 +10,7 @@ Source-agnostic ingestion contracts and pipeline for Papita
 | Python       | **≥3.12** (CI/dev; `ingestor-ci` uses 3.12). Packaging bounds `requires-python = ">=3.10,<3.15"` match model/api. |
 | Epic         | PPT-076 / [#170](https://github.com/Elmorralito/save-ma-money/issues/170)                                         |
 | Scaffold     | PPT-077 / [#171](https://github.com/Elmorralito/save-ma-money/issues/171)                                         |
+| Contracts    | PPT-079 / [#173](https://github.com/Elmorralito/save-ma-money/issues/173)                                         |
 
 ## Dependency graph (one-way)
 
@@ -18,10 +19,54 @@ modules/ingestors/*  →  papita-ingestor-core  →  papita-transactions-model
 ```
 
 - Plugins (e.g. `papita-ingestor-email`) depend on **core**.
-- Core depends on **`papita_txnsmodel`** for future upsert bridges — domain rules
+- Core depends on **`papita_txnsmodel`** for `IngestionBridgeService` — domain rules
   stay in the model layer.
 - **`papita_txnsapi` / `@papita/web` must not import plugin packages** (or core
   parsers). API may later expose thin status routers that call model services only.
+
+## What this package owns (PPT-079)
+
+| Surface                                                    | Role                                                         |
+| ---------------------------------------------------------- | ------------------------------------------------------------ |
+| `RawRecord` / `ParsedRecord` / `FetchFilter` / `RunResult` | Source-agnostic DTOs                                         |
+| `BaseIngestorSource` / `BaseRecordParser`                  | Plugin ABCs                                                  |
+| `SourceRegistry` / `ParserRegistry`                        | Decorator registration (+ parser priority)                   |
+| `IngestionRunner`                                          | stream fetch → parse → validate → **persist** → **ack**      |
+| `to_ingest_transaction_request` / `encode_raw_payload`     | Bridge + DLQ helpers                                         |
+| `BaseIngestorSettings`                                     | `fetch_limit`, `dry_run` (honored by runner; no FK defaults) |
+| `build_base_ingestion_flow()`                              | Optional Prefect factory (`poetry install -E prefect`)       |
+
+**Persist** goes only through `IngestionBridgeService.ingest_transaction` /
+`record_dead_letter`. Core does not inspect provider-specific payload shapes.
+
+### Runner semantics (locked)
+
+| Path                              | Behavior                                                     |
+| --------------------------------- | ------------------------------------------------------------ |
+| Persist success                   | Ack at source                                                |
+| Parse / validation failure        | Dead-letter, then **ack** (poison-message; stops redelivery) |
+| Persist failure / unknown outcome | No ack, no DLQ (retry on next run)                           |
+| Ack failure                       | Recorded on `RunResult`; batch continues                     |
+| `dry_run=True`                    | Parse/validate only — no persist, DLQ, or ack                |
+
+## Plugin handoff
+
+Downstream issues **consume** these contracts (they do not redefine them):
+
+| Issue                                                                     | Consumes                                     |
+| ------------------------------------------------------------------------- | -------------------------------------------- |
+| PPT-080 / [#174](https://github.com/Elmorralito/save-ma-money/issues/174) | `BaseIngestorSource` + registry (Gmail)      |
+| PPT-081 / [#175](https://github.com/Elmorralito/save-ma-money/issues/175) | `BaseRecordParser` + registry (bank parsers) |
+| PPT-082 / [#176](https://github.com/Elmorralito/save-ma-money/issues/176) | `IngestionRunner` + flow factory             |
+
+Register with class attribute `registry_id` (or pass `source_id=` / `parser_id=` to
+the decorator). Duplicate registry ids raise. Supply complete FK UUIDs on
+`ParsedRecord` before persist — core does not invent account/category defaults.
+Pass `owner` as a `UsersDTO` or zero-arg callable into `IngestionRunner`.
+
+**Required:** non-empty `source_ref` on both `RawRecord` and `ParsedRecord` (bridge
+idempotency + safe retry). Do not pass `parsers=[]` — omit `parsers` to use the
+registry, or pass a non-empty instance list.
 
 ## Local commands
 
@@ -33,17 +78,24 @@ make ingestor-test
 make ingestor-lint
 ```
 
+Optional Prefect extra (for `build_base_ingestion_flow`):
+
+```bash
+poetry install -E prefect --with development
+```
+
 ## Coverage
 
-Scaffold ships import smoke tests only. Coverage target **≥80%** on new module
-`src/` trees is owned by PPT-084 / [#178](https://github.com/Elmorralito/save-ma-money/issues/178).
+Unit tests cover mapping, registries, runner routing, and an import guard.
+Coverage target **≥80%** on new module `src/` trees is owned by PPT-084 /
+[#178](https://github.com/Elmorralito/save-ma-money/issues/178).
 
 ## Secrets
 
 See [`.env.example`](.env.example) for **variable names only**. Real values belong
 under `environments/<env>/.env` (never commit secrets).
 
-## Out of scope (this package at scaffold)
+## Out of scope
 
-Gmail OAuth, bank parsers, Prefect flows, and API routers land in later PPT-076
-children — not in this scaffold.
+Concrete Gmail / bank parsers, Compose worker packaging, and API routers land in
+later PPT-076 children — not in this package.

--- a/modules/ingestor-core/pyproject.toml
+++ b/modules/ingestor-core/pyproject.toml
@@ -19,7 +19,12 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
-dependencies = []
+dependencies = [
+    "pydantic-settings>=2.15.0,<3.0.0",
+]
+
+[project.optional-dependencies]
+prefect = ["prefect>=3.0,<4.0"]
 
 [project.urls]
 Homepage = "https://github.com/Elmorralito/save-ma-money/tree/main/modules/ingestor-core"
@@ -34,6 +39,11 @@ include = [{ path = "pyproject.toml", format = ["sdist"] }]
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
 papita-transactions-model = { path = "../model", develop = true }
+pydantic-settings = ">=2.15.0,<3.0.0"
+prefect = { version = ">=3.0,<4.0", optional = true }
+
+[tool.poetry.extras]
+prefect = ["prefect"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=9.1.1"

--- a/modules/ingestor-core/src/papita_ingestor_core/__init__.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/__init__.py
@@ -1,4 +1,4 @@
-"""papita-ingestor-core — source-agnostic ingestion contracts (scaffold).
+"""papita-ingestor-core — source-agnostic ingestion contracts (PPT-079 / #173).
 
 Business rules stay in ``papita_txnsmodel``. Concrete sources (email, bank-api)
 live in plugin packages under ``modules/ingestors/`` and must not be imported
@@ -8,5 +8,43 @@ here.
 from __future__ import annotations
 
 from papita_ingestor_core.__meta__ import __version__
+from papita_ingestor_core.errors import (
+    IngestorConnectionError,
+    IngestorError,
+    IngestorFetchError,
+    IngestorParseError,
+    IngestorPersistError,
+    IngestorValidationError,
+)
+from papita_ingestor_core.flows import build_base_ingestion_flow
+from papita_ingestor_core.mapping import encode_raw_payload, to_ingest_transaction_request
+from papita_ingestor_core.parsers import BaseRecordParser
+from papita_ingestor_core.registry import ParserRegistry, SourceRegistry
+from papita_ingestor_core.runner import IngestionRunner
+from papita_ingestor_core.settings import BaseIngestorSettings
+from papita_ingestor_core.sources import BaseIngestorSource
+from papita_ingestor_core.types import FetchFilter, ParsedRecord, RawRecord, RecordFailure, RunResult
 
-__all__ = ["__version__"]
+__all__ = [
+    "__version__",
+    "BaseIngestorSettings",
+    "BaseIngestorSource",
+    "BaseRecordParser",
+    "FetchFilter",
+    "IngestorConnectionError",
+    "IngestorError",
+    "IngestorFetchError",
+    "IngestorParseError",
+    "IngestorPersistError",
+    "IngestorValidationError",
+    "IngestionRunner",
+    "ParsedRecord",
+    "ParserRegistry",
+    "RawRecord",
+    "RecordFailure",
+    "RunResult",
+    "SourceRegistry",
+    "build_base_ingestion_flow",
+    "encode_raw_payload",
+    "to_ingest_transaction_request",
+]

--- a/modules/ingestor-core/src/papita_ingestor_core/errors/__init__.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/errors/__init__.py
@@ -1,0 +1,21 @@
+"""Ingestor error types."""
+
+from __future__ import annotations
+
+from papita_ingestor_core.errors.taxonomy import (
+    IngestorConnectionError,
+    IngestorError,
+    IngestorFetchError,
+    IngestorParseError,
+    IngestorPersistError,
+    IngestorValidationError,
+)
+
+__all__ = [
+    "IngestorConnectionError",
+    "IngestorError",
+    "IngestorFetchError",
+    "IngestorParseError",
+    "IngestorPersistError",
+    "IngestorValidationError",
+]

--- a/modules/ingestor-core/src/papita_ingestor_core/errors/taxonomy.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/errors/taxonomy.py
@@ -1,0 +1,37 @@
+"""Typed ingestion error taxonomy (PPT-079 / #173)."""
+
+from __future__ import annotations
+
+
+class IngestorError(Exception):
+    """Base error for papita_ingestor_core."""
+
+
+class IngestorConnectionError(IngestorError):
+    """Source connect / disconnect / health failures."""
+
+
+class IngestorFetchError(IngestorError):
+    """Failures while fetching records from a source."""
+
+
+class IngestorParseError(IngestorError):
+    """Parser could not turn a RawRecord into a ParsedRecord."""
+
+
+class IngestorValidationError(IngestorError):
+    """Parsed payload failed validation (including bridge shape ValueError)."""
+
+
+class IngestorPersistError(IngestorError):
+    """Persist / dead-letter failures after a validated payload."""
+
+
+__all__ = [
+    "IngestorError",
+    "IngestorConnectionError",
+    "IngestorFetchError",
+    "IngestorParseError",
+    "IngestorValidationError",
+    "IngestorPersistError",
+]

--- a/modules/ingestor-core/src/papita_ingestor_core/flows/__init__.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/flows/__init__.py
@@ -1,0 +1,7 @@
+"""Prefect flow factory exports."""
+
+from __future__ import annotations
+
+from papita_ingestor_core.flows.base import build_base_ingestion_flow
+
+__all__ = ["build_base_ingestion_flow"]

--- a/modules/ingestor-core/src/papita_ingestor_core/flows/base.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/flows/base.py
@@ -1,0 +1,50 @@
+"""Prefect flow factory (optional extra ``prefect``) — PPT-079 / #173."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from papita_ingestor_core.runner.ingestion_runner import IngestionRunner
+from papita_ingestor_core.types.records import FetchFilter, RunResult
+
+
+def build_base_ingestion_flow(
+    *,
+    name: str = "papita-base-ingestion",
+    runner_factory: Callable[[], IngestionRunner] | None = None,
+) -> Any:
+    """Return a Prefect ``@flow`` that runs ``IngestionRunner``.
+
+    Requires the optional Poetry extra: ``poetry install -E prefect``.
+
+    Args:
+        name: Prefect flow name.
+        runner_factory: Zero-arg callable that builds a configured ``IngestionRunner``.
+            Required at flow run time.
+
+    Returns:
+        A Prefect flow callable.
+
+    Raises:
+        ImportError: If Prefect is not installed.
+    """
+    try:
+        from prefect import flow
+    except ImportError as exc:  # pragma: no cover - exercised when extra missing
+        raise ImportError(
+            "Prefect is required for build_base_ingestion_flow(). "
+            "Install with: poetry install -E prefect  (papita-ingestor-core)"
+        ) from exc
+
+    @flow(name=name)
+    def _ingestion_flow(fetch_filter: FetchFilter | None = None) -> RunResult:
+        if runner_factory is None:
+            raise ValueError("runner_factory is required to run the base ingestion flow")
+        runner = runner_factory()
+        return runner.run(fetch_filter)
+
+    return _ingestion_flow
+
+
+__all__ = ["build_base_ingestion_flow"]

--- a/modules/ingestor-core/src/papita_ingestor_core/mapping/__init__.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/mapping/__init__.py
@@ -1,0 +1,8 @@
+"""Mapping helpers between core DTOs and the model bridge."""
+
+from __future__ import annotations
+
+from papita_ingestor_core.mapping.raw_payload import encode_raw_payload
+from papita_ingestor_core.mapping.to_bridge import to_ingest_transaction_request
+
+__all__ = ["encode_raw_payload", "to_ingest_transaction_request"]

--- a/modules/ingestor-core/src/papita_ingestor_core/mapping/raw_payload.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/mapping/raw_payload.py
@@ -1,0 +1,24 @@
+"""Opaque encoding of RawRecord content for dead-letter storage."""
+
+from __future__ import annotations
+
+import base64
+
+from papita_ingestor_core.types.records import RawRecord
+
+
+def encode_raw_payload(record: RawRecord) -> str:
+    """Encode ``record.content`` to a string without inspecting structure.
+
+    ``str`` content is returned as-is. ``bytes`` are base64-encoded with a
+    ``b64:`` prefix so round-trips remain unambiguous.
+    """
+    content = record.content
+    if isinstance(content, str):
+        return content
+    if isinstance(content, bytes):
+        return "b64:" + base64.b64encode(content).decode("ascii")
+    raise TypeError(f"Unsupported RawRecord.content type: {type(content)!r}")
+
+
+__all__ = ["encode_raw_payload"]

--- a/modules/ingestor-core/src/papita_ingestor_core/mapping/to_bridge.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/mapping/to_bridge.py
@@ -1,0 +1,58 @@
+"""Map ParsedRecord → IngestTransactionRequest (PPT-079 / #173)."""
+
+from __future__ import annotations
+
+from papita_ingestor_core.errors.taxonomy import IngestorValidationError
+from papita_ingestor_core.types.records import ParsedRecord
+from papita_txnsmodel.model.enums import TransactionKind
+from papita_txnsmodel.services.ingestion import IngestTransactionRequest
+
+
+def _assert_complete_fks(parsed: ParsedRecord) -> None:
+    """Require kind-shaped account/category FKs before calling the bridge."""
+    kind = parsed.transaction_kind
+    if kind == TransactionKind.INCOME:
+        if parsed.from_account_id is not None or parsed.to_account_id is None or parsed.category_id is None:
+            raise IngestorValidationError(
+                "INCOME ParsedRecord requires to_account_id and category_id; from_account_id must be null."
+            )
+    elif kind == TransactionKind.EXPENSE:
+        if parsed.to_account_id is not None or parsed.from_account_id is None or parsed.category_id is None:
+            raise IngestorValidationError(
+                "EXPENSE ParsedRecord requires from_account_id and category_id; to_account_id must be null."
+            )
+    elif kind == TransactionKind.TRANSFER:
+        if parsed.from_account_id is None or parsed.to_account_id is None or parsed.category_id is not None:
+            raise IngestorValidationError(
+                "TRANSFER ParsedRecord requires from_account_id and to_account_id; category_id must be null."
+            )
+    else:
+        raise IngestorValidationError(f"Unsupported transaction_kind: {kind!r}")
+
+
+def to_ingest_transaction_request(parsed: ParsedRecord) -> IngestTransactionRequest:
+    """Convert a complete ``ParsedRecord`` into a bridge request.
+
+    Raises:
+        IngestorValidationError: Incomplete FKs for the transaction kind.
+    """
+    _assert_complete_fks(parsed)
+    return IngestTransactionRequest(
+        ingestion_source=parsed.ingestion_source,
+        source_ref=parsed.source_ref,
+        transaction_kind=parsed.transaction_kind,
+        amount=parsed.amount,
+        currency=parsed.currency,
+        transaction_ts=parsed.transaction_ts,
+        from_account_id=parsed.from_account_id,
+        to_account_id=parsed.to_account_id,
+        category_id=parsed.category_id,
+        template_id=parsed.template_id,
+        status=parsed.status,
+        description=parsed.description,
+        reference_number=parsed.reference_number,
+        tags=list(parsed.tags),
+    )
+
+
+__all__ = ["to_ingest_transaction_request"]

--- a/modules/ingestor-core/src/papita_ingestor_core/parsers/__init__.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/parsers/__init__.py
@@ -1,0 +1,7 @@
+"""Parser ABC exports."""
+
+from __future__ import annotations
+
+from papita_ingestor_core.parsers.base import BaseRecordParser
+
+__all__ = ["BaseRecordParser"]

--- a/modules/ingestor-core/src/papita_ingestor_core/parsers/base.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/parsers/base.py
@@ -1,0 +1,36 @@
+"""Abstract record parser (PPT-079 / #173)."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from papita_ingestor_core.types.records import ParsedRecord, RawRecord
+
+
+class BaseRecordParser(ABC):
+    """Parse opaque ``RawRecord`` values into bridge-aligned ``ParsedRecord``."""
+
+    @property
+    @abstractmethod
+    def parser_id(self) -> str:
+        """Stable registry identity for this parser implementation."""
+
+    @property
+    def priority(self) -> int:
+        """Higher priority wins when multiple parsers ``can_parse`` the same record."""
+        return 0
+
+    @abstractmethod
+    def can_parse(self, record: RawRecord) -> bool:
+        """Return whether this parser claims ``record``."""
+
+    @abstractmethod
+    def parse(self, record: RawRecord) -> ParsedRecord:
+        """Convert ``record`` into a ``ParsedRecord`` (may still need FK completeness)."""
+
+    def validate(self, parsed: ParsedRecord) -> ParsedRecord:
+        """Optional post-parse validation; default is identity."""
+        return parsed
+
+
+__all__ = ["BaseRecordParser"]

--- a/modules/ingestor-core/src/papita_ingestor_core/registry/__init__.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/registry/__init__.py
@@ -1,0 +1,8 @@
+"""Registry exports."""
+
+from __future__ import annotations
+
+from papita_ingestor_core.registry.parsers import ParserRegistry
+from papita_ingestor_core.registry.sources import SourceRegistry
+
+__all__ = ["ParserRegistry", "SourceRegistry"]

--- a/modules/ingestor-core/src/papita_ingestor_core/registry/parsers.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/registry/parsers.py
@@ -1,0 +1,73 @@
+"""Parser registry with decorator registration and priority ordering."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from papita_ingestor_core.parsers.base import BaseRecordParser
+from papita_ingestor_core.types.records import RawRecord
+
+_P = TypeVar("_P", bound=type[BaseRecordParser])
+
+
+class ParserRegistry:
+    """In-memory registry of ``BaseRecordParser`` implementations."""
+
+    _parsers: dict[str, type[BaseRecordParser]] = {}
+
+    @classmethod
+    def register(cls, parser_cls: _P | None = None, *, parser_id: str | None = None) -> Callable[[_P], _P] | _P:
+        """Register a parser class via decorator or direct call."""
+
+        def decorator(target: _P) -> _P:
+            if not issubclass(target, BaseRecordParser):
+                raise TypeError(f"{target!r} must subclass BaseRecordParser")
+            identity = parser_id or getattr(target, "registry_id", None)
+            if not identity or not isinstance(identity, str):
+                raise ValueError(f"{target.__name__}: set class attribute registry_id or pass parser_id= to register()")
+            if identity in cls._parsers:
+                raise ValueError(f"parser_id already registered: {identity!r}")
+            cls._parsers[identity] = target
+            return target
+
+        if parser_cls is not None:
+            return decorator(parser_cls)
+        return decorator
+
+    @classmethod
+    def get(cls, parser_id: str) -> type[BaseRecordParser]:
+        """Return a registered parser class or raise ``KeyError``."""
+        return cls._parsers[parser_id]
+
+    @classmethod
+    def all(cls) -> dict[str, type[BaseRecordParser]]:
+        """Copy of registered parser classes."""
+        return dict(cls._parsers)
+
+    @classmethod
+    def clear(cls) -> None:
+        """Remove all registrations (tests)."""
+        cls._parsers.clear()
+
+    @classmethod
+    def create_instances(cls) -> list[BaseRecordParser]:
+        """Instantiate all registered parser classes once (for a single run)."""
+        return [parser_cls() for parser_cls in cls._parsers.values()]
+
+    @classmethod
+    def select_for(cls, record: RawRecord, *, instances: list[BaseRecordParser] | None = None) -> BaseRecordParser:
+        """Pick the highest-priority parser that ``can_parse`` ``record``.
+
+        Tie-break: higher ``priority``, then lexicographic ``parser_id``.
+        Prefer passing a cached ``instances`` list from ``create_instances()``.
+        """
+        candidates = instances if instances is not None else cls.create_instances()
+        matching = [parser for parser in candidates if parser.can_parse(record)]
+        if not matching:
+            raise LookupError(f"No parser registered for record source_ref={record.source_ref!r}")
+        matching.sort(key=lambda p: (-int(p.priority), p.parser_id))
+        return matching[0]
+
+
+__all__ = ["ParserRegistry"]

--- a/modules/ingestor-core/src/papita_ingestor_core/registry/sources.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/registry/sources.py
@@ -1,0 +1,57 @@
+"""Source registry with decorator registration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from papita_ingestor_core.sources.base import BaseIngestorSource
+
+_S = TypeVar("_S", bound=type[BaseIngestorSource])
+
+
+class SourceRegistry:
+    """In-memory registry of ``BaseIngestorSource`` implementations."""
+
+    _sources: dict[str, type[BaseIngestorSource]] = {}
+
+    @classmethod
+    def register(cls, source_cls: _S | None = None, *, source_id: str | None = None) -> Callable[[_S], _S] | _S:
+        """Register a source class.
+
+        Prefer ``@SourceRegistry.register`` when the class defines ``registry_id``,
+        or ``@SourceRegistry.register(source_id=\"…\")``.
+        """
+
+        def decorator(target: _S) -> _S:
+            if not issubclass(target, BaseIngestorSource):
+                raise TypeError(f"{target!r} must subclass BaseIngestorSource")
+            identity = source_id or getattr(target, "registry_id", None)
+            if not identity or not isinstance(identity, str):
+                raise ValueError(f"{target.__name__}: set class attribute registry_id or pass source_id= to register()")
+            if identity in cls._sources:
+                raise ValueError(f"source_id already registered: {identity!r}")
+            cls._sources[identity] = target
+            return target
+
+        if source_cls is not None:
+            return decorator(source_cls)
+        return decorator
+
+    @classmethod
+    def get(cls, source_id: str) -> type[BaseIngestorSource]:
+        """Return a registered source class or raise ``KeyError``."""
+        return cls._sources[source_id]
+
+    @classmethod
+    def all(cls) -> dict[str, type[BaseIngestorSource]]:
+        """Copy of registered source classes."""
+        return dict(cls._sources)
+
+    @classmethod
+    def clear(cls) -> None:
+        """Remove all registrations (tests)."""
+        cls._sources.clear()
+
+
+__all__ = ["SourceRegistry"]

--- a/modules/ingestor-core/src/papita_ingestor_core/runner/__init__.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/runner/__init__.py
@@ -1,0 +1,7 @@
+"""Runner exports."""
+
+from __future__ import annotations
+
+from papita_ingestor_core.runner.ingestion_runner import IngestionRunner
+
+__all__ = ["IngestionRunner"]

--- a/modules/ingestor-core/src/papita_ingestor_core/runner/ingestion_runner.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/runner/ingestion_runner.py
@@ -1,0 +1,287 @@
+"""IngestionRunner: fetch → parse → validate → bridge persist → ack (PPT-079 / #173)."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable, Iterator
+from typing import Any, TypeAlias
+
+from papita_ingestor_core.errors.taxonomy import (
+    IngestorConnectionError,
+    IngestorError,
+    IngestorFetchError,
+    IngestorParseError,
+    IngestorPersistError,
+    IngestorValidationError,
+)
+from papita_ingestor_core.mapping.raw_payload import encode_raw_payload
+from papita_ingestor_core.mapping.to_bridge import to_ingest_transaction_request
+from papita_ingestor_core.parsers.base import BaseRecordParser
+from papita_ingestor_core.registry.parsers import ParserRegistry
+from papita_ingestor_core.settings.base import BaseIngestorSettings
+from papita_ingestor_core.sources.base import BaseIngestorSource
+from papita_ingestor_core.types.records import FetchFilter, RawRecord, RecordFailure, RunResult
+from papita_txnsmodel.access.users.dto import UsersDTO
+from papita_txnsmodel.services.ingestion import IngestionBridgeService
+
+logger = logging.getLogger(__name__)
+
+OwnerProvider: TypeAlias = UsersDTO | Callable[[], UsersDTO]
+_KNOWN_OUTCOMES = frozenset({"created", "updated", "reactivated"})
+
+
+class IngestionRunner:
+    """Orchestrate one ingestion run against a source and registered parsers."""
+
+    _source: BaseIngestorSource
+    _owner: OwnerProvider
+    _bridge: IngestionBridgeService | Any
+    _parsers: list[BaseRecordParser] | None
+    _settings: BaseIngestorSettings
+
+    def __init__(
+        self,
+        *,
+        source: BaseIngestorSource,
+        owner: OwnerProvider,
+        bridge: IngestionBridgeService | Any,
+        parsers: Iterable[BaseRecordParser] | None = None,
+        settings: BaseIngestorSettings | None = None,
+    ) -> None:
+        if owner is None:
+            raise ValueError("IngestionRunner requires an owner UsersDTO or zero-arg callable")
+        self._source = source
+        self._owner = owner
+        self._bridge = bridge
+        self._parsers = list(parsers) if parsers is not None else None
+        self._settings = settings or BaseIngestorSettings()
+
+    def _resolve_owner(self) -> UsersDTO:
+        owner = self._owner() if callable(self._owner) else self._owner
+        if owner is None or getattr(owner, "id", None) is None:
+            raise ValueError("IngestionRunner owner must be a UsersDTO with an id")
+        return owner
+
+    def _resolve_parsers(self) -> list[BaseRecordParser]:
+        """Cache parser instances once per run (avoid per-record construction)."""
+        if self._parsers is not None:
+            parsers = list(self._parsers)
+        else:
+            parsers = ParserRegistry.create_instances()
+        if not parsers:
+            raise ValueError(
+                "IngestionRunner requires at least one parser "
+                + "(pass parsers=… or register parsers on ParserRegistry)"
+            )
+        return parsers
+
+    def _effective_fetch_filter(self, fetch_filter: FetchFilter | None) -> FetchFilter | None:
+        """Merge settings.fetch_limit when the caller did not set FetchFilter.limit."""
+        limit = self._settings.fetch_limit
+        if fetch_filter is None:
+            if limit is None:
+                return None
+            return FetchFilter(limit=limit)
+        if fetch_filter.limit is None and limit is not None:
+            return fetch_filter.model_copy(update={"limit": limit})
+        return fetch_filter
+
+    def _iter_records(self, fetch_filter: FetchFilter | None) -> Iterator[RawRecord]:
+        """Stream source records; enforce limit even if the source ignores FetchFilter."""
+        effective = self._effective_fetch_filter(fetch_filter)
+        limit = effective.limit if effective is not None else None
+        yielded = 0
+        for record in self._source.fetch(effective):
+            yield record
+            yielded += 1
+            if limit is not None and yielded >= limit:
+                break
+
+    def run(self, fetch_filter: FetchFilter | None = None) -> RunResult:
+        """Execute fetch → parse → persist → ack. Connect/fetch failures abort the run.
+
+        Per-record ack failures are recorded and the batch continues. Parse/validation
+        failures dead-letter then ack (poison-message semantics) when DLQ write succeeds.
+        """
+        result = RunResult()
+        owner = self._resolve_owner()
+        parsers = self._resolve_parsers()
+        try:
+            self._source.connect()
+        except IngestorError:
+            raise
+        except Exception as exc:
+            raise IngestorConnectionError(str(exc)) from exc
+
+        try:
+            try:
+                for record in self._iter_records(fetch_filter):
+                    result.fetched += 1
+                    self._process_record(owner=owner, record=record, result=result, parsers=parsers)
+            except IngestorError:
+                raise
+            except Exception as exc:
+                raise IngestorFetchError(str(exc)) from exc
+        finally:
+            try:
+                self._source.disconnect()
+            except Exception:  # pylint: disable=broad-except
+                logger.exception("Source disconnect failed for %s", self._source.source_id)
+
+        return result
+
+    def _parse_and_map(self, *, record: RawRecord, parsers: list[BaseRecordParser]):
+        """Select parser, parse/validate, and map to a bridge request."""
+        if not (record.source_ref or "").strip():
+            raise IngestorValidationError("RawRecord.source_ref is required for idempotent ingest")
+
+        parser = ParserRegistry.select_for(record, instances=parsers)
+        try:
+            parsed = parser.parse(record)
+            parsed = parser.validate(parsed)
+        except IngestorValidationError:
+            raise
+        except IngestorParseError:
+            raise
+        except Exception as exc:
+            raise IngestorParseError(str(exc)) from exc
+
+        if not (parsed.source_ref or "").strip():
+            raise IngestorValidationError("ParsedRecord.source_ref is required for idempotent ingest")
+        return to_ingest_transaction_request(parsed)
+
+    def _persist(self, *, owner: UsersDTO, request: Any) -> str:
+        """Call the bridge and return a known outcome string."""
+        try:
+            ingest_result = self._bridge.ingest_transaction(owner=owner, request=request)
+        except ValueError as exc:
+            raise IngestorValidationError(str(exc)) from exc
+        except IngestorError:
+            raise
+        except Exception as exc:
+            raise IngestorPersistError(str(exc)) from exc
+
+        outcome = getattr(ingest_result, "outcome", None)
+        if outcome not in _KNOWN_OUTCOMES:
+            raise IngestorPersistError(f"Unexpected ingest outcome: {outcome!r}")
+        return outcome
+
+    @staticmethod
+    def _count_outcome(result: RunResult, outcome: str) -> None:
+        if outcome == "created":
+            result.created += 1
+        elif outcome == "updated":
+            result.updated += 1
+        else:
+            result.reactivated += 1
+
+    def _record_persist_failure(self, *, record: RawRecord, result: RunResult, exc: IngestorPersistError) -> None:
+        result.failed += 1
+        result.failures.append(
+            RecordFailure(
+                source_ref=record.source_ref,
+                error_type=type(exc).__name__,
+                message=str(exc),
+                dead_lettered=False,
+            )
+        )
+        logger.warning("Persist failed source_ref=%s: %s", record.source_ref, exc)
+
+    def _process_record(
+        self,
+        *,
+        owner: UsersDTO,
+        record: RawRecord,
+        result: RunResult,
+        parsers: list[BaseRecordParser],
+    ) -> None:
+        try:
+            request = self._parse_and_map(record=record, parsers=parsers)
+            if self._settings.dry_run:
+                result.dry_run_skipped += 1
+                return
+            outcome = self._persist(owner=owner, request=request)
+            self._count_outcome(result, outcome)
+            self._acknowledge(record=record, result=result, count_as_failure=True)
+        except (IngestorParseError, IngestorValidationError) as exc:
+            self._dead_letter(owner=owner, record=record, result=result, exc=exc)
+        except IngestorPersistError as exc:
+            self._record_persist_failure(record=record, result=result, exc=exc)
+        except LookupError as exc:
+            self._dead_letter(
+                owner=owner,
+                record=record,
+                result=result,
+                exc=IngestorParseError(str(exc)),
+            )
+
+    def _acknowledge(self, *, record: RawRecord, result: RunResult, count_as_failure: bool) -> bool:
+        """Ack at the source; never raise — batch processing must continue."""
+        try:
+            self._source.acknowledge(record)
+            result.acknowledged += 1
+            return True
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception("Acknowledge failed source_ref=%s", record.source_ref)
+            if count_as_failure:
+                result.failed += 1
+            result.failures.append(
+                RecordFailure(
+                    source_ref=record.source_ref,
+                    error_type="IngestorAckError",
+                    message=str(exc),
+                    dead_lettered=False,
+                )
+            )
+            return False
+
+    def _dead_letter(
+        self,
+        *,
+        owner: UsersDTO,
+        record: RawRecord,
+        result: RunResult,
+        exc: Exception,
+    ) -> None:
+        """Record a DLQ row; on success ack the poison message to stop redelivery."""
+        if self._settings.dry_run:
+            result.failed += 1
+            result.dry_run_skipped += 1
+            result.failures.append(
+                RecordFailure(
+                    source_ref=record.source_ref,
+                    error_type=type(exc).__name__,
+                    message=str(exc),
+                    dead_lettered=False,
+                )
+            )
+            return
+
+        result.failed += 1
+        dead_lettered = False
+        try:
+            self._bridge.record_dead_letter(
+                owner=owner,
+                ingestion_source=record.ingestion_source,
+                raw_payload=encode_raw_payload(record),
+                error_message=str(exc),
+                source_ref=record.source_ref,
+            )
+            dead_lettered = True
+            result.dead_lettered += 1
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("Dead-letter write failed source_ref=%s", record.source_ref)
+        result.failures.append(
+            RecordFailure(
+                source_ref=record.source_ref,
+                error_type=type(exc).__name__,
+                message=str(exc),
+                dead_lettered=dead_lettered,
+            )
+        )
+        if dead_lettered:
+            # Poison-message: ack after successful DLQ so the source does not redeliver forever.
+            self._acknowledge(record=record, result=result, count_as_failure=False)
+
+
+__all__ = ["IngestionRunner", "OwnerProvider"]

--- a/modules/ingestor-core/src/papita_ingestor_core/settings/__init__.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/settings/__init__.py
@@ -1,0 +1,7 @@
+"""Settings exports."""
+
+from __future__ import annotations
+
+from papita_ingestor_core.settings.base import BaseIngestorSettings
+
+__all__ = ["BaseIngestorSettings"]

--- a/modules/ingestor-core/src/papita_ingestor_core/settings/base.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/settings/base.py
@@ -1,0 +1,25 @@
+"""Common ingestor settings (no FK defaults — PPT-079 / #173)."""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class BaseIngestorSettings(BaseSettings):
+    """Shared knobs for ingestion runs; plugins may subclass.
+
+    ``IngestionRunner`` honors:
+
+    - ``fetch_limit``: applied when ``FetchFilter.limit`` is unset (and as a
+      hard cap while streaming).
+    - ``dry_run``: parse/validate only — no bridge persist, no DLQ, no ack.
+    """
+
+    model_config = SettingsConfigDict(extra="ignore", env_prefix="PAPITA_INGESTOR_")
+
+    fetch_limit: int | None = Field(default=None, ge=1)
+    dry_run: bool = False
+
+
+__all__ = ["BaseIngestorSettings"]

--- a/modules/ingestor-core/src/papita_ingestor_core/sources/__init__.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/sources/__init__.py
@@ -1,0 +1,7 @@
+"""Source ABC exports."""
+
+from __future__ import annotations
+
+from papita_ingestor_core.sources.base import BaseIngestorSource
+
+__all__ = ["BaseIngestorSource"]

--- a/modules/ingestor-core/src/papita_ingestor_core/sources/base.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/sources/base.py
@@ -1,0 +1,48 @@
+"""Abstract ingestion source (PPT-079 / #173)."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from typing import Self
+
+from papita_ingestor_core.types.records import FetchFilter, RawRecord
+
+
+class BaseIngestorSource(ABC):
+    """Source-agnostic fetch + acknowledge contract."""
+
+    @property
+    @abstractmethod
+    def source_id(self) -> str:
+        """Stable registry identity for this source implementation."""
+
+    @abstractmethod
+    def connect(self) -> None:
+        """Open the underlying connection / session."""
+
+    @abstractmethod
+    def disconnect(self) -> None:
+        """Close the underlying connection / session."""
+
+    def health_check(self) -> bool:
+        """Optional liveness probe; default assumes connected sources are healthy."""
+        return True
+
+    @abstractmethod
+    def fetch(self, fetch_filter: FetchFilter | None = None) -> Iterable[RawRecord]:
+        """Yield opaque records matching ``fetch_filter``."""
+
+    @abstractmethod
+    def acknowledge(self, record: RawRecord) -> None:
+        """Mark ``record`` as successfully processed at the source."""
+
+    def __enter__(self) -> Self:
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.disconnect()
+
+
+__all__ = ["BaseIngestorSource"]

--- a/modules/ingestor-core/src/papita_ingestor_core/types/__init__.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/types/__init__.py
@@ -1,0 +1,13 @@
+"""Public DTO exports."""
+
+from __future__ import annotations
+
+from papita_ingestor_core.types.records import FetchFilter, ParsedRecord, RawRecord, RecordFailure, RunResult
+
+__all__ = [
+    "FetchFilter",
+    "ParsedRecord",
+    "RawRecord",
+    "RecordFailure",
+    "RunResult",
+]

--- a/modules/ingestor-core/src/papita_ingestor_core/types/records.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/types/records.py
@@ -1,0 +1,95 @@
+"""Source-agnostic ingestion DTOs (PPT-079 / #173)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from papita_txnsmodel.model.enums import IngestionSource, TransactionKind, TransactionStatus
+
+BridgeOutcome = Literal["created", "updated", "reactivated"]
+
+
+class RawRecord(BaseModel):
+    """Opaque source payload — core must not inspect ``content`` shapes."""
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    source_id: str = Field(min_length=1)
+    source_ref: str | None = Field(default=None, max_length=255)
+    content: bytes | str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    ingestion_source: IngestionSource = IngestionSource.EMAIL
+
+
+class ParsedRecord(BaseModel):
+    """Normalized record field-aligned with ``IngestTransactionRequest``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ingestion_source: IngestionSource
+    source_ref: str | None = Field(default=None, max_length=255)
+    transaction_kind: TransactionKind
+    amount: float = Field(gt=0)
+    currency: str = Field(default="USD", min_length=3, max_length=3)
+    transaction_ts: datetime | None = None
+    from_account_id: uuid.UUID | None = None
+    to_account_id: uuid.UUID | None = None
+    category_id: uuid.UUID | None = None
+    template_id: uuid.UUID | None = None
+    status: TransactionStatus = TransactionStatus.COMPLETED
+    description: str = ""
+    reference_number: str | None = Field(default=None, max_length=64)
+    tags: list[str] = Field(default_factory=list)
+
+
+class FetchFilter(BaseModel):
+    """Optional fetch window / cursor constraints for sources."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    since: datetime | None = None
+    until: datetime | None = None
+    limit: int | None = Field(default=None, ge=1)
+    cursor: str | None = None
+    extra: dict[str, Any] = Field(default_factory=dict)
+
+
+class RecordFailure(BaseModel):
+    """Per-record failure captured in a run result."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_ref: str | None = None
+    error_type: str
+    message: str
+    dead_lettered: bool = False
+
+
+class RunResult(BaseModel):
+    """Aggregate outcome of one ``IngestionRunner`` invocation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    fetched: int = 0
+    created: int = 0
+    updated: int = 0
+    reactivated: int = 0
+    failed: int = 0
+    dead_lettered: int = 0
+    acknowledged: int = 0
+    dry_run_skipped: int = 0
+    failures: list[RecordFailure] = Field(default_factory=list)
+
+
+__all__ = [
+    "BridgeOutcome",
+    "FetchFilter",
+    "ParsedRecord",
+    "RawRecord",
+    "RecordFailure",
+    "RunResult",
+]

--- a/modules/ingestor-core/tests/conftest.py
+++ b/modules/ingestor-core/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Shared fixtures and registry cleanup for papita_ingestor_core tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Allow `import fakes` from sibling modules (path has a hyphen; not a Python package).
+_TESTS_DIR = Path(__file__).resolve().parent
+if str(_TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TESTS_DIR))
+
+from papita_ingestor_core.registry.parsers import ParserRegistry
+from papita_ingestor_core.registry.sources import SourceRegistry
+
+
+@pytest.fixture(autouse=True)
+def _clear_registries() -> None:
+    """Isolate decorator registrations across tests."""
+    SourceRegistry.clear()
+    ParserRegistry.clear()
+    yield
+    SourceRegistry.clear()
+    ParserRegistry.clear()

--- a/modules/ingestor-core/tests/fakes.py
+++ b/modules/ingestor-core/tests/fakes.py
@@ -1,0 +1,146 @@
+"""Reusable fakes for papita_ingestor_core unit tests."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+from types import SimpleNamespace
+from typing import Any
+
+from papita_ingestor_core.parsers.base import BaseRecordParser
+from papita_ingestor_core.sources.base import BaseIngestorSource
+from papita_ingestor_core.types.records import FetchFilter, ParsedRecord, RawRecord
+from papita_txnsmodel.access.users.dto import UsersDTO
+from papita_txnsmodel.model.enums import IngestionSource, TransactionKind
+
+
+def make_owner() -> UsersDTO:
+    """Minimal trusted owner for runner tests."""
+    return UsersDTO(
+        id=uuid.uuid4(),
+        username="ingest_owner",
+        email="ingest_owner@example.local",
+        password="Password1!",
+        auth_provider="local",
+    )
+
+
+class FakeBridge:
+    """In-memory stand-in for ``IngestionBridgeService``."""
+
+    def __init__(self, *, fail_persist: bool = False, fail_dead_letter: bool = False) -> None:
+        self.fail_persist = fail_persist
+        self.fail_dead_letter = fail_dead_letter
+        self.ingests: list[Any] = []
+        self.dead_letters: list[dict[str, Any]] = []
+
+    def ingest_transaction(self, *, owner: UsersDTO, request: Any, **kwargs: Any) -> Any:
+        if self.fail_persist:
+            raise RuntimeError("bridge persist failed")
+        self.ingests.append({"owner": owner, "request": request, "kwargs": kwargs})
+        return SimpleNamespace(outcome="created", transaction=None, provenance=None)
+
+    def record_dead_letter(self, *, owner: UsersDTO, **kwargs: Any) -> Any:
+        if self.fail_dead_letter:
+            raise RuntimeError("dlq failed")
+        payload = {"owner": owner, **kwargs}
+        self.dead_letters.append(payload)
+        return payload
+
+
+class FakeSource(BaseIngestorSource):
+    """Deterministic source for runner tests."""
+
+    registry_id = "fake-source"
+
+    def __init__(
+        self,
+        records: list[RawRecord] | None = None,
+        *,
+        fail_connect: bool = False,
+        fail_ack_refs: set[str] | None = None,
+    ) -> None:
+        self._records = list(records or [])
+        self.fail_connect = fail_connect
+        self.fail_ack_refs = set(fail_ack_refs or ())
+        self.connected = False
+        self.acked: list[RawRecord] = []
+
+    @property
+    def source_id(self) -> str:
+        return self.registry_id
+
+    def connect(self) -> None:
+        if self.fail_connect:
+            raise ConnectionError("cannot connect")
+        self.connected = True
+
+    def disconnect(self) -> None:
+        self.connected = False
+
+    def fetch(self, fetch_filter: FetchFilter | None = None) -> Iterable[RawRecord]:
+        records = list(self._records)
+        if fetch_filter is not None and fetch_filter.limit is not None:
+            records = records[: fetch_filter.limit]
+        return records
+
+    def acknowledge(self, record: RawRecord) -> None:
+        if record.source_ref in self.fail_ack_refs:
+            raise RuntimeError(f"ack failed for {record.source_ref}")
+        self.acked.append(record)
+
+
+class FakeParser(BaseRecordParser):
+    """Parser that accepts any record and emits a complete EXPENSE ParsedRecord."""
+
+    registry_id = "fake-parser"
+
+    def __init__(
+        self,
+        *,
+        from_account_id: uuid.UUID | None = None,
+        category_id: uuid.UUID | None = None,
+        incomplete: bool = False,
+        raise_on_parse: bool = False,
+        priority_value: int = 10,
+    ) -> None:
+        self._from_account_id = from_account_id or uuid.uuid4()
+        self._category_id = category_id or uuid.uuid4()
+        self._incomplete = incomplete
+        self._raise_on_parse = raise_on_parse
+        self._priority_value = priority_value
+
+    @property
+    def parser_id(self) -> str:
+        return self.registry_id
+
+    @property
+    def priority(self) -> int:
+        return self._priority_value
+
+    def can_parse(self, record: RawRecord) -> bool:
+        return True
+
+    def parse(self, record: RawRecord) -> ParsedRecord:
+        if self._raise_on_parse:
+            raise ValueError("boom parse")
+        return ParsedRecord(
+            ingestion_source=record.ingestion_source,
+            source_ref=record.source_ref,
+            transaction_kind=TransactionKind.EXPENSE,
+            amount=12.5,
+            from_account_id=None if self._incomplete else self._from_account_id,
+            to_account_id=None,
+            category_id=None if self._incomplete else self._category_id,
+            description="fake expense",
+        )
+
+
+def make_raw(*, source_ref: str = "msg-1", content: str | bytes = "opaque") -> RawRecord:
+    """Build a minimal RawRecord."""
+    return RawRecord(
+        source_id="fake-source",
+        source_ref=source_ref,
+        content=content,
+        ingestion_source=IngestionSource.EMAIL,
+    )

--- a/modules/ingestor-core/tests/test_mapping.py
+++ b/modules/ingestor-core/tests/test_mapping.py
@@ -1,0 +1,73 @@
+"""Unit tests for RawRecord encoding and bridge mapping."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from papita_ingestor_core.errors.taxonomy import IngestorValidationError
+from papita_ingestor_core.mapping.raw_payload import encode_raw_payload
+from papita_ingestor_core.mapping.to_bridge import to_ingest_transaction_request
+from papita_ingestor_core.types.records import ParsedRecord, RawRecord
+from papita_txnsmodel.model.enums import IngestionSource, TransactionKind
+
+
+def test_encode_raw_payload_str_passthrough() -> None:
+    record = RawRecord(source_id="s", content="hello", ingestion_source=IngestionSource.EMAIL)
+    assert encode_raw_payload(record) == "hello"
+
+
+def test_encode_raw_payload_bytes_b64_prefix() -> None:
+    record = RawRecord(source_id="s", content=b"\x00\xff", ingestion_source=IngestionSource.EMAIL)
+    encoded = encode_raw_payload(record)
+    assert encoded.startswith("b64:")
+    assert "AP8=" in encoded or encoded.endswith("AP8=")
+
+
+def test_to_bridge_expense_complete() -> None:
+    account = uuid.uuid4()
+    category = uuid.uuid4()
+    parsed = ParsedRecord(
+        ingestion_source=IngestionSource.EMAIL,
+        source_ref="r1",
+        transaction_kind=TransactionKind.EXPENSE,
+        amount=9.99,
+        from_account_id=account,
+        category_id=category,
+    )
+    request = to_ingest_transaction_request(parsed)
+    assert request.from_account_id == account
+    assert request.category_id == category
+    assert request.to_account_id is None
+
+
+@pytest.mark.parametrize(
+    "kind,kwargs,match",
+    [
+        (
+            TransactionKind.EXPENSE,
+            {"from_account_id": None, "to_account_id": None, "category_id": uuid.uuid4()},
+            "EXPENSE",
+        ),
+        (
+            TransactionKind.INCOME,
+            {"from_account_id": uuid.uuid4(), "to_account_id": uuid.uuid4(), "category_id": uuid.uuid4()},
+            "INCOME",
+        ),
+        (
+            TransactionKind.TRANSFER,
+            {"from_account_id": uuid.uuid4(), "to_account_id": uuid.uuid4(), "category_id": uuid.uuid4()},
+            "TRANSFER",
+        ),
+    ],
+)
+def test_to_bridge_rejects_incomplete_fks(kind: TransactionKind, kwargs: dict, match: str) -> None:
+    parsed = ParsedRecord(
+        ingestion_source=IngestionSource.EMAIL,
+        transaction_kind=kind,
+        amount=1.0,
+        **kwargs,
+    )
+    with pytest.raises(IngestorValidationError, match=match):
+        to_ingest_transaction_request(parsed)

--- a/modules/ingestor-core/tests/test_no_plugin_imports.py
+++ b/modules/ingestor-core/tests/test_no_plugin_imports.py
@@ -1,0 +1,42 @@
+"""Guard: core must not import Gmail / IMAP / HTML / email plugin packages."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+FORBIDDEN_MODULES = {
+    "google",
+    "googleapiclient",
+    "google_auth_oauthlib",
+    "imaplib",
+    "bs4",
+    "beautifulsoup4",
+    "papita_ingestor_email",
+}
+
+
+def _iter_python_files() -> list[Path]:
+    root = Path(__file__).resolve().parents[1] / "src" / "papita_ingestor_core"
+    return sorted(root.rglob("*.py"))
+
+
+def _imported_roots(tree: ast.AST) -> set[str]:
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                roots.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            roots.add(node.module.split(".", 1)[0])
+    return roots
+
+
+def test_core_has_no_plugin_or_provider_imports() -> None:
+    offenders: list[str] = []
+    for path in _iter_python_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        hits = _imported_roots(tree) & FORBIDDEN_MODULES
+        if hits:
+            offenders.append(f"{path.relative_to(path.parents[2])}: {sorted(hits)}")
+    assert not offenders, "Forbidden imports in papita_ingestor_core:\n" + "\n".join(offenders)

--- a/modules/ingestor-core/tests/test_registry.py
+++ b/modules/ingestor-core/tests/test_registry.py
@@ -1,0 +1,79 @@
+"""Registry registration and parser priority selection."""
+
+from __future__ import annotations
+
+import pytest
+from fakes import FakeParser, FakeSource, make_raw
+
+from papita_ingestor_core.registry.parsers import ParserRegistry
+from papita_ingestor_core.registry.sources import SourceRegistry
+
+
+def test_source_registry_decorator() -> None:
+    @SourceRegistry.register
+    class Registered(FakeSource):
+        registry_id = "registered-source"
+
+    assert SourceRegistry.get("registered-source") is Registered
+
+
+def test_parser_priority_selects_highest() -> None:
+    class Low(FakeParser):
+        registry_id = "aaa"
+
+        def __init__(self) -> None:
+            super().__init__(priority_value=1)
+
+        @property
+        def parser_id(self) -> str:
+            return "aaa"
+
+    class High(FakeParser):
+        registry_id = "zzz"
+
+        def __init__(self) -> None:
+            super().__init__(priority_value=50)
+
+        @property
+        def parser_id(self) -> str:
+            return "zzz"
+
+    ParserRegistry.register(Low)
+    ParserRegistry.register(High)
+    selected = ParserRegistry.select_for(make_raw())
+    assert selected.parser_id == "zzz"
+
+
+def test_parser_select_raises_when_none_match() -> None:
+    class Never(FakeParser):
+        registry_id = "never"
+
+        def can_parse(self, record) -> bool:  # type: ignore[override]
+            return False
+
+    with pytest.raises(LookupError):
+        ParserRegistry.select_for(make_raw(), instances=[Never()])
+
+
+def test_parser_registry_rejects_duplicate_id() -> None:
+    @ParserRegistry.register
+    class First(FakeParser):
+        registry_id = "dup-parser"
+
+    with pytest.raises(ValueError, match="already registered"):
+
+        @ParserRegistry.register
+        class Second(FakeParser):
+            registry_id = "dup-parser"
+
+
+def test_source_registry_rejects_duplicate_id() -> None:
+    @SourceRegistry.register
+    class First(FakeSource):
+        registry_id = "dup-source"
+
+    with pytest.raises(ValueError, match="already registered"):
+
+        @SourceRegistry.register
+        class Second(FakeSource):
+            registry_id = "dup-source"

--- a/modules/ingestor-core/tests/test_runner.py
+++ b/modules/ingestor-core/tests/test_runner.py
@@ -1,0 +1,261 @@
+"""IngestionRunner persist-then-ack and failure routing."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fakes import FakeBridge, FakeParser, FakeSource, make_owner, make_raw
+
+from papita_ingestor_core.errors.taxonomy import IngestorConnectionError
+from papita_ingestor_core.flows.base import build_base_ingestion_flow
+from papita_ingestor_core.registry.parsers import ParserRegistry
+from papita_ingestor_core.runner.ingestion_runner import IngestionRunner
+from papita_ingestor_core.settings.base import BaseIngestorSettings
+from papita_ingestor_core.types.records import FetchFilter
+
+
+def test_runner_happy_path_persist_then_ack() -> None:
+    record = make_raw()
+    source = FakeSource([record])
+    bridge = FakeBridge()
+    runner = IngestionRunner(
+        source=source,
+        owner=make_owner(),
+        bridge=bridge,
+        parsers=[FakeParser()],
+    )
+    result = runner.run()
+    assert result.fetched == 1
+    assert result.created == 1
+    assert result.acknowledged == 1
+    assert result.failed == 0
+    assert len(bridge.ingests) == 1
+    assert source.acked == [record]
+
+
+def test_runner_parse_failure_dead_letters_then_acks() -> None:
+    """Poison-message semantics: successful DLQ must ack to stop redelivery."""
+    record = make_raw(source_ref="bad")
+    source = FakeSource([record])
+    bridge = FakeBridge()
+    runner = IngestionRunner(
+        source=source,
+        owner=make_owner(),
+        bridge=bridge,
+        parsers=[FakeParser(raise_on_parse=True)],
+    )
+    result = runner.run()
+    assert result.failed == 1
+    assert result.dead_lettered == 1
+    assert result.acknowledged == 1
+    assert source.acked == [record]
+    assert len(bridge.dead_letters) == 1
+
+
+def test_runner_incomplete_fk_dead_letters_then_acks() -> None:
+    source = FakeSource([make_raw()])
+    bridge = FakeBridge()
+    runner = IngestionRunner(
+        source=source,
+        owner=make_owner(),
+        bridge=bridge,
+        parsers=[FakeParser(incomplete=True)],
+    )
+    result = runner.run()
+    assert result.failed == 1
+    assert result.dead_lettered == 1
+    assert result.acknowledged == 1
+
+
+def test_runner_persist_failure_no_ack_no_dlq() -> None:
+    source = FakeSource([make_raw()])
+    bridge = FakeBridge(fail_persist=True)
+    runner = IngestionRunner(
+        source=source,
+        owner=make_owner(),
+        bridge=bridge,
+        parsers=[FakeParser()],
+    )
+    result = runner.run()
+    assert result.failed == 1
+    assert result.dead_lettered == 0
+    assert result.acknowledged == 0
+    assert bridge.dead_letters == []
+
+
+def test_runner_ack_failure_continues_batch() -> None:
+    first = make_raw(source_ref="a")
+    second = make_raw(source_ref="b")
+    source = FakeSource([first, second], fail_ack_refs={"a"})
+    bridge = FakeBridge()
+    runner = IngestionRunner(
+        source=source,
+        owner=make_owner(),
+        bridge=bridge,
+        parsers=[FakeParser()],
+    )
+    result = runner.run()
+    assert result.fetched == 2
+    assert result.created == 2
+    assert result.acknowledged == 1
+    assert result.failed == 1
+    assert source.acked == [second]
+    assert any(f.error_type == "IngestorAckError" for f in result.failures)
+
+
+def test_runner_unknown_outcome_no_ack() -> None:
+    class WeirdBridge(FakeBridge):
+        def ingest_transaction(self, *, owner, request, **kwargs):  # type: ignore[no-untyped-def]
+            self.ingests.append({"owner": owner, "request": request})
+            return SimpleNamespace(outcome="mystery")
+
+    source = FakeSource([make_raw()])
+    runner = IngestionRunner(
+        source=source,
+        owner=make_owner(),
+        bridge=WeirdBridge(),
+        parsers=[FakeParser()],
+    )
+    result = runner.run()
+    assert result.failed == 1
+    assert result.acknowledged == 0
+    assert source.acked == []
+
+
+def test_runner_requires_source_ref() -> None:
+    from papita_ingestor_core.types.records import RawRecord
+    from papita_txnsmodel.model.enums import IngestionSource
+
+    bare = RawRecord(source_id="fake-source", source_ref=None, content="x", ingestion_source=IngestionSource.EMAIL)
+    source = FakeSource([bare])
+    bridge = FakeBridge()
+    runner = IngestionRunner(
+        source=source,
+        owner=make_owner(),
+        bridge=bridge,
+        parsers=[FakeParser()],
+    )
+    result = runner.run()
+    assert result.failed == 1
+    assert result.dead_lettered == 1
+    assert result.acknowledged == 1
+    assert bridge.ingests == []
+
+
+def test_runner_dry_run_skips_persist_dlq_ack() -> None:
+    source = FakeSource([make_raw(source_ref="ok"), make_raw(source_ref="bad")])
+    bridge = FakeBridge()
+
+    class Selective(FakeParser):
+        def parse(self, record):  # type: ignore[no-untyped-def]
+            if record.source_ref == "bad":
+                raise ValueError("nope")
+            return super().parse(record)
+
+    runner = IngestionRunner(
+        source=source,
+        owner=make_owner(),
+        bridge=bridge,
+        parsers=[Selective()],
+        settings=BaseIngestorSettings(dry_run=True),
+    )
+    result = runner.run()
+    assert result.fetched == 2
+    assert result.dry_run_skipped == 2
+    assert result.created == 0
+    assert result.acknowledged == 0
+    assert result.dead_lettered == 0
+    assert bridge.ingests == []
+    assert bridge.dead_letters == []
+    assert source.acked == []
+
+
+def test_runner_fetch_limit_from_settings() -> None:
+    records = [make_raw(source_ref=f"m{i}") for i in range(5)]
+    source = FakeSource(records)
+    bridge = FakeBridge()
+    runner = IngestionRunner(
+        source=source,
+        owner=make_owner(),
+        bridge=bridge,
+        parsers=[FakeParser()],
+        settings=BaseIngestorSettings(fetch_limit=2),
+    )
+    result = runner.run()
+    assert result.fetched == 2
+    assert result.created == 2
+
+
+def test_runner_fetch_filter_limit_wins_over_settings() -> None:
+    records = [make_raw(source_ref=f"m{i}") for i in range(5)]
+    source = FakeSource(records)
+    runner = IngestionRunner(
+        source=source,
+        owner=make_owner(),
+        bridge=FakeBridge(),
+        parsers=[FakeParser()],
+        settings=BaseIngestorSettings(fetch_limit=2),
+    )
+    result = runner.run(FetchFilter(limit=3))
+    assert result.fetched == 3
+
+
+def test_runner_empty_parsers_raises() -> None:
+    runner = IngestionRunner(
+        source=FakeSource([make_raw()]),
+        owner=make_owner(),
+        bridge=FakeBridge(),
+        parsers=[],
+    )
+    with pytest.raises(ValueError, match="at least one parser"):
+        runner.run()
+
+
+def test_runner_connect_failure_aborts() -> None:
+    runner = IngestionRunner(
+        source=FakeSource(fail_connect=True),
+        owner=make_owner(),
+        bridge=FakeBridge(),
+        parsers=[FakeParser()],
+    )
+    with pytest.raises(IngestorConnectionError):
+        runner.run()
+
+
+def test_runner_uses_registry_when_parsers_omitted() -> None:
+    @ParserRegistry.register
+    class Registered(FakeParser):
+        registry_id = "registered-parser"
+
+        def __init__(self) -> None:
+            super().__init__()
+
+        @property
+        def parser_id(self) -> str:
+            return "registered-parser"
+
+    source = FakeSource([make_raw()])
+    bridge = FakeBridge()
+    runner = IngestionRunner(source=source, owner=make_owner(), bridge=bridge)
+    result = runner.run()
+    assert result.created == 1
+    assert result.acknowledged == 1
+
+
+def test_build_base_ingestion_flow_requires_prefect_or_runs() -> None:
+    """Factory either imports Prefect or raises a clear InstallError."""
+    source = FakeSource([make_raw()])
+    bridge = FakeBridge()
+    owner = make_owner()
+
+    def factory() -> IngestionRunner:
+        return IngestionRunner(source=source, owner=owner, bridge=bridge, parsers=[FakeParser()])
+
+    try:
+        flow = build_base_ingestion_flow(runner_factory=factory)
+    except ImportError as exc:
+        assert "prefect" in str(exc).lower()
+        return
+    result = flow()
+    assert result.created == 1

--- a/modules/model/CHANGELOG.md
+++ b/modules/model/CHANGELOG.md
@@ -30,7 +30,6 @@ This file is **not** the monorepo issue tracker changelog. Root
 - Update CI adoption badge [skip ci]
   ([`c41fda7`](https://github.com/Elmorralito/save-ma-money/commit/c41fda7c9f4610dd4714712506f463bdbe5b4643))
 
-
 ## v1.0.3 (2026-08-03)
 
 ### Bug Fixes


### PR DESCRIPTION
**Branch:** `feat/PPT-079` · **Base:** `main` · **1 commit** · **34 files**

**Suggested title:** `feat/PPT-079: [ingestor] Core contracts, registries, and IngestionRunner`

## Summary

Implements PPT-079 / #173 source-agnostic ingestion contracts inside `papita-ingestor-core`: DTOs, source/parser ABCs and registries, typed errors, bridge mapping, settings, optional Prefect flow factory, and `IngestionRunner`. Plugins can register and run with fakes without core importing Gmail/IMAP/HTML libraries; persist goes only through the PPT-078 `IngestionBridgeService`.

## Out of scope / Highlights

**Out of scope**

- Concrete Gmail source / bank parsers / email flow (PPT-080–082 / #174–#176)
- Live B0 Postgres integration coverage (deferred; mocked persist here; ≥80% cov PPT-084 / #178)
- API routers / Compose worker packaging

**Highlights**

- Locked runner semantics: persist-then-ack; DLQ-then-ack poison-message path; `dry_run` / `fetch_limit`; required `source_ref`
- Open/Closed registries (duplicate id rejected; parser priority + per-run instance cache)
- AST import guard blocks google/imap/bs4/`papita_ingestor_email` in core

## Changes

**ingestor-core contracts**

- DTOs: `RawRecord`, `ParsedRecord`, `FetchFilter`, `RunResult` (+ per-record failures)
- ABCs: `BaseIngestorSource`, `BaseRecordParser`
- Registries: `SourceRegistry` / `ParserRegistry`
- Errors + opaque DLQ encode + FK-shaped bridge mapper
- `IngestionRunner` streams fetch; continues after ack errors; unknown bridge outcome = persist failure (no ack)
- `BaseIngestorSettings` (`PAPITA_INGESTOR_*`) honored by runner
- Optional `build_base_ingestion_flow()` behind `poetry install -E prefect`

**tests / docs / strata**

- Fake source/parser E2E tests, mapping/registry/runner/import-guard coverage
- README plugin handoff + locked semantics; CHANGELOG note
- `.strata` project_state + learning for DLQ-then-ack

## File changes

<details>
<summary>File changes (~34 files)</summary>

```
 .strata/memory/MEMORY.md
 .strata/memory/learnings/INDEX.md
 .strata/memory/learnings/ingestor-runner-poison-ack.md
 .strata/memory/project_state.md
 modules/ingestor-core/CHANGELOG.md
 modules/ingestor-core/README.md
 modules/ingestor-core/pyproject.toml
 modules/ingestor-core/src/papita_ingestor_core/** (errors, flows, mapping, parsers, registry, runner, settings, sources, types)
 modules/ingestor-core/tests/{conftest,fakes,test_mapping,test_no_plugin_imports,test_registry,test_runner}.py
```

</details>

## Commits

- `e6f512a` feat/PPT-079: [ingestor] Core contracts, registries, and IngestionRunner

## Checks, tests, and validation already done

- `make ingestor-test` — pass (29 tests)
- `make ingestor-lint` — pass (black / isort / flake8 / pylint)
- Pre-commit on commit — pass (incl. strata strict + mypy)

## QA / test plan

- [ ] Confirm `ingestor-ci` runs and is green on this PR
- [ ] Spot-check README runner semantics table vs `IngestionRunner` behavior
- [ ] Confirm no provider imports leak into `papita_ingestor_core` (import-guard test)

## Risks

> [!CAUTION]
>
> ### Risks
>
> - Runner treats `owner` as trusted worker input (must be bound correctly in PPT-082)
> - DLQ-then-ack stops redelivery amplification; DLQ table still lacks upsert-by-`source_ref` (model follow-up if needed)
> - Optional Prefect extra not installed in default CI path (factory ImportError is intentional)

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - `parsers=[]` is rejected at run start; omit `parsers` to use the registry
> - Coverage ≥80% gate remains PPT-084 / #178
> - No live Docker Postgres bridge test in this PR (mocked bridge)

## References

- Closes [#173](https://github.com/Elmorralito/save-ma-money/issues/173) (PPT-079)
- Parent epic [#170](https://github.com/Elmorralito/save-ma-money/issues/170) (PPT-076)
- Depends on [#171](https://github.com/Elmorralito/save-ma-money/issues/171) / [#172](https://github.com/Elmorralito/save-ma-money/issues/172) (closed)
- Downstream consumers: [#174](https://github.com/Elmorralito/save-ma-money/issues/174) / [#175](https://github.com/Elmorralito/save-ma-money/issues/175) / [#176](https://github.com/Elmorralito/save-ma-money/issues/176)

Made with [Cursor](https://cursor.com)