### PR TITLE
feat/PPT-080: [ingestor] Gmail OAuth2 source plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,15 @@ modules/web/.lighthouseci/
 .env.local
 environments/**/.env
 !environments/**/.env.example
+
+# Gmail / Google OAuth artifacts (PPT-080 / #174) — never commit
+token.json
+credentials.json
+client_secret*.json
+**/token.json
+**/credentials.json
+**/client_secret*.json
+
 .dbversion
 # Build files
 build/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,7 +8,9 @@ description = "Environment templates and documented placeholder values"
 paths = [
   '''(?i)(^|/)\.env\.example$''',
   '''(?i)environments/.+/\.env\.example$''',
+  '''(?i)modules/ingestors/email/\.env\.example$''',
   '''(?i)modules/api/README\.md$''',
+  '''(?i)modules/ingestors/email/README\.md$''',
   # Fake PKCE verifier fixtures in Auth unit tests (not live secrets).
   '''(?i)modules/api/tests/test_auth_supabase\.py$''',
 ]

--- a/.strata/memory/MEMORY.md
+++ b/.strata/memory/MEMORY.md
@@ -4,9 +4,9 @@ Pure hot index: live pointers + the generated rules-by-trigger table. Keep ≤80
 
 ## Live pointers
 
-- [Project state](project_state.md) — PPT-079 / #173 in progress (IngestionRunner contracts); PPT-078 closed.
-- [Active issues](../issues/ACTIVE.md) — prefer project_state for in-flight PR (PPT-079).
-- [Open backlog](../issues/OPEN.md) — PPT-076 epic children after #173.
+- [Project state](project_state.md) — PPT-080 / #174 in progress (GmailSource R2); PPT-079 closed.
+- [Active issues](../issues/ACTIVE.md) — prefer project_state for in-flight PR (PPT-080).
+- [Open backlog](../issues/OPEN.md) — PPT-076 epic children after #174.
 - Closed work — GitHub issues + `git log` (no `.strata/issues/archive/`).
 
 ## Rules by trigger

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -14,28 +14,27 @@ Capture with `/strata:capture` only for work in flight.
 
 ### Last completed (this session)
 
+- **PPT-079 / #173:** core contracts, registries, `IngestionRunner` on main (#213).
 - **PPT-078 / #172:** provenance sidecar + `IngestionBridgeService` on main (#212).
 - **PPT-077 / #171:** ingestor-core + email package scaffolds on main (#211).
