### PR TITLE
feat/PPT-081: [ingestor] Bancolombia and Nequi email parsers

### DIFF
--- a/.strata/memory/MEMORY.md
+++ b/.strata/memory/MEMORY.md
@@ -4,9 +4,9 @@ Pure hot index: live pointers + the generated rules-by-trigger table. Keep ≤80
 
 ## Live pointers
 
-- [Project state](project_state.md) — PPT-080 / #174 in progress (GmailSource R2); PPT-079 closed.
-- [Active issues](../issues/ACTIVE.md) — prefer project_state for in-flight PR (PPT-080).
-- [Open backlog](../issues/OPEN.md) — PPT-076 epic children after #174.
+- [Project state](project_state.md) — PPT-081 / #175 in progress (bank email parsers); PPT-080 closed.
+- [Active issues](../issues/ACTIVE.md) — prefer project_state for in-flight PR (PPT-081).
+- [Open backlog](../issues/OPEN.md) — PPT-076 epic children after #175.
 - Closed work — GitHub issues + `git log` (no `.strata/issues/archive/`).
 
 ## Rules by trigger

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -14,27 +14,27 @@ Capture with `/strata:capture` only for work in flight.
 
 ### Last completed (this session)
 
+- **PPT-080 / #174:** `GmailSource` + `GmailSettings` on main (#214).
 - **PPT-079 / #173:** core contracts, registries, `IngestionRunner` on main (#213).
 - **PPT-078 / #172:** provenance sidecar + `IngestionBridgeService` on main (#212).
 - **PPT-077 / #171:** ingestor-core + email package scaffolds on main (#211).
 
 ### In progress (ACTIVE)
 
-- **PPT-080 / #174:** `GmailSource` + `GmailSettings` on `feat/PPT-080`
-  (R2 headless `GMAIL_*` refresh-token; mocked CI; optional local live smoke).
-  Parent epic **PPT-076 / #170**. Downstream soft: #175 parsers; hard: #176 Prefect.
+- **PPT-081 / #175:** Bancolombia + synthetic Nequi email parsers + hybrid
+  `FallbackEmailParser` on `175-featppt-081-…` (R1=B; COP; FKs deferred to #176).
+  Parent epic **PPT-076 / #170**. Downstream hard: #176 Prefect/end-to-end.
 
 ### Open (backlog)
 
-- **PPT-076** remaining children after #174 (bank parsers #175, email flow #176, etc.).
+- **PPT-076** remaining children after #175 (email flow #176, etc.).
 - **PPT-066 follow-up:** after 1–2 releases, drop legacy `model-v*` publish trigger.
 - Alembic/`alembic check` SQLModel CHECK alignment (`chk_financing_share`, etc.).
 
 ### Next action
 
-- Land PPT-080 / #174; keep plugins on core ABC (`content`, `acknowledge(RawRecord)`,
-  `registry_id`) — ignore issue draft typos. Compose `GmailSettings` with
-  `BaseIngestorSettings` (do not subclass; dual env prefixes).
+- Land PPT-081 / #175; hand off stable `parser_id`s + unrecognized→DLQ semantics to
+  PPT-082 / #176 (account/category FK resolution). Do not ship Nu under `NequiParser`.
 
 ### Uncommitted / staging notes
 