-- **PPT-070 / #163:** epic closed — payment dues #164–#168
-  (PRs [#197](https://github.com/Elmorralito/save-ma-money/pull/197)–[#207](https://github.com/Elmorralito/save-ma-money/pull/207)).
 
 ### In progress (ACTIVE)
 
-- **PPT-079 / #173:** core contracts, registries, `IngestionRunner` on `feat/PPT-079`
-  (persist-then-ack; DLQ-then-ack poison semantics; `source_ref` required).
-  Parent epic **PPT-076 / #170**. Downstream: #174 / #175 / #176.
+- **PPT-080 / #174:** `GmailSource` + `GmailSettings` on `feat/PPT-080`
+  (R2 headless `GMAIL_*` refresh-token; mocked CI; optional local live smoke).
+  Parent epic **PPT-076 / #170**. Downstream soft: #175 parsers; hard: #176 Prefect.
 
 ### Open (backlog)
 
-- **PPT-076** remaining children after #173 (Gmail source, bank parsers, email flow, etc.).
+- **PPT-076** remaining children after #174 (bank parsers #175, email flow #176, etc.).
 - **PPT-066 follow-up:** after 1–2 releases, drop legacy `model-v*` publish trigger.
 - Alembic/`alembic check` SQLModel CHECK alignment (`chk_financing_share`, etc.).
 
 ### Next action
 
-- Land PPT-079 / #173 ([PR #213](https://github.com/Elmorralito/save-ma-money/pull/213));
-  keep plugins consuming contracts (do not redefine them).
-  QC note: prettier blank-line fix in `modules/model/CHANGELOG.md` for `--all-files`.
+- Land PPT-080 / #174; keep plugins on core ABC (`content`, `acknowledge(RawRecord)`,
+  `registry_id`) — ignore issue draft typos. Compose `GmailSettings` with
+  `BaseIngestorSettings` (do not subclass; dual env prefixes).
 
 ### Uncommitted / staging notes
 

--- a/modules/ingestors/email/.env.example
+++ b/modules/ingestors/email/.env.example
@@ -1,7 +1,10 @@
-# Variable names only — no secrets. Runtime values live under environments/*/.env
-# Forward-looking names for Gmail OAuth (PPT-080) — not wired in this scaffold.
+# Variable names only — no secrets. Runtime values live under environments/<env>/.env
+# Gmail OAuth (PPT-080 / #174) — headless refresh-token mode (default).
 
 # GMAIL_CLIENT_ID=
 # GMAIL_CLIENT_SECRET=
 # GMAIL_REFRESH_TOKEN=
-# GMAIL_TOKEN_URI=
+# GMAIL_TOKEN_URI=https://oauth2.googleapis.com/token
+# GMAIL_PROCESSED_LABEL=PAPITA_PROCESSED
+# Optional secondary: path to a token JSON (not the default runtime path)
+# GMAIL_TOKEN_FILE=

--- a/modules/ingestors/email/.gitignore
+++ b/modules/ingestors/email/.gitignore
@@ -1,0 +1,5 @@
+# Local OAuth bootstrap leftovers (PPT-080 / #174). Root .gitignore also covers these.
+token.json
+credentials.json
+client_secret*.json
+*.apps.googleusercontent.com.json

--- a/modules/ingestors/email/README.md
+++ b/modules/ingestors/email/README.md
@@ -13,9 +13,11 @@ Email / Gmail source plugin for Papita ingestion (`papita_ingestor_email`).
 
 ## Role
 
-Plugin package under `modules/ingestors/`. Implements (in later children) Gmail
-fetch + bank-specific parsers. This scaffold is importable smoke only — **no
-OAuth, no parsers, no Prefect**.
+Plugin package under `modules/ingestors/`. Hosts the Gmail OAuth2 source
+(PPT-080 / [#174](https://github.com/Elmorralito/save-ma-money/issues/174)) and
+later bank-specific parsers (PPT-081). Prefect packaging is PPT-082 — not this
+package’s job. CI for the Gmail source uses **mocks only** (no live Google
+credentials in Actions).
 
 ## Dependency graph (one-way)
 
@@ -24,6 +26,26 @@ papita-ingestor-email  →  papita-ingestor-core  →  papita-transactions-model
 ```
 
 `papita_txnsapi` / `@papita/web` **must not** import this package.
+
+## Gmail source (PPT-080 / #174)
+
+`GmailSource` implements `BaseIngestorSource` and self-registers as `"gmail"`:
+
+```python
+from papita_ingestor_core import FetchFilter, SourceRegistry
+from papita_ingestor_email import GmailSettings, create_gmail_source
+
+# After `import papita_ingestor_email` (or create_gmail_source):
+assert SourceRegistry.get("gmail") is not None
+
+with create_gmail_source(GmailSettings()) as source:  # reads GMAIL_* from env
+    for record in source.fetch(FetchFilter(limit=10, extra={"sender": "bank@example.com"})):
+        # record.content = raw MIME bytes; metadata has subject/sender/headers
+        source.acknowledge(record)  # applies GMAIL_PROCESSED_LABEL
+```
+
+CI uses **mocked** `googleapiclient` only. Live smoke needs `GMAIL_*` in
+`environments/local/.env` (see bootstrap below).
 
 ## Local commands
 
@@ -35,4 +57,87 @@ make ingestor-lint
 
 ## Secrets
 
-See [`.env.example`](.env.example). Real OAuth tokens never belong in git.
+**R2 locked (PPT-080 / #174):** headless refresh-token env is the default runtime
+path. Interactive `InstalledAppFlow` is bootstrap-only (to mint
+`GMAIL_REFRESH_TOKEN`). If `GMAIL_TOKEN_FILE` points at a readable authorized-user
+JSON, that file is preferred at connect time; otherwise
+`GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET` / `GMAIL_REFRESH_TOKEN` are required.
+
+`GmailSettings` composes with (does not subclass) `BaseIngestorSettings` so
+`GMAIL_*` and `PAPITA_INGESTOR_*` prefixes stay distinct.
+
+Names only in [`.env.example`](.env.example). Put real values in
+`environments/<env>/.env` (gitignored). Never commit `token.json`,
+`credentials.json`, `client_secret*.json`, or refresh tokens — ignored via root
+and module `.gitignore`.
+
+| Variable                | Purpose                                                   |
+| ----------------------- | --------------------------------------------------------- |
+| `GMAIL_CLIENT_ID`       | OAuth Desktop client ID                                   |
+| `GMAIL_CLIENT_SECRET`   | OAuth Desktop client secret                               |
+| `GMAIL_REFRESH_TOKEN`   | Long-lived refresh token (headless default)               |
+| `GMAIL_TOKEN_URI`       | Usually `https://oauth2.googleapis.com/token`             |
+| `GMAIL_PROCESSED_LABEL` | Label applied on acknowledge (default `PAPITA_PROCESSED`) |
+| `GMAIL_TOKEN_FILE`      | Optional secondary path to a token JSON (not the default) |
+
+Runner knobs such as `fetch_limit` / `dry_run` stay on `PAPITA_INGESTOR_*`
+(`BaseIngestorSettings`) — do not remap them to `GMAIL_*`. Compose both settings
+objects at the runner/plugin boundary.
+
+## Local Gmail OAuth bootstrap
+
+Use this once to obtain `GMAIL_REFRESH_TOKEN` for **optional local live smoke**.
+Unit tests do not require it.
+
+### 1. Google Cloud
+
+1. Create or select a project in [Google Cloud Console](https://console.cloud.google.com/).
+2. Enable **Gmail API** (APIs & Services → Library).
+3. Configure the **OAuth consent screen** (External, or Internal for Workspace).
+   - Add scope `https://www.googleapis.com/auth/gmail.modify` (read + label/modify).
+   - While the app is in Testing, add your mailbox as a **test user**.
+4. Create credentials → **OAuth client ID** → type **Desktop app**.
+   - Note the client ID and secret (or download the client JSON for the bootstrap only).
+
+### 2. One-time consent (refresh token)
+
+With `google-auth-oauthlib` available in this package’s env (dev/bootstrap only):
+
+```bash
+# Run from a throwaway directory. Do not commit credentials.json or printed tokens.
+poetry run python - <<'PY'
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
+flow = InstalledAppFlow.from_client_secrets_file("credentials.json", SCOPES)
+# force offline access if the library version requires it:
+# flow.authorization_url(access_type="offline", prompt="consent")
+creds = flow.run_local_server(port=0)
+print("GMAIL_REFRESH_TOKEN=", creds.refresh_token)
+print("GMAIL_TOKEN_URI=", creds.token_uri)
+PY
+```
+
+Sign in as the mailbox user, approve scopes, copy the refresh token. Then delete
+local `credentials.json` / any generated `token.json`.
+
+If a later run returns no refresh token: revoke the app under
+[Google Account → Third-party access](https://myaccount.google.com/permissions)
+and consent again with offline access.
+
+### 3. Wire env for local smoke
+
+```bash
+# environments/local/.env  (gitignored)
+GMAIL_CLIENT_ID=....apps.googleusercontent.com
+GMAIL_CLIENT_SECRET=...
+GMAIL_REFRESH_TOKEN=...
+GMAIL_TOKEN_URI=https://oauth2.googleapis.com/token
+GMAIL_PROCESSED_LABEL=PAPITA_PROCESSED
+```
+
+### 4. What not to do
+
+- Do not put Google secrets in GitHub Actions for PPT-080 CI.
+- Do not commit OAuth client JSON or refresh tokens under `modules/` or the repo root.
+- Mailbox OAuth is **not** Supabase JWT / BFF auth; tenancy/`owner_id` is wired later (Prefect/API children).

--- a/modules/ingestors/email/pyproject.toml
+++ b/modules/ingestors/email/pyproject.toml
@@ -19,7 +19,11 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
-dependencies = []
+dependencies = [
+    "google-auth-oauthlib>=1.4.0,<2.0.0",
+    "google-auth>=2.56.3,<3.0.0",
+    "google-api-python-client>=2.198.0,<3.0.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/Elmorralito/save-ma-money/tree/main/modules/ingestors/email"
@@ -34,6 +38,9 @@ include = [{ path = "pyproject.toml", format = ["sdist"] }]
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
 papita-ingestor-core = { path = "../../ingestor-core", develop = true }
+google-auth-oauthlib = ">=1.4.0,<2.0.0"
+google-auth = ">=2.56.3,<3.0.0"
+google-api-python-client = ">=2.198.0,<3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=9.1.1"

--- a/modules/ingestors/email/src/papita_ingestor_email/__init__.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/__init__.py
@@ -1,4 +1,4 @@
-"""papita-ingestor-email — Gmail / email source plugin (scaffold).
+"""papita-ingestor-email — Gmail / email source plugin.
 
 Depends on ``papita_ingestor_core`` only. Do not import this package from
 ``papita_txnsapi`` or ``@papita/web``.
@@ -7,5 +7,13 @@ Depends on ``papita_ingestor_core`` only. Do not import this package from
 from __future__ import annotations
 
 from papita_ingestor_email.__meta__ import __version__
+from papita_ingestor_email.settings import GmailSettings
+from papita_ingestor_email.sources import GmailSource, create_gmail_source, ensure_registered
 
-__all__ = ["__version__"]
+__all__ = [
+    "GmailSettings",
+    "GmailSource",
+    "create_gmail_source",
+    "ensure_registered",
+    "__version__",
+]

--- a/modules/ingestors/email/src/papita_ingestor_email/settings.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/settings.py
@@ -1,0 +1,51 @@
+"""Gmail plugin settings (PPT-080 / #174).
+
+Uses ``GMAIL_*`` env vars. Runner knobs (``fetch_limit``, ``dry_run``) stay on
+``papita_ingestor_core.settings.BaseIngestorSettings`` (``PAPITA_INGESTOR_*``).
+
+Intentionally does **not** subclass ``BaseIngestorSettings``: that base uses
+``env_prefix=\"PAPITA_INGESTOR_\"``, while Gmail credentials must use ``GMAIL_*``.
+Compose both settings objects at the runner/plugin boundary (R2).
+"""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token"
+_DEFAULT_PROCESSED_LABEL = "PAPITA_PROCESSED"
+
+
+class GmailSettings(BaseSettings):
+    """Headless Gmail OAuth credentials and ack label (R2 default).
+
+    Auth material (either is enough):
+
+    - Env refresh-token path: ``client_id`` + ``client_secret`` + ``refresh_token``
+    - Secondary path: ``token_file`` pointing at an authorized-user JSON
+    """
+
+    model_config = SettingsConfigDict(extra="ignore", env_prefix="GMAIL_")
+
+    client_id: str | None = Field(default=None, min_length=1)
+    client_secret: str | None = Field(default=None, min_length=1)
+    refresh_token: str | None = Field(default=None, min_length=1)
+    token_uri: str = Field(default=_DEFAULT_TOKEN_URI, min_length=1)
+    processed_label: str = Field(default=_DEFAULT_PROCESSED_LABEL, min_length=1)
+    token_file: str | None = None
+
+    @model_validator(mode="after")
+    def _require_auth_material(self) -> Self:
+        has_token_file = bool(self.token_file and self.token_file.strip())
+        has_env_triplet = bool(self.client_id and self.client_secret and self.refresh_token)
+        if has_token_file or has_env_triplet:
+            return self
+        raise ValueError(
+            "Gmail auth requires GMAIL_TOKEN_FILE or GMAIL_CLIENT_ID + GMAIL_CLIENT_SECRET + GMAIL_REFRESH_TOKEN"
+        )
+
+
+__all__ = ["GmailSettings"]

--- a/modules/ingestors/email/src/papita_ingestor_email/sources/__init__.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/sources/__init__.py
@@ -1,0 +1,15 @@
+"""Email / Gmail source plugins."""
+
+from __future__ import annotations
+
+from papita_ingestor_email.sources.gmail import GmailSource, create_gmail_source, ensure_registered
+from papita_ingestor_email.sources.query import build_gmail_query
+
+ensure_registered()
+
+__all__ = [
+    "GmailSource",
+    "build_gmail_query",
+    "create_gmail_source",
+    "ensure_registered",
+]

--- a/modules/ingestors/email/src/papita_ingestor_email/sources/gmail.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/sources/gmail.py
@@ -1,0 +1,273 @@
+"""Gmail OAuth2 ``BaseIngestorSource`` plugin (PPT-080 / #174)."""
+
+from __future__ import annotations
+
+import base64
+import logging
+from collections.abc import Iterable
+from email import policy
+from email.parser import BytesParser
+from pathlib import Path
+from typing import Any
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import Resource, build
+
+from papita_ingestor_core.errors import IngestorConnectionError, IngestorFetchError
+from papita_ingestor_core.registry import SourceRegistry
+from papita_ingestor_core.sources import BaseIngestorSource
+from papita_ingestor_core.types.records import FetchFilter, RawRecord
+from papita_ingestor_email.settings import GmailSettings
+from papita_ingestor_email.sources.query import build_gmail_query
+from papita_txnsmodel.model.enums import IngestionSource
+
+logger = logging.getLogger(__name__)
+
+_GMAIL_SCOPE = "https://www.googleapis.com/auth/gmail.modify"
+_LIST_PAGE_SIZE = 100
+
+
+@SourceRegistry.register
+class GmailSource(BaseIngestorSource):
+    """Headless Gmail source using refresh-token credentials (R2)."""
+
+    registry_id = "gmail"
+
+    def __init__(
+        self,
+        settings: GmailSettings | None = None,
+        *,
+        service: Resource | None = None,
+    ) -> None:
+        """Create a Gmail source.
+
+        Args:
+            settings: Gmail env settings. Loaded from ``GMAIL_*`` when omitted.
+            service: Optional pre-built Gmail API resource (unit tests / DI).
+        """
+        self._settings = settings
+        self._service = service
+        self._owns_service = service is None
+        self._label_id: str | None = None
+        self._connected = False
+
+    @property
+    def source_id(self) -> str:
+        return self.registry_id
+
+    @property
+    def settings(self) -> GmailSettings:
+        """Lazy settings load so registry import does not require env secrets."""
+        if self._settings is None:
+            self._settings = GmailSettings()
+        return self._settings
+
+    def connect(self) -> None:
+        created_service = False
+        try:
+            if self._service is None:
+                self._service = self._build_service()
+                self._owns_service = True
+                created_service = True
+            self._label_id = self._ensure_processed_label()
+        except Exception as exc:
+            if created_service:
+                self._service = None
+            self._label_id = None
+            self._connected = False
+            if isinstance(exc, IngestorConnectionError):
+                raise
+            raise IngestorConnectionError(f"Gmail connect failed: {exc}") from exc
+        self._connected = True
+        logger.info("Connected Gmail source (processed_label=%s)", self.settings.processed_label)
+
+    def disconnect(self) -> None:
+        if self._owns_service:
+            self._service = None
+        self._label_id = None
+        self._connected = False
+
+    def health_check(self) -> bool:
+        if not self._connected or self._service is None:
+            return False
+        try:
+            self._service.users().getProfile(userId="me").execute()
+            return True
+        except Exception as exc:
+            logger.warning("Gmail health_check failed: %s", exc)
+            return False
+
+    def fetch(self, fetch_filter: FetchFilter | None = None) -> Iterable[RawRecord]:
+        if not self._connected or self._service is None:
+            raise IngestorFetchError("Gmail source is not connected")
+
+        query = build_gmail_query(fetch_filter, processed_label=self.settings.processed_label)
+        remaining = fetch_filter.limit if fetch_filter is not None else None
+        page_token = fetch_filter.cursor if fetch_filter is not None else None
+
+        try:
+            yield from self._iter_messages(query=query, remaining=remaining, page_token=page_token)
+        except IngestorFetchError:
+            raise
+        except Exception as exc:
+            raise IngestorFetchError(f"Gmail fetch failed: {exc}") from exc
+
+    def acknowledge(self, record: RawRecord) -> None:
+        if not self._connected or self._service is None or self._label_id is None:
+            raise IngestorConnectionError("Gmail source is not connected")
+        if not record.source_ref:
+            raise IngestorFetchError("acknowledge requires RawRecord.source_ref (Gmail message id)")
+
+        try:
+            self._service.users().messages().modify(
+                userId="me",
+                id=record.source_ref,
+                body={"addLabelIds": [self._label_id]},
+            ).execute()
+        except Exception as exc:
+            raise IngestorFetchError(f"Gmail acknowledge failed for {record.source_ref}: {exc}") from exc
+        logger.debug("Acknowledged Gmail message %s with label %s", record.source_ref, self.settings.processed_label)
+
+    def _build_service(self) -> Resource:
+        credentials = self._build_credentials()
+        if not credentials.valid:
+            if not credentials.refresh_token:
+                raise IngestorConnectionError("Gmail refresh token missing")
+            credentials.refresh(Request())
+        return build("gmail", "v1", credentials=credentials, cache_discovery=False)
+
+    def _build_credentials(self) -> Credentials:
+        """Load credentials from ``token_file`` when present, else env refresh-token (R2)."""
+        settings = self.settings
+        token_path = Path(settings.token_file).expanduser() if settings.token_file else None
+        if token_path is not None and token_path.is_file():
+            logger.debug("Loading Gmail credentials from token_file=%s", token_path)
+            return Credentials.from_authorized_user_file(str(token_path), [_GMAIL_SCOPE])
+
+        if not (settings.client_id and settings.client_secret and settings.refresh_token):
+            raise IngestorConnectionError(
+                "Gmail env credentials incomplete; set GMAIL_CLIENT_ID/SECRET/REFRESH_TOKEN "
+                "or a readable GMAIL_TOKEN_FILE"
+            )
+        return Credentials(
+            token=None,
+            refresh_token=settings.refresh_token,
+            token_uri=settings.token_uri,
+            client_id=settings.client_id,
+            client_secret=settings.client_secret,
+            scopes=[_GMAIL_SCOPE],
+        )
+
+    def _ensure_processed_label(self) -> str:
+        assert self._service is not None
+        label_name = self.settings.processed_label
+        listed = self._service.users().labels().list(userId="me").execute()
+        for label in listed.get("labels", []):
+            if label.get("name") == label_name:
+                return str(label["id"])
+
+        created = (
+            self._service.users()
+            .labels()
+            .create(
+                userId="me",
+                body={
+                    "name": label_name,
+                    "labelListVisibility": "labelShow",
+                    "messageListVisibility": "show",
+                },
+            )
+            .execute()
+        )
+        label_id = created.get("id")
+        if not label_id:
+            raise IngestorConnectionError(f"Gmail label create returned no id for {label_name!r}")
+        logger.info("Created Gmail label %s (%s)", label_name, label_id)
+        return str(label_id)
+
+    def _iter_messages(
+        self,
+        *,
+        query: str,
+        remaining: int | None,
+        page_token: str | None,
+    ) -> Iterable[RawRecord]:
+        assert self._service is not None
+        token = page_token
+        left = remaining
+
+        while True:
+            page_size = _LIST_PAGE_SIZE if left is None else min(_LIST_PAGE_SIZE, left)
+            response = (
+                self._service.users()
+                .messages()
+                .list(userId="me", q=query, maxResults=page_size, pageToken=token)
+                .execute()
+            )
+            messages = response.get("messages") or []
+            if not messages:
+                # Empty page: stop even if a nextPageToken is present (avoid hang).
+                return
+
+            for item in messages:
+                message_id = item.get("id")
+                if not message_id:
+                    continue
+                message = self._service.users().messages().get(userId="me", id=message_id, format="raw").execute()
+                yield self._to_raw_record(message)
+                if left is not None:
+                    left -= 1
+                    if left <= 0:
+                        return
+
+            token = response.get("nextPageToken")
+            if not token:
+                return
+
+    def _to_raw_record(self, message: dict[str, Any]) -> RawRecord:
+        message_id = str(message["id"])
+        raw_b64 = message.get("raw") or ""
+        content = base64.urlsafe_b64decode(raw_b64 + "=" * (-len(raw_b64) % 4))
+        subject, sender, headers = _parse_mime_headers(content)
+        metadata: dict[str, Any] = {
+            "subject": subject,
+            "sender": sender,
+            "headers": headers,
+            "thread_id": message.get("threadId"),
+            "label_ids": message.get("labelIds") or [],
+            "snippet": message.get("snippet"),
+            "internal_date": message.get("internalDate"),
+            "history_id": message.get("historyId"),
+        }
+        return RawRecord(
+            source_id=self.source_id,
+            source_ref=message_id,
+            content=content,
+            metadata=metadata,
+            ingestion_source=IngestionSource.EMAIL,
+        )
+
+
+def create_gmail_source(settings: GmailSettings | None = None) -> GmailSource:
+    """Factory for runners / Prefect wiring (PPT-082)."""
+    ensure_registered()
+    return GmailSource(settings=settings)
+
+
+def ensure_registered() -> type[GmailSource]:
+    """Idempotent registry ensure (core tests may ``SourceRegistry.clear()``)."""
+    if "gmail" not in SourceRegistry.all():
+        SourceRegistry.register(GmailSource)
+    return GmailSource
+
+
+def _parse_mime_headers(content: bytes) -> tuple[str | None, str | None, dict[str, str]]:
+    if not content:
+        return None, None, {}
+    parsed = BytesParser(policy=policy.default).parsebytes(content)
+    headers = {str(key): str(value) for key, value in parsed.items()}
+    return parsed.get("Subject"), parsed.get("From"), headers
+
+
+__all__ = ["GmailSource", "create_gmail_source", "ensure_registered"]

--- a/modules/ingestors/email/src/papita_ingestor_email/sources/query.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/sources/query.py
@@ -1,0 +1,50 @@
+"""Gmail search query builder (PPT-080 / #174)."""
+
+from __future__ import annotations
+
+from papita_ingestor_core.types.records import FetchFilter
+
+
+def _quote_label(label: str) -> str:
+    """Quote label names that contain spaces for Gmail ``q`` syntax."""
+    if " " in label or '"' in label:
+        escaped = label.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return label
+
+
+def build_gmail_query(
+    fetch_filter: FetchFilter | None,
+    *,
+    processed_label: str,
+) -> str:
+    """Build a Gmail ``messages.list`` ``q`` string.
+
+    Always excludes the processed label so acknowledged mail is not re-fetched.
+    Supports ``FetchFilter.since`` / ``until`` (epoch seconds), and ``extra`` keys
+    ``sender``, ``subject``, and ``q`` (raw fragment).
+    """
+    parts: list[str] = [f"-label:{_quote_label(processed_label)}"]
+    if fetch_filter is None:
+        return " ".join(parts)
+
+    if fetch_filter.since is not None:
+        parts.append(f"after:{int(fetch_filter.since.timestamp())}")
+    if fetch_filter.until is not None:
+        parts.append(f"before:{int(fetch_filter.until.timestamp())}")
+
+    extra = fetch_filter.extra
+    sender = extra.get("sender")
+    if sender:
+        parts.append(f"from:{sender}")
+    subject = extra.get("subject")
+    if subject:
+        parts.append(f"subject:({subject})")
+    raw_q = extra.get("q")
+    if raw_q:
+        parts.append(str(raw_q))
+
+    return " ".join(parts)
+
+
+__all__ = ["build_gmail_query"]

--- a/modules/ingestors/email/tests/conftest.py
+++ b/modules/ingestors/email/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Email plugin test fixtures."""
+
+from __future__ import annotations
+
+import pytest
+
+from papita_ingestor_email.sources.gmail import ensure_registered
+
+
+@pytest.fixture(autouse=True)
+def _ensure_gmail_registered() -> None:
+    """Re-register after core suite ``SourceRegistry.clear()`` in shared pytest runs."""
+    ensure_registered()

--- a/modules/ingestors/email/tests/test_gmail_query.py
+++ b/modules/ingestors/email/tests/test_gmail_query.py
@@ -1,0 +1,36 @@
+"""Tests for Gmail query builder."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from papita_ingestor_core.types.records import FetchFilter
+from papita_ingestor_email.sources.query import build_gmail_query
+
+
+def test_query_excludes_processed_label_by_default() -> None:
+    assert build_gmail_query(None, processed_label="PAPITA_PROCESSED") == "-label:PAPITA_PROCESSED"
+
+
+def test_query_quotes_label_with_spaces() -> None:
+    query = build_gmail_query(None, processed_label="PAPITA PROCESSED")
+    assert query == '-label:"PAPITA PROCESSED"'
+
+
+def test_query_includes_since_until_and_extra_filters() -> None:
+    since = datetime(2024, 1, 15, 12, 0, tzinfo=timezone.utc)
+    until = datetime(2024, 2, 1, 0, 0, tzinfo=timezone.utc)
+    fetch_filter = FetchFilter(
+        since=since,
+        until=until,
+        extra={"sender": "bank@example.com", "subject": "Alert", "q": "has:attachment"},
+    )
+
+    query = build_gmail_query(fetch_filter, processed_label="PAPITA_PROCESSED")
+
+    assert "-label:PAPITA_PROCESSED" in query
+    assert f"after:{int(since.timestamp())}" in query
+    assert f"before:{int(until.timestamp())}" in query
+    assert "from:bank@example.com" in query
+    assert "subject:(Alert)" in query
+    assert "has:attachment" in query

--- a/modules/ingestors/email/tests/test_gmail_settings.py
+++ b/modules/ingestors/email/tests/test_gmail_settings.py
@@ -1,0 +1,67 @@
+"""Unit tests for GmailSettings (R2 headless env + optional token_file)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from papita_ingestor_email.settings import GmailSettings
+
+
+def test_gmail_settings_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Loads GMAIL_* without requiring PAPITA_INGESTOR_* runner knobs."""
+    monkeypatch.setenv("GMAIL_CLIENT_ID", "client.apps.googleusercontent.com")
+    monkeypatch.setenv("GMAIL_CLIENT_SECRET", "secret-value")
+    monkeypatch.setenv("GMAIL_REFRESH_TOKEN", "refresh-token-value")
+    monkeypatch.delenv("GMAIL_TOKEN_URI", raising=False)
+    monkeypatch.delenv("GMAIL_PROCESSED_LABEL", raising=False)
+    monkeypatch.delenv("GMAIL_TOKEN_FILE", raising=False)
+
+    settings = GmailSettings()
+
+    assert settings.client_id == "client.apps.googleusercontent.com"
+    assert settings.client_secret == "secret-value"
+    assert settings.refresh_token == "refresh-token-value"
+    assert settings.token_uri == "https://oauth2.googleapis.com/token"
+    assert settings.processed_label == "PAPITA_PROCESSED"
+    assert settings.token_file is None
+
+
+def test_gmail_settings_optional_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Optional token_file / label / token_uri override via env."""
+    monkeypatch.setenv("GMAIL_CLIENT_ID", "id")
+    monkeypatch.setenv("GMAIL_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("GMAIL_REFRESH_TOKEN", "refresh")
+    monkeypatch.setenv("GMAIL_TOKEN_URI", "https://example.test/token")
+    monkeypatch.setenv("GMAIL_PROCESSED_LABEL", "CUSTOM_LABEL")
+    monkeypatch.setenv("GMAIL_TOKEN_FILE", "/tmp/gmail-token.json")
+
+    settings = GmailSettings()
+
+    assert settings.token_uri == "https://example.test/token"
+    assert settings.processed_label == "CUSTOM_LABEL"
+    assert settings.token_file == "/tmp/gmail-token.json"
+
+
+def test_gmail_settings_token_file_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Secondary path: token_file alone satisfies auth material."""
+    monkeypatch.delenv("GMAIL_CLIENT_ID", raising=False)
+    monkeypatch.delenv("GMAIL_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("GMAIL_REFRESH_TOKEN", raising=False)
+    monkeypatch.setenv("GMAIL_TOKEN_FILE", "/tmp/gmail-token.json")
+
+    settings = GmailSettings()
+
+    assert settings.token_file == "/tmp/gmail-token.json"
+    assert settings.refresh_token is None
+
+
+def test_gmail_settings_requires_auth_material(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing both env triplet and token_file fails fast."""
+    monkeypatch.delenv("GMAIL_CLIENT_ID", raising=False)
+    monkeypatch.delenv("GMAIL_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("GMAIL_REFRESH_TOKEN", raising=False)
+    monkeypatch.delenv("GMAIL_TOKEN_FILE", raising=False)
+
+    with pytest.raises(ValidationError):
+        GmailSettings()

--- a/modules/ingestors/email/tests/test_gmail_source.py
+++ b/modules/ingestors/email/tests/test_gmail_source.py
@@ -1,0 +1,253 @@
+"""Mocked unit tests for GmailSource (no live Google network)."""
+
+from __future__ import annotations
+
+import base64
+from email.message import EmailMessage
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from papita_ingestor_core.errors import IngestorConnectionError, IngestorFetchError
+from papita_ingestor_core.registry import SourceRegistry
+from papita_ingestor_core.types.records import FetchFilter, RawRecord
+from papita_ingestor_email.settings import GmailSettings
+from papita_ingestor_email.sources.gmail import GmailSource, create_gmail_source, ensure_registered
+from papita_txnsmodel.model.enums import IngestionSource
+
+
+def _settings() -> GmailSettings:
+    return GmailSettings(
+        client_id="client.apps.googleusercontent.com",
+        client_secret="secret",
+        refresh_token="refresh",
+        processed_label="PAPITA_PROCESSED",
+    )
+
+
+def _raw_message_bytes(*, subject: str = "Txn alert", sender: str = "bank@example.com") -> bytes:
+    message = EmailMessage()
+    message["Subject"] = subject
+    message["From"] = sender
+    message["To"] = "me@example.com"
+    message.set_content("opaque body")
+    return message.as_bytes()
+
+
+def _gmail_api_message(message_id: str = "msg-1", **overrides: Any) -> dict[str, Any]:
+    raw = base64.urlsafe_b64encode(_raw_message_bytes()).decode("ascii").rstrip("=")
+    payload = {
+        "id": message_id,
+        "threadId": "thread-1",
+        "labelIds": ["INBOX"],
+        "snippet": "opaque body",
+        "internalDate": "1700000000000",
+        "historyId": "99",
+        "raw": raw,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _mock_service(
+    *,
+    labels: list[dict[str, str]] | None = None,
+    list_pages: list[dict[str, Any]] | None = None,
+    messages: dict[str, dict[str, Any]] | None = None,
+) -> MagicMock:
+    service = MagicMock()
+    users = service.users.return_value
+
+    users.labels.return_value.list.return_value.execute.return_value = {"labels": labels or []}
+    users.labels.return_value.create.return_value.execute.return_value = {
+        "id": "Label_created",
+        "name": "PAPITA_PROCESSED",
+    }
+
+    pages = list(list_pages if list_pages is not None else [{"messages": [{"id": "msg-1"}]}])
+    users.messages.return_value.list.return_value.execute.side_effect = pages
+
+    by_id = messages or {"msg-1": _gmail_api_message("msg-1")}
+
+    def _get(**kwargs: Any) -> MagicMock:
+        handle = MagicMock()
+        handle.execute.return_value = by_id[kwargs["id"]]
+        return handle
+
+    users.messages.return_value.get.side_effect = _get
+    users.messages.return_value.modify.return_value.execute.return_value = {}
+    users.getProfile.return_value.execute.return_value = {"emailAddress": "me@example.com"}
+    return service
+
+
+def test_source_registry_get_gmail() -> None:
+    ensure_registered()
+    assert SourceRegistry.get("gmail") is GmailSource
+
+
+def test_create_gmail_source_factory() -> None:
+    source = create_gmail_source(settings=_settings())
+    assert isinstance(source, GmailSource)
+    assert source.source_id == "gmail"
+
+
+def test_connect_creates_processed_label_when_missing() -> None:
+    service = _mock_service(labels=[])
+    source = GmailSource(settings=_settings(), service=service)
+
+    source.connect()
+
+    service.users.return_value.labels.return_value.create.assert_called_once()
+    assert source.health_check() is True
+    source.disconnect()
+    assert source.health_check() is False
+
+
+def test_connect_reuses_existing_label() -> None:
+    service = _mock_service(labels=[{"id": "Label_9", "name": "PAPITA_PROCESSED"}])
+    source = GmailSource(settings=_settings(), service=service)
+
+    source.connect()
+
+    service.users.return_value.labels.return_value.create.assert_not_called()
+    assert source._label_id == "Label_9"  # noqa: SLF001 — intentional state check
+
+
+def test_fetch_requires_connect() -> None:
+    source = GmailSource(settings=_settings(), service=_mock_service())
+    with pytest.raises(IngestorFetchError, match="not connected"):
+        list(source.fetch())
+
+
+def test_fetch_yields_raw_records_with_metadata() -> None:
+    service = _mock_service()
+    source = GmailSource(settings=_settings(), service=service)
+    source.connect()
+
+    records = list(source.fetch(FetchFilter(limit=1)))
+
+    assert len(records) == 1
+    record = records[0]
+    assert record.source_id == "gmail"
+    assert record.source_ref == "msg-1"
+    assert record.ingestion_source == IngestionSource.EMAIL
+    assert isinstance(record.content, (bytes, bytearray))
+    assert record.metadata["subject"] == "Txn alert"
+    assert record.metadata["sender"] == "bank@example.com"
+    assert "Subject" in record.metadata["headers"]
+
+    list_kwargs = service.users.return_value.messages.return_value.list.call_args.kwargs
+    assert "-label:PAPITA_PROCESSED" in list_kwargs["q"]
+    assert list_kwargs["maxResults"] == 1
+
+
+def test_acknowledge_adds_processed_label() -> None:
+    service = _mock_service(labels=[{"id": "Label_9", "name": "PAPITA_PROCESSED"}])
+    source = GmailSource(settings=_settings(), service=service)
+    source.connect()
+
+    record = RawRecord(
+        source_id="gmail",
+        source_ref="msg-1",
+        content=b"x",
+        ingestion_source=IngestionSource.EMAIL,
+    )
+    source.acknowledge(record)
+
+    modify_kwargs = service.users.return_value.messages.return_value.modify.call_args.kwargs
+    assert modify_kwargs["id"] == "msg-1"
+    assert modify_kwargs["body"] == {"addLabelIds": ["Label_9"]}
+
+
+def test_acknowledge_requires_source_ref() -> None:
+    service = _mock_service(labels=[{"id": "Label_9", "name": "PAPITA_PROCESSED"}])
+    source = GmailSource(settings=_settings(), service=service)
+    source.connect()
+    record = RawRecord(source_id="gmail", content=b"x", ingestion_source=IngestionSource.EMAIL)
+
+    with pytest.raises(IngestorFetchError, match="source_ref"):
+        source.acknowledge(record)
+
+
+def test_context_manager_connect_disconnect() -> None:
+    service = _mock_service(labels=[{"id": "Label_9", "name": "PAPITA_PROCESSED"}])
+    source = GmailSource(settings=_settings(), service=service)
+
+    with source:
+        assert source.health_check() is True
+    assert source.health_check() is False
+
+
+def test_connect_wraps_service_errors() -> None:
+    service = MagicMock()
+    service.users.return_value.labels.return_value.list.return_value.execute.side_effect = RuntimeError("boom")
+    source = GmailSource(settings=_settings(), service=service)
+
+    with pytest.raises(IngestorConnectionError, match="Gmail connect failed"):
+        source.connect()
+
+
+def test_connect_failure_clears_owned_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Failed label ensure must not leave a owned live client attached."""
+    fake_service = _mock_service(labels=[])
+    fake_service.users.return_value.labels.return_value.list.return_value.execute.side_effect = RuntimeError(
+        "label boom"
+    )
+
+    source = GmailSource(settings=_settings())
+    monkeypatch.setattr(source, "_build_service", lambda: fake_service)
+
+    with pytest.raises(IngestorConnectionError, match="Gmail connect failed"):
+        source.connect()
+
+    assert source._service is None  # noqa: SLF001
+    assert source._connected is False  # noqa: SLF001
+
+
+def test_fetch_stops_on_empty_messages_page() -> None:
+    """Empty list page terminates even if Google returns a nextPageToken."""
+    service = _mock_service(list_pages=[{"messages": [], "nextPageToken": "ghost"}])
+    source = GmailSource(settings=_settings(), service=service)
+    source.connect()
+
+    assert list(source.fetch()) == []
+    service.users.return_value.messages.return_value.list.assert_called_once()
+
+
+def test_build_credentials_prefers_token_file(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Secondary path: readable GMAIL_TOKEN_FILE loads authorized-user JSON."""
+    token_path = tmp_path / "token.json"
+    token_path.write_text(
+        '{"token": "ya29.access", "refresh_token": "refresh", '
+        '"token_uri": "https://oauth2.googleapis.com/token", '
+        '"client_id": "id", "client_secret": "secret", '
+        '"scopes": ["https://www.googleapis.com/auth/gmail.modify"]}',
+        encoding="utf-8",
+    )
+    settings = GmailSettings(token_file=str(token_path))
+    source = GmailSource(settings=settings)
+
+    loaded: dict[str, object] = {}
+
+    def _fake_from_file(path: str, scopes: list[str] | None = None) -> MagicMock:
+        loaded["path"] = path
+        loaded["scopes"] = scopes
+        creds = MagicMock()
+        creds.valid = True
+        creds.refresh_token = "refresh"
+        return creds
+
+    monkeypatch.setattr(
+        "papita_ingestor_email.sources.gmail.Credentials.from_authorized_user_file",
+        _fake_from_file,
+    )
+    monkeypatch.setattr(
+        "papita_ingestor_email.sources.gmail.build",
+        lambda *args, **kwargs: _mock_service(labels=[{"id": "Label_9", "name": "PAPITA_PROCESSED"}]),
+    )
+
+    source.connect()
+
+    assert loaded["path"] == str(token_path)
+    assert source.health_check() is True


### PR DESCRIPTION
**Branch:** `feat/PPT-080` · **Base:** `main` · **1 commit** · **17 files**

**Suggested title:** `feat/PPT-080: [ingestor] Gmail OAuth2 source plugin`

## Summary

Implements `GmailSource` in `papita-ingestor-email` against `papita_ingestor_core` contracts (PPT-080 / #174). Headless refresh-token env (`GMAIL_*`, R2) is the default runtime path; CI stays fully mocked with no live Google credentials. Operators can optionally bootstrap a refresh token for local smoke only.

## Out of scope / Highlights

**Out of scope**

- Outlook / IMAP providers
- Bank body parsers (PPT-081 / #175)
- Prefect email flow packaging (PPT-082 / #176)
- SPA mailbox linking UI
- End-to-end ledger ingestion (needs parsers + bridge owner wiring)

**Highlights**

- Self-registers as `"gmail"` via `@SourceRegistry.register` + `registry_id` (matches core; not the issue draft’s unsupported positional form)
- Compose `GmailSettings` with `BaseIngestorSettings` so `GMAIL_*` and `PAPITA_INGESTOR_*` stay distinct
- Query exclusion of processed label + optional `GMAIL_TOKEN_FILE` secondary path

## Changes

**Ingestor email plugin**

- `GmailSource`: connect (refresh-token or authorized-user file), ensure processed label, fetch `list`→`get` raw MIME → `RawRecord`, acknowledge via label
- `build_gmail_query`: `-label:…`, since/until, sender/subject/raw `q`
- Google client libraries added to email `pyproject.toml`

**Secrets / hygiene**

- Root + module `.gitignore` for `token.json` / `credentials.json` / `client_secret*.json`
- `.env.example` names-only; README documents R2 + OAuth bootstrap
- `.gitleaks.toml` allowlists email README / `.env.example`

**Tests / docs / strata**

- Mocked unit tests for settings, query, source lifecycle
- `.strata` memory pointers updated for PPT-080 in progress

## File changes

<details>
<summary>File changes (~17 files)</summary>

```
 .gitignore                                         |   9 +
 .gitleaks.toml                                     |   2 +
 .strata/memory/MEMORY.md                           |   6 +-
 .strata/memory/project_state.md                    |  17 +-
 modules/ingestors/email/.env.example               |   9 +-
 modules/ingestors/email/.gitignore                 |   5 +
 modules/ingestors/email/README.md                  | 113 ++++++++-
 modules/ingestors/email/pyproject.toml             |   9 +-
 .../email/src/papita_ingestor_email/__init__.py    |  12 +-
 .../email/src/papita_ingestor_email/settings.py    |  51 ++++
 .../src/papita_ingestor_email/sources/__init__.py  |  15 ++
 .../src/papita_ingestor_email/sources/gmail.py     | 273 +++++++++++++++++++++
 .../src/papita_ingestor_email/sources/query.py     |  50 ++++
 modules/ingestors/email/tests/conftest.py          |  13 +
 modules/ingestors/email/tests/test_gmail_query.py  |  36 +++
 .../ingestors/email/tests/test_gmail_settings.py   |  67 +++++
 modules/ingestors/email/tests/test_gmail_source.py | 253 +++++++++++++++++++
 17 files changed, 918 insertions(+), 22 deletions(-)
```

</details>

## Commits

- `0020161` feat/PPT-080: [ingestor] Gmail OAuth2 source plugin

## Checks, tests, and validation already done

- `make ingestor-test` — pass (49 tests)
- `make ingestor-lint` — pass
- Pre-commit on commit — pass (including strata strict pairing)
- Live Gmail fetch/ack smoke — not run in this PR path (optional local only)
- GitHub Actions CI — not observed yet at PR open

## QA / test plan

- [ ] Ingestor CI green on the PR
- [ ] Confirm `SourceRegistry.get("gmail")` works after `import papita_ingestor_email` in a clean env
- [ ] Optional local: with `GMAIL_*` in `environments/local/.env`, fetch a few messages (no ack) and verify metadata
- [ ] Confirm no `token.json` / `credentials.json` / client secrets committed

## Risks

> [!CAUTION]
>
> ### Risks
>
> - Live Gmail needs `GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET` / `GMAIL_REFRESH_TOKEN` (or readable `GMAIL_TOKEN_FILE`); values must stay in gitignored `environments/<env>/.env`
> - `acknowledge` applies `GMAIL_PROCESSED_LABEL` (default `PAPITA_PROCESSED`) and excludes those messages from later fetches — use carefully on real mailboxes
> - OAuth consent app in Testing must list the mailbox as a test user (`403 access_denied` otherwise)

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - Issue #174 draft typos (`raw_content`, `acknowledge(record_id)`, `@register("gmail)"`, subclassing `BaseIngestorSettings`) are intentionally followed as **core ABC** / R2 compose instead
> - Full ingest → parse → persist needs PPT-081 parsers; this PR is source-only
> - `poetry update papita-ingestor-email` (or `make ingestor-install`) needed locally so root venv picks up Google transitive deps (`poetry.lock` is gitignored)

## References

- Closes [#174](https://github.com/Elmorralito/save-ma-money/issues/174) (PPT-080)
- Parent epic [#170](https://github.com/Elmorralito/save-ma-money/issues/170) (PPT-076)
- Depends on [#173](https://github.com/Elmorralito/save-ma-money/issues/173) (PPT-079) — already on main
- Soft downstream: [#175](https://github.com/Elmorralito/save-ma-money/issues/175); hard: [#176](https://github.com/Elmorralito/save-ma-money/issues/176)

Made with [Cursor](https://cursor.com)