--- a/modules/ingestors/email/CHANGELOG.md
+++ b/modules/ingestors/email/CHANGELOG.md
@@ -13,3 +13,6 @@ This file is **not** the monorepo issue tracker changelog. Root
 - Package scaffold for PPT-077 / [#171](https://github.com/Elmorralito/save-ma-money/issues/171)
   (`src/papita_ingestor_email`, smoke tests, path dependency on
   `papita-ingestor-core`).
+- Bank email parsers for PPT-081 / [#175](https://github.com/Elmorralito/save-ma-money/issues/175):
+  `BancolombiaParser`, synthetic `NequiParser`, hybrid `FallbackEmailParser`,
+  MIME helpers, sanitized `.eml` fixtures, and `ensure_parsers_registered()`.

--- a/modules/ingestors/email/README.md
+++ b/modules/ingestors/email/README.md
@@ -15,9 +15,10 @@ Email / Gmail source plugin for Papita ingestion (`papita_ingestor_email`).
 
 Plugin package under `modules/ingestors/`. Hosts the Gmail OAuth2 source
 (PPT-080 / [#174](https://github.com/Elmorralito/save-ma-money/issues/174)) and
-later bank-specific parsers (PPT-081). Prefect packaging is PPT-082 — not this
-package’s job. CI for the Gmail source uses **mocks only** (no live Google
-credentials in Actions).
+bank-specific email parsers (PPT-081 /
+[#175](https://github.com/Elmorralito/save-ma-money/issues/175)). Prefect
+packaging is PPT-082 — not this package’s job. CI for the Gmail source uses
+**mocks only** (no live Google credentials in Actions).
 
 ## Dependency graph (one-way)
 
@@ -46,6 +47,36 @@ with create_gmail_source(GmailSettings()) as source:  # reads GMAIL_* from env
 
 CI uses **mocked** `googleapiclient` only. Live smoke needs `GMAIL_*` in
 `environments/local/.env` (see bootstrap below).
+
+## Bank email parsers (PPT-081 / #175)
+
+`BancolombiaParser`, `NequiParser`, and hybrid `FallbackEmailParser` implement
+`BaseRecordParser` and register on `ParserRegistry` when the package (or
+`papita_ingestor_email.parsers`) is imported:
+
+```python
+from papita_ingestor_core import ParserRegistry
+from papita_ingestor_email import ensure_parsers_registered
+
+ensure_parsers_registered()  # idempotent after ParserRegistry.clear()
+parser = ParserRegistry.select_for(raw_record)  # bank parsers beat fallback
+parsed = parser.parse(raw_record)  # currency COP; FKs None until PPT-082
+```
+
+| Parser                | `parser_id`         | Priority | Notes                                                                       |
+| --------------------- | ------------------- | -------- | --------------------------------------------------------------------------- |
+| `BancolombiaParser`   | `bancolombia-email` | 100      | Sender `*notificacionesbancolombia.com`; Recibiste / transferiste / Pagaste |
+| `NequiParser`         | `nequi-email`       | 90       | **Synthetic** `@nequi.com.co` fixtures (not Nu / `nu.com.co`)               |
+| `FallbackEmailParser` | `fallback-email`    | -100     | Email-shaped leftovers → `IngestorParseError("unrecognized email")`         |
+
+Unrecognized path:
+
+1. Without Fallback in `instances` → `LookupError` → runner DLQ.
+2. With Fallback → typed `IngestorParseError` → same DLQ; never invents amounts / never returns `None`.
+
+Unit fixtures live under `tests/fixtures/emails/` (sanitized MIME). Account /
+category UUID resolution is deferred to PPT-082 / [#176](https://github.com/Elmorralito/save-ma-money/issues/176).
+Nu payment and Nu monthly extracto emails are out of scope for these parsers.
 
 ## Local commands
 

--- a/modules/ingestors/email/src/papita_ingestor_email/__init__.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/__init__.py
@@ -7,13 +7,20 @@ Depends on ``papita_ingestor_core`` only. Do not import this package from
 from __future__ import annotations
 
 from papita_ingestor_email.__meta__ import __version__
+from papita_ingestor_email.parsers import BancolombiaParser, FallbackEmailParser, NequiParser, ensure_parsers_registered
 from papita_ingestor_email.settings import GmailSettings
 from papita_ingestor_email.sources import GmailSource, create_gmail_source, ensure_registered
 
+ensure_parsers_registered()
+
 __all__ = [
+    "BancolombiaParser",
+    "FallbackEmailParser",
     "GmailSettings",
     "GmailSource",
+    "NequiParser",
     "create_gmail_source",
+    "ensure_parsers_registered",
     "ensure_registered",
     "__version__",
 ]

--- a/modules/ingestors/email/src/papita_ingestor_email/parsers/__init__.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/parsers/__init__.py
@@ -1,0 +1,34 @@
+"""Bank email parsers for ``papita_ingestor_email`` (PPT-081 / #175)."""
+
+from __future__ import annotations
+
+from papita_ingestor_core.registry import ParserRegistry
+from papita_ingestor_email.parsers.bancolombia import BancolombiaParser
+from papita_ingestor_email.parsers.fallback import FallbackEmailParser
+from papita_ingestor_email.parsers.nequi import NequiParser
+
+_PARSER_CLASSES = (
+    BancolombiaParser,
+    NequiParser,
+    FallbackEmailParser,
+)
+
+
+def ensure_parsers_registered() -> dict[str, type]:
+    """Idempotent ``ParserRegistry`` ensure (core tests may ``ParserRegistry.clear()``)."""
+    registered = ParserRegistry.all()
+    for parser_cls in _PARSER_CLASSES:
+        identity = parser_cls.registry_id
+        if identity not in registered:
+            ParserRegistry.register(parser_cls)
+    return {cls.registry_id: cls for cls in _PARSER_CLASSES}
+
+
+ensure_parsers_registered()
+
+__all__ = [
+    "BancolombiaParser",
+    "FallbackEmailParser",
+    "NequiParser",
+    "ensure_parsers_registered",
+]

--- a/modules/ingestors/email/src/papita_ingestor_email/parsers/amounts.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/parsers/amounts.py
@@ -1,0 +1,69 @@
+"""COP amount and timestamp helpers for Colombian bank email parsers."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+# Bancolombia-style: $20,000 or $3,000,000.00 (US thousands commas).
+_AMOUNT_RE = re.compile(r"\$\s*(\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?)")
+_DATE_RE = re.compile(
+    r"(?P<d>\d{1,2})/(?P<m>\d{1,2})/(?P<y>\d{2,4})(?:\s*(?:a\s+las\s+)?(?P<h>\d{1,2}):(?P<min>\d{2}))?",
+    re.IGNORECASE,
+)
+_MASKED_ACCOUNT_RE = re.compile(r"\*+\s*(\d{4})")
+
+
+def parse_cop_amount(text: str) -> float | None:
+    """Parse the first ``$`` amount with US-style thousands separators into a float.
+
+    Args:
+        text: Visible email body text.
+
+    Returns:
+        Positive amount, or ``None`` when no match.
+    """
+    match = _AMOUNT_RE.search(text)
+    if match is None:
+        return None
+    raw = match.group(1).replace(",", "")
+    try:
+        amount = float(raw)
+    except ValueError:
+        return None
+    if amount <= 0:
+        return None
+    return amount
+
+
+def parse_spanish_datetime(text: str) -> datetime | None:
+    """Parse ``DD/MM/YYYY`` or ``DD/MM/YY`` with optional ``HH:MM`` from Spanish alerts."""
+    match = _DATE_RE.search(text)
+    if match is None:
+        return None
+    day = int(match.group("d"))
+    month = int(match.group("m"))
+    year = int(match.group("y"))
+    if year < 100:
+        year += 2000
+    hour = int(match.group("h") or 0)
+    minute = int(match.group("min") or 0)
+    try:
+        return datetime(year, month, day, hour, minute)
+    except ValueError:
+        return None
+
+
+def extract_masked_account(text: str) -> str | None:
+    """Return the last-4 digits from a masked product token like ``*7756``."""
+    match = _MASKED_ACCOUNT_RE.search(text)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+__all__ = [
+    "extract_masked_account",
+    "parse_cop_amount",
+    "parse_spanish_datetime",
+]

--- a/modules/ingestors/email/src/papita_ingestor_email/parsers/bancolombia.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/parsers/bancolombia.py
@@ -1,0 +1,108 @@
+"""Bancolombia Alertas y Notificaciones parser (PPT-081 / #175)."""
+
+from __future__ import annotations
+
+import re
+
+from papita_ingestor_core.errors import IngestorParseError
+from papita_ingestor_core.parsers.base import BaseRecordParser
+from papita_ingestor_core.registry import ParserRegistry
+from papita_ingestor_core.types.records import ParsedRecord, RawRecord
+from papita_ingestor_email.parsers.amounts import extract_masked_account, parse_cop_amount, parse_spanish_datetime
+from papita_ingestor_email.parsers.mime import extract_email_text, sender_address, subject_line
+from papita_txnsmodel.model.enums import IngestionSource, TransactionKind
+
+_SENDER_DOMAIN_RE = re.compile(r"@([a-z0-9.-]*notificacionesbancolombia\.com)\b", re.IGNORECASE)
+_CLAIM_MARKERS_RE = re.compile(r"\b(Recibiste\s+una\s+transferencia|transferiste|Pagaste)\b", re.IGNORECASE)
+_INCOME_RE = re.compile(
+    r"Recibiste\s+una\s+transferencia\s+por\s+\$[\d,]+(?:\.\d{1,2})?\s+de\s+(.+?)\s+en\s+tu\s+cuenta",
+    re.IGNORECASE,
+)
+_TRANSFER_RE = re.compile(
+    r"transferiste\s+\$[\d,]+(?:\.\d{1,2})?\s+a\s+(?:la\s+llave\s+)?(.+?)\s+desde\s+tu\s+cuenta",
+    re.IGNORECASE,
+)
+_EXPENSE_RE = re.compile(
+    r"Pagaste\s+\$[\d,]+(?:\.\d{1,2})?\s+a\s+(.+?)\s+desde\s+tu\s+producto",
+    re.IGNORECASE,
+)
+
+
+@ParserRegistry.register
+class BancolombiaParser(BaseRecordParser):
+    """Parse Bancolombia alert emails into COP ``ParsedRecord`` values."""
+
+    registry_id = "bancolombia-email"
+
+    @property
+    def parser_id(self) -> str:
+        return self.registry_id
+
+    @property
+    def priority(self) -> int:
+        return 100
+
+    def can_parse(self, record: RawRecord) -> bool:
+        if record.ingestion_source != IngestionSource.EMAIL:
+            return False
+        sender = sender_address(record.metadata.get("sender"), record.content)
+        if not _SENDER_DOMAIN_RE.search(sender):
+            return False
+        body = extract_email_text(record.content)
+        subject = subject_line(record.metadata.get("subject"), record.content)
+        haystack = f"{subject} {body}"
+        return bool(_CLAIM_MARKERS_RE.search(haystack))
+
+    def parse(self, record: RawRecord) -> ParsedRecord:
+        if not (record.source_ref or "").strip():
+            raise IngestorParseError("BancolombiaParser requires RawRecord.source_ref")
+
+        body = extract_email_text(record.content)
+        subject = subject_line(record.metadata.get("subject"), record.content)
+        haystack = f"{subject} {body}"
+
+        kind, merchant = self._classify(haystack)
+        amount = parse_cop_amount(haystack)
+        if amount is None:
+            raise IngestorParseError("BancolombiaParser could not extract amount")
+
+        masked = extract_masked_account(haystack)
+        tags = ["bancolombia"]
+        if masked:
+            tags.append(f"account_last4:{masked}")
+
+        description_parts = [f"Bancolombia {kind.value.lower()}"]
+        if merchant:
+            description_parts.append(merchant)
+        if masked:
+            description_parts.append(f"*{masked}")
+
+        return ParsedRecord(
+            ingestion_source=record.ingestion_source,
+            source_ref=record.source_ref,
+            transaction_kind=kind,
+            amount=amount,
+            currency="COP",
+            transaction_ts=parse_spanish_datetime(haystack),
+            description=" · ".join(description_parts),
+            tags=tags,
+        )
+
+    @staticmethod
+    def _classify(text: str) -> tuple[TransactionKind, str | None]:
+        income = _INCOME_RE.search(text)
+        if income:
+            return TransactionKind.INCOME, income.group(1).strip(" .,;")
+
+        transfer = _TRANSFER_RE.search(text)
+        if transfer:
+            return TransactionKind.TRANSFER, transfer.group(1).strip(" .,;")
+
+        expense = _EXPENSE_RE.search(text)
+        if expense:
+            return TransactionKind.EXPENSE, expense.group(1).strip(" .,;")
+
+        raise IngestorParseError("BancolombiaParser claimed record but no template matched")
+
+
+__all__ = ["BancolombiaParser"]

--- a/modules/ingestors/email/src/papita_ingestor_email/parsers/fallback.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/parsers/fallback.py
@@ -1,0 +1,45 @@
+"""Hybrid unrecognized-email parser (PPT-081 / #175 Soft Fallback).
+
+Bank parsers win on priority. This class claims leftover email-shaped records
+and raises ``IngestorParseError`` so the runner DLQs without inventing amounts.
+When Fallback is omitted from ``instances``, unmatched records still raise
+registry ``LookupError`` (same DLQ outcome).
+"""
+
+from __future__ import annotations
+
+from papita_ingestor_core.errors import IngestorParseError
+from papita_ingestor_core.parsers.base import BaseRecordParser
+from papita_ingestor_core.registry import ParserRegistry
+from papita_ingestor_core.types.records import ParsedRecord, RawRecord
+from papita_ingestor_email.parsers.mime import sender_address
+from papita_txnsmodel.model.enums import IngestionSource
+
+
+@ParserRegistry.register
+class FallbackEmailParser(BaseRecordParser):
+    """Lowest-priority email leftover parser — never invents ``ParsedRecord`` amounts."""
+
+    registry_id = "fallback-email"
+
+    @property
+    def parser_id(self) -> str:
+        return self.registry_id
+
+    @property
+    def priority(self) -> int:
+        return -100
+
+    def can_parse(self, record: RawRecord) -> bool:
+        """Claim email-shaped leftovers only (banks must outrank via priority)."""
+        if record.ingestion_source != IngestionSource.EMAIL:
+            return False
+        sender = sender_address(record.metadata.get("sender"), record.content)
+        # Require a From signal so non-email opaque payloads stay on LookupError.
+        return bool(sender)
+
+    def parse(self, record: RawRecord) -> ParsedRecord:
+        raise IngestorParseError("unrecognized email")
+
+
+__all__ = ["FallbackEmailParser"]

--- a/modules/ingestors/email/src/papita_ingestor_email/parsers/mime.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/parsers/mime.py
@@ -1,0 +1,152 @@
+"""MIME / HTML helpers for email bank parsers (PPT-081 / #175)."""
+
+from __future__ import annotations
+
+import re
+from email import policy
+from email.message import Message
+from email.parser import BytesParser, Parser
+from html.parser import HTMLParser
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+class _HTMLTextExtractor(HTMLParser):
+    """Collect visible text from HTML, ignoring script/style bodies."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._chunks: list[str] = []
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in {"script", "style"}:
+            self._skip_depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"script", "style"} and self._skip_depth > 0:
+            self._skip_depth -= 1
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth == 0 and data:
+            self._chunks.append(data)
+
+    def text(self) -> str:
+        return _WHITESPACE_RE.sub(" ", "".join(self._chunks)).strip()
+
+
+def html_to_text(html: str) -> str:
+    """Strip tags from HTML and collapse whitespace."""
+    extractor = _HTMLTextExtractor()
+    extractor.feed(html)
+    extractor.close()
+    return extractor.text()
+
+
+def _decode_part_payload(part: Message) -> str:
+    payload = part.get_payload(decode=True)
+    if isinstance(payload, bytes):
+        charset = part.get_content_charset() or "utf-8"
+        return payload.decode(charset, errors="replace")
+    if isinstance(payload, str):
+        return payload
+    return str(part.get_payload() or "")
+
+
+def _iter_text_parts(message: Message) -> list[tuple[str, str]]:
+    """Return ``(content_type, body)`` pairs for text parts (depth-first)."""
+    parts: list[tuple[str, str]] = []
+    if message.is_multipart():
+        for part in message.walk():
+            if part.is_multipart():
+                continue
+            content_type = (part.get_content_type() or "").lower()
+            if content_type in {"text/html", "text/plain"}:
+                parts.append((content_type, _decode_part_payload(part)))
+        return parts
+
+    content_type = (message.get_content_type() or "").lower()
+    if content_type in {"text/html", "text/plain"}:
+        parts.append((content_type, _decode_part_payload(message)))
+    elif not content_type or content_type == "text/plain":
+        # Some minimal fixtures omit Content-Type; treat body as plain text.
+        parts.append(("text/plain", _decode_part_payload(message)))
+    return parts
+
+
+def _text_from_message(message: Message) -> str:
+    parts = _iter_text_parts(message)
+    html_bodies = [body for ctype, body in parts if ctype == "text/html" and body.strip()]
+    if html_bodies:
+        return html_to_text(html_bodies[0])
+    plain_bodies = [body for ctype, body in parts if ctype == "text/plain" and body.strip()]
+    if plain_bodies:
+        return _WHITESPACE_RE.sub(" ", plain_bodies[0]).strip()
+    return ""
+
+
+def extract_email_text(content: bytes | str) -> str:
+    """Prefer ``text/html`` (stripped), else ``text/plain``, from MIME or raw text.
+
+    Args:
+        content: Raw MIME bytes (GmailSource) or a string body / MIME text.
+
+    Returns:
+        Normalized visible text suitable for regex templates.
+    """
+    message: Message | None = None
+    if isinstance(content, bytes):
+        if content.strip():
+            message = BytesParser(policy=policy.default).parsebytes(content)
+    else:
+        stripped = content.strip()
+        if not stripped:
+            message = None
+        elif stripped.lower().startswith("<!doctype") or stripped.lower().startswith("<html"):
+            return html_to_text(stripped)
+        elif "\n" in stripped and ("content-type:" in stripped.lower() or stripped.lower().startswith("from:")):
+            message = Parser(policy=policy.default).parsestr(stripped)
+        else:
+            return _WHITESPACE_RE.sub(" ", stripped)
+
+    if message is None:
+        return ""
+    return _text_from_message(message)
+
+
+def sender_address(metadata_sender: str | None, content: bytes | str) -> str:
+    """Best-effort From address from Gmail metadata or MIME headers."""
+    if metadata_sender:
+        return metadata_sender.strip()
+    if isinstance(content, bytes):
+        if not content:
+            return ""
+        message = BytesParser(policy=policy.default).parsebytes(content)
+    else:
+        if "from:" not in content.lower():
+            return ""
+        message = Parser(policy=policy.default).parsestr(content)
+    return (message.get("From") or "").strip()
+
+
+def subject_line(metadata_subject: str | None, content: bytes | str) -> str:
+    """Best-effort Subject from Gmail metadata or MIME headers."""
+    if metadata_subject:
+        return metadata_subject.strip()
+    if isinstance(content, bytes):
+        if not content:
+            return ""
+        message = BytesParser(policy=policy.default).parsebytes(content)
+    else:
+        if "subject:" not in content.lower():
+            return ""
+        message = Parser(policy=policy.default).parsestr(content)
+    return (message.get("Subject") or "").strip()
+
+
+__all__ = [
+    "extract_email_text",
+    "html_to_text",
+    "sender_address",
+    "subject_line",
+]

--- a/modules/ingestors/email/src/papita_ingestor_email/parsers/nequi.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/parsers/nequi.py
@@ -1,0 +1,100 @@
+"""Synthetic Nequi notification parser (PPT-081 / #175, R1=B).
+
+Fixtures use public-shaped ``@nequi.com.co`` senders. This is **not** a Nu
+parser — do not map ``nu@nu.com.co`` samples here.
+"""
+
+from __future__ import annotations
+
+import re
+
+from papita_ingestor_core.errors import IngestorParseError
+from papita_ingestor_core.parsers.base import BaseRecordParser
+from papita_ingestor_core.registry import ParserRegistry
+from papita_ingestor_core.types.records import ParsedRecord, RawRecord
+from papita_ingestor_email.parsers.amounts import parse_cop_amount, parse_spanish_datetime
+from papita_ingestor_email.parsers.mime import extract_email_text, sender_address, subject_line
+from papita_txnsmodel.model.enums import IngestionSource, TransactionKind
+
+_SENDER_DOMAIN_RE = re.compile(r"@([a-z0-9.-]*nequi\.com\.co)\b", re.IGNORECASE)
+_CLAIM_MARKERS_RE = re.compile(r"\b(Recibiste|Enviaste)\b", re.IGNORECASE)
+_INCOME_RE = re.compile(
+    r"Recibiste\s+\$[\d,]+(?:\.\d{1,2})?\s+de\s+(.+?)(?:\s+en\s+tu\s+Nequi|\s+el\s+|\.|$)",
+    re.IGNORECASE,
+)
+_EXPENSE_RE = re.compile(
+    r"Enviaste\s+\$[\d,]+(?:\.\d{1,2})?\s+a\s+(.+?)(?:\s+desde\s+tu\s+Nequi|\s+el\s+|\.|$)",
+    re.IGNORECASE,
+)
+
+
+@ParserRegistry.register
+class NequiParser(BaseRecordParser):
+    """Parse synthetic Nequi alert emails into COP ``ParsedRecord`` values."""
+
+    registry_id = "nequi-email"
+
+    @property
+    def parser_id(self) -> str:
+        return self.registry_id
+
+    @property
+    def priority(self) -> int:
+        return 90
+
+    def can_parse(self, record: RawRecord) -> bool:
+        if record.ingestion_source != IngestionSource.EMAIL:
+            return False
+        sender = sender_address(record.metadata.get("sender"), record.content)
+        if not _SENDER_DOMAIN_RE.search(sender):
+            return False
+        # Explicitly reject Nu brand addresses even if somehow mixed in metadata.
+        if re.search(r"@nu\.com\.co\b", sender, re.IGNORECASE):
+            return False
+        body = extract_email_text(record.content)
+        subject = subject_line(record.metadata.get("subject"), record.content)
+        haystack = f"{subject} {body}"
+        return bool(_CLAIM_MARKERS_RE.search(haystack))
+
+    def parse(self, record: RawRecord) -> ParsedRecord:
+        if not (record.source_ref or "").strip():
+            raise IngestorParseError("NequiParser requires RawRecord.source_ref")
+
+        body = extract_email_text(record.content)
+        subject = subject_line(record.metadata.get("subject"), record.content)
+        haystack = f"{subject} {body}"
+
+        kind, merchant = self._classify(haystack)
+        amount = parse_cop_amount(haystack)
+        if amount is None:
+            raise IngestorParseError("NequiParser could not extract amount")
+
+        description_parts = [f"Nequi {kind.value.lower()}"]
+        if merchant:
+            description_parts.append(merchant)
+
+        return ParsedRecord(
+            ingestion_source=record.ingestion_source,
+            source_ref=record.source_ref,
+            transaction_kind=kind,
+            amount=amount,
+            currency="COP",
+            transaction_ts=parse_spanish_datetime(haystack),
+            description=" · ".join(description_parts),
+            tags=["nequi"],
+        )
+
+    @staticmethod
+    def _classify(text: str) -> tuple[TransactionKind, str | None]:
+        income = _INCOME_RE.search(text)
+        if income:
+            return TransactionKind.INCOME, income.group(1).strip(" .,;")
+
+        expense = _EXPENSE_RE.search(text)
+        if expense:
+            return TransactionKind.EXPENSE, expense.group(1).strip(" .,;")
+
+        raise IngestorParseError("NequiParser claimed record but no template matched")
+
+
+__all__ = ["NequiParser"]

--- a/modules/ingestors/email/tests/conftest.py
+++ b/modules/ingestors/email/tests/conftest.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import pytest
 
+from papita_ingestor_email.parsers import ensure_parsers_registered
 from papita_ingestor_email.sources.gmail import ensure_registered
+
+_TESTS_DIR = Path(__file__).resolve().parent
+if str(_TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TESTS_DIR))
 
 
 @pytest.fixture(autouse=True)
 def _ensure_gmail_registered() -> None:
     """Re-register after core suite ``SourceRegistry.clear()`` in shared pytest runs."""
     ensure_registered()
+    ensure_parsers_registered()

--- a/modules/ingestors/email/tests/fixtures/emails/bancolombia_expense.eml
+++ b/modules/ingestors/email/tests/fixtures/emails/bancolombia_expense.eml
@@ -1,0 +1,7 @@
+From: Alertas y Notificaciones <alertasynotificaciones@an.notificacionesbancolombia.com>
+To: user@example.com
+Subject: Alertas y Notificaciones
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+
+<html><body><p>Bancolombia: Pagaste $258,000.00 a CONJUNTO EJEMPLO SA desde tu producto *1234 el 08/07/2026 12:26.</p></body></html>

--- a/modules/ingestors/email/tests/fixtures/emails/bancolombia_income.eml
+++ b/modules/ingestors/email/tests/fixtures/emails/bancolombia_income.eml
@@ -1,0 +1,7 @@
+From: Alertas y Notificaciones <alertasynotificaciones@an.notificacionesbancolombia.com>
+To: user@example.com
+Subject: Alertas y Notificaciones
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+
+<html><body><p>Bancolombia: Recibiste una transferencia por $20,000 de ANA PEREZ en tu cuenta *1234, el 15/06/2026 a las 11:02.</p></body></html>

--- a/modules/ingestors/email/tests/fixtures/emails/bancolombia_malformed.eml
+++ b/modules/ingestors/email/tests/fixtures/emails/bancolombia_malformed.eml
@@ -1,0 +1,7 @@
+From: Alertas y Notificaciones <alertasynotificaciones@an.notificacionesbancolombia.com>
+To: user@example.com
+Subject: Alertas y Notificaciones
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+
+<html><body><p>Bancolombia: Pagaste a COMERCIO sin monto desde tu producto *1234.</p></body></html>

--- a/modules/ingestors/email/tests/fixtures/emails/bancolombia_transfer.eml
+++ b/modules/ingestors/email/tests/fixtures/emails/bancolombia_transfer.eml
@@ -1,0 +1,7 @@
+From: Alertas y Notificaciones <alertasynotificaciones@an.notificacionesbancolombia.com>
+To: user@example.com
+Subject: Alertas y Notificaciones
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+
+<html><body><p>Bancolombia: CLIENTE, transferiste $3,000,000.00 a la llave abc@breb.co desde tu cuenta *1234 el 08/07/26 a las 10:19.</p></body></html>

--- a/modules/ingestors/email/tests/fixtures/emails/nequi_expense.eml
+++ b/modules/ingestors/email/tests/fixtures/emails/nequi_expense.eml
@@ -1,0 +1,7 @@
+From: Nequi Notificaciones <notificaciones@nequi.com.co>
+To: user@example.com
+Subject: Movimiento en tu Nequi
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+
+<html><body><p>Enviaste $25,000 a TIENDA DEMO desde tu Nequi el 12/08/2026 a las 18:40.</p></body></html>

--- a/modules/ingestors/email/tests/fixtures/emails/nequi_income.eml
+++ b/modules/ingestors/email/tests/fixtures/emails/nequi_income.eml
@@ -1,0 +1,7 @@
+From: Nequi Notificaciones <notificaciones@nequi.com.co>
+To: user@example.com
+Subject: Movimiento en tu Nequi
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+
+<html><body><p>Recibiste $50,000 de JUAN DEMO en tu Nequi el 12/08/2026 a las 09:15.</p></body></html>

--- a/modules/ingestors/email/tests/fixtures/emails/unrecognized.eml
+++ b/modules/ingestors/email/tests/fixtures/emails/unrecognized.eml
@@ -1,0 +1,7 @@
+From: Newsletter <news@example.com>
+To: user@example.com
+Subject: Weekly digest
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+
+<html><body><p>Hello, here is your weekly digest with no bank amounts.</p></body></html>

--- a/modules/ingestors/email/tests/helpers_records.py
+++ b/modules/ingestors/email/tests/helpers_records.py
@@ -1,0 +1,37 @@
+"""Shared RawRecord builders for email parser tests."""
+
+from __future__ import annotations
+
+from email import policy
+from email.parser import BytesParser
+from pathlib import Path
+
+from papita_ingestor_core.types.records import RawRecord
+from papita_txnsmodel.model.enums import IngestionSource
+
+FIXTURES = Path(__file__).parent / "fixtures" / "emails"
+
+
+def load_eml(name: str) -> bytes:
+    """Read a committed MIME fixture."""
+    return (FIXTURES / name).read_bytes()
+
+
+def raw_from_eml(name: str, *, source_ref: str = "gmail-msg-1") -> RawRecord:
+    """Build a Gmail-shaped ``RawRecord`` from a fixture ``.eml`` file."""
+    content = load_eml(name)
+    parsed = BytesParser(policy=policy.default).parsebytes(content)
+    return RawRecord(
+        source_id="gmail",
+        source_ref=source_ref,
+        content=content,
+        metadata={
+            "subject": parsed.get("Subject"),
+            "sender": parsed.get("From"),
+            "headers": {str(k): str(v) for k, v in parsed.items()},
+        },
+        ingestion_source=IngestionSource.EMAIL,
+    )
+
+
+__all__ = ["FIXTURES", "load_eml", "raw_from_eml"]

--- a/modules/ingestors/email/tests/test_mime_helper.py
+++ b/modules/ingestors/email/tests/test_mime_helper.py
@@ -1,0 +1,18 @@
+"""Tests for MIME / HTML extraction helpers."""
+
+from __future__ import annotations
+
+from helpers_records import load_eml
+
+from papita_ingestor_email.parsers.mime import extract_email_text, html_to_text
+
+
+def test_html_to_text_strips_tags() -> None:
+    assert html_to_text("<p>Hello <b>world</b></p>") == "Hello world"
+
+
+def test_extract_email_text_prefers_html_part() -> None:
+    text = extract_email_text(load_eml("bancolombia_income.eml"))
+    assert "Recibiste una transferencia" in text
+    assert "$20,000" in text
+    assert "<html>" not in text.lower()

--- a/modules/ingestors/email/tests/test_parsers.py
+++ b/modules/ingestors/email/tests/test_parsers.py
@@ -1,0 +1,190 @@
+"""Unit tests for Bancolombia / Nequi / Fallback email parsers (PPT-081 / #175)."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+from types import SimpleNamespace
+
+import pytest
+from helpers_records import raw_from_eml
+
+from papita_ingestor_core.errors import IngestorParseError
+from papita_ingestor_core.registry import ParserRegistry
+from papita_ingestor_core.runner.ingestion_runner import IngestionRunner
+from papita_ingestor_core.settings.base import BaseIngestorSettings
+from papita_ingestor_core.sources.base import BaseIngestorSource
+from papita_ingestor_core.types.records import FetchFilter, RawRecord
+from papita_ingestor_email.parsers import BancolombiaParser, FallbackEmailParser, NequiParser, ensure_parsers_registered
+from papita_txnsmodel.access.users.dto import UsersDTO
+from papita_txnsmodel.model.enums import TransactionKind
+
+
+class _ListSource(BaseIngestorSource):
+    """Minimal source that yields a fixed record list."""
+
+    registry_id = "list-source"
+
+    def __init__(self, records: list[RawRecord]) -> None:
+        self._records = list(records)
+
+    @property
+    def source_id(self) -> str:
+        return self.registry_id
+
+    def connect(self) -> None:
+        return None
+
+    def disconnect(self) -> None:
+        return None
+
+    def fetch(self, fetch_filter: FetchFilter | None = None) -> Iterable[RawRecord]:
+        return list(self._records)
+
+    def acknowledge(self, record: RawRecord) -> None:
+        return None
+
+
+class _DlqBridge:
+    """Bridge stub that records dead letters only."""
+
+    def __init__(self) -> None:
+        self.ingests: list[object] = []
+        self.dead_letters: list[dict] = []
+
+    def ingest_transaction(self, *, owner: UsersDTO, request: object, **kwargs: object) -> SimpleNamespace:
+        self.ingests.append(request)
+        return SimpleNamespace(outcome="created")
+
+    def record_dead_letter(self, *, owner: UsersDTO, **kwargs: object) -> dict:
+        payload = {"owner": owner, **kwargs}
+        self.dead_letters.append(payload)
+        return payload
+
+
+@pytest.fixture(autouse=True)
+def _parsers_registered() -> None:
+    ensure_parsers_registered()
+
+
+def test_ensure_parsers_registered_is_idempotent_after_clear() -> None:
+    ParserRegistry.clear()
+    ensure_parsers_registered()
+    assert set(ParserRegistry.all()) >= {"bancolombia-email", "nequi-email", "fallback-email"}
+    ensure_parsers_registered()
+    assert ParserRegistry.get("bancolombia-email") is BancolombiaParser
+
+
+@pytest.mark.parametrize(
+    ("fixture", "kind", "amount", "merchant_substring"),
+    [
+        ("bancolombia_income.eml", TransactionKind.INCOME, 20_000.0, "ANA PEREZ"),
+        ("bancolombia_transfer.eml", TransactionKind.TRANSFER, 3_000_000.0, "abc@breb.co"),
+        ("bancolombia_expense.eml", TransactionKind.EXPENSE, 258_000.0, "CONJUNTO EJEMPLO SA"),
+    ],
+)
+def test_bancolombia_parses_kinds(
+    fixture: str,
+    kind: TransactionKind,
+    amount: float,
+    merchant_substring: str,
+) -> None:
+    record = raw_from_eml(fixture, source_ref=f"bcol-{kind.value}")
+    parser = BancolombiaParser()
+    assert parser.can_parse(record) is True
+    parsed = parser.parse(record)
+    assert parsed.transaction_kind == kind
+    assert parsed.amount == amount
+    assert parsed.currency == "COP"
+    assert parsed.source_ref == record.source_ref
+    assert merchant_substring in parsed.description
+    assert "bancolombia" in parsed.tags
+    assert parsed.from_account_id is None
+    assert parsed.to_account_id is None
+    assert parsed.category_id is None
+    assert parsed.transaction_ts is not None
+
+
+def test_bancolombia_malformed_raises_parse_error() -> None:
+    record = raw_from_eml("bancolombia_malformed.eml")
+    parser = BancolombiaParser()
+    assert parser.can_parse(record) is True
+    with pytest.raises(IngestorParseError):
+        parser.parse(record)
+
+
+@pytest.mark.parametrize(
+    ("fixture", "kind", "amount"),
+    [
+        ("nequi_income.eml", TransactionKind.INCOME, 50_000.0),
+        ("nequi_expense.eml", TransactionKind.EXPENSE, 25_000.0),
+    ],
+)
+def test_nequi_synthetic_parses(fixture: str, kind: TransactionKind, amount: float) -> None:
+    record = raw_from_eml(fixture, source_ref=f"nequi-{kind.value}")
+    parser = NequiParser()
+    assert parser.can_parse(record) is True
+    parsed = parser.parse(record)
+    assert parsed.transaction_kind == kind
+    assert parsed.amount == amount
+    assert parsed.currency == "COP"
+    assert parsed.source_ref == record.source_ref
+    assert "nequi" in parsed.tags
+
+
+def test_nequi_rejects_nu_sender() -> None:
+    record = raw_from_eml("nequi_income.eml")
+    record.metadata["sender"] = "Nu <nu@nu.com.co>"
+    assert NequiParser().can_parse(record) is False
+
+
+def test_registry_priority_prefers_bancolombia_over_fallback() -> None:
+    record = raw_from_eml("bancolombia_expense.eml")
+    selected = ParserRegistry.select_for(
+        record,
+        instances=[FallbackEmailParser(), BancolombiaParser(), NequiParser()],
+    )
+    assert selected.parser_id == "bancolombia-email"
+
+
+def test_unrecognized_with_fallback_raises_parse_error() -> None:
+    record = raw_from_eml("unrecognized.eml")
+    selected = ParserRegistry.select_for(
+        record,
+        instances=[BancolombiaParser(), NequiParser(), FallbackEmailParser()],
+    )
+    assert selected.parser_id == "fallback-email"
+    with pytest.raises(IngestorParseError, match="unrecognized email"):
+        selected.parse(record)
+
+
+def test_unrecognized_without_fallback_raises_lookup_error() -> None:
+    record = raw_from_eml("unrecognized.eml")
+    with pytest.raises(LookupError):
+        ParserRegistry.select_for(record, instances=[BancolombiaParser(), NequiParser()])
+
+
+def test_runner_unmatched_dead_letters() -> None:
+    """AC2: unmatched → LookupError → runner DLQ (no invented ledger write)."""
+    record = raw_from_eml("unrecognized.eml", source_ref="unmatched-1")
+    bridge = _DlqBridge()
+    owner = UsersDTO(
+        id=uuid.uuid4(),
+        username="ingest_owner",
+        email="ingest_owner@example.local",
+        password="Password1!",
+        auth_provider="local",
+    )
+    runner = IngestionRunner(
+        source=_ListSource([record]),
+        owner=owner,
+        bridge=bridge,
+        parsers=[BancolombiaParser(), NequiParser()],
+        settings=BaseIngestorSettings(dry_run=False),
+    )
+    result = runner.run()
+    assert result.fetched == 1
+    assert result.dead_lettered == 1
+    assert result.failed == 1
+    assert bridge.ingests == []
+    assert len(bridge.dead_letters) == 1


### PR DESCRIPTION
**Branch:** `175-featppt-081-ingestor-bancolombia-and-nequi-email-parsers` · **Base:** `main` · **1 commit** · **22 files**

**Suggested title:** `feat/PPT-081: [ingestor] Bancolombia and Nequi email parsers`

## Summary

Ships MVP bank email parsers in `papita-ingestor-email` for Bancolombia alerts and synthetic Nequi notifications (`BaseRecordParser` + `ParserRegistry`), so Gmail-fetched MIME can become COP `ParsedRecord`s without inventing ledger amounts. Unrecognized or unmatched email goes to typed parse failure / runner DLQ. Account and category FKs stay `None` for PPT-082.

## Out of scope / Highlights

**Out of scope**

- Nu payment / Nu monthly extracto (not Nequi)
- Davivienda / other banks
- Account/category UUID resolution and Prefect end-to-end flow (PPT-082 / #176)
- Persist/upsert (model bridge owns that)

**Highlights**

- R1=B: `NequiParser` uses synthetic `@nequi.com.co` fixtures and rejects Nu senders
- Hybrid `FallbackEmailParser` (priority `-100`) raises `IngestorParseError("unrecognized email")`; without Fallback, registry `LookupError` → runner DLQ
- Sanitized `.eml` fixtures only (no live mailbox / no user PDF PII)

## Changes

**Ingestor email parsers**

- `BancolombiaParser`: Recibiste → INCOME, transferiste → TRANSFER, Pagaste → EXPENSE; COP; `source_ref` from `RawRecord`
- `NequiParser`: synthetic Recibiste/Enviaste templates
- `FallbackEmailParser`: email-shaped leftovers only; never invents amounts / never returns `None`
- MIME → visible text helper + COP amount/date helpers
- `ensure_parsers_registered()` on package import (idempotent after `ParserRegistry.clear()`)

**Tests / docs / strata**

- Unit fixtures under `tests/fixtures/emails/`; parser + MIME tests; runner unmatched → DLQ coverage
- README / CHANGELOG for PPT-081; `.strata` project state updated

## File changes

<details>
<summary>File changes (~22 files)</summary>

```
 .strata/memory/MEMORY.md                           |   6 +-
 .strata/memory/project_state.md                    |  14 +-
 modules/ingestors/email/CHANGELOG.md               |   3 +
 modules/ingestors/email/README.md                  |  37 +++-
 .../email/src/papita_ingestor_email/__init__.py    |   7 +
 .../src/papita_ingestor_email/parsers/__init__.py  |  34 ++++
 .../src/papita_ingestor_email/parsers/amounts.py   |  69 ++++++++
 .../papita_ingestor_email/parsers/bancolombia.py   | 108 ++++++++++++
 .../src/papita_ingestor_email/parsers/fallback.py  |  45 +++++
 .../src/papita_ingestor_email/parsers/mime.py      | 152 +++++++++++++++++
 .../src/papita_ingestor_email/parsers/nequi.py     | 100 +++++++++++
 modules/ingestors/email/tests/conftest.py          |   9 +
 .../tests/fixtures/emails/*.eml                    |  49 +
 modules/ingestors/email/tests/helpers_records.py   |  37 ++++
 modules/ingestors/email/tests/test_mime_helper.py  |  18 ++
 modules/ingestors/email/tests/test_parsers.py      | 190 +++++++++++++++++++++
 22 files changed, 865 insertions(+), 13 deletions(-)
```

</details>

## Commits

- `8777297` feat/PPT-081: [ingestor] Bancolombia and Nequi email parsers

## Checks, tests, and validation already done

- `make ingestor-test` — 63 passed
- `make ingestor-lint` — passed
- Pre-commit on commit — passed (prettier + strata strict pairing)

## QA / test plan

- [ ] Confirm CI Ingestor / quality checks green on this PR
- [ ] Spot-check fixture parse expectations (Bancolombia three kinds + Nequi income/expense)
- [ ] Confirm unrecognized path: LookupError without Fallback; `IngestorParseError` with Fallback
- [ ] Confirm Nu sender is not claimed by `NequiParser`

## Risks

> [!CAUTION]
>
> ### Risks
>
> - Template/regex drift vs future real Bancolombia/Nequi HTML may cause claim-then-`IngestorParseError` (safe DLQ, but ops noise until fixtures update)
> - `FallbackEmailParser` claims any EMAIL record with a From header; bank parsers must keep higher priority

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - Nequi fixtures are synthetic (issue AC path R1=B); not validated against a live Nequi mailbox
> - Parsed FKs are intentionally `None` until PPT-082 / #176 account resolution
> - Nu brand emails remain out of scope for these parsers

## References

- Closes [#175](https://github.com/Elmorralito/save-ma-money/issues/175) (PPT-081)
- Parent epic [#170](https://github.com/Elmorralito/save-ma-money/issues/170) (PPT-076)
- Depends on [#173](https://github.com/Elmorralito/save-ma-money/issues/173) (PPT-079) · soft [#174](https://github.com/Elmorralito/save-ma-money/issues/174) (PPT-080)
- Blocks [#176](https://github.com/Elmorralito/save-ma-money/issues/176) (PPT-082)

Made with [Cursor](https://cursor.com)