### PR TITLE
feat/PPT-083: [api] Ingestion connection and run-status endpoints

### DIFF
--- a/.cursor/CLAUDE.md
+++ b/.cursor/CLAUDE.md
@@ -2,7 +2,8 @@
 
 Before memory operations or deep project work, read [`.strata/MANIFEST.md`](../.strata/MANIFEST.md) — the project memory contract (structure, routing rules, load order) — and load per its rules.
 
-Project memory is repo-owned under `.strata/` (strata format, `layout_version: 3`). Do not write project memory to tool-owned paths such as `~/.claude/` or `~/.codex/`.
+Project memory is repo-owned under `.strata/` (strata format, `layout_version: 3`).
+Do not write project memory to tool-owned paths such as `~/.claude/` or `~/.codex/`.
 
 **Operational details** (setup, architecture, CI, PR checklist, code style) live in [`.cursor/AGENTS.md`](AGENTS.md). [`.agents/AGENTS.md`](../.agents/AGENTS.md) symlinks there — edit **only** `.cursor/AGENTS.md`.
 

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -14,27 +14,27 @@ Capture with `/strata:capture` only for work in flight.
 
 ### Last completed (this session)
 
+- **PPT-082 / #176:** Prefect hourly email flow + Compose packaging on main (#216).
 - **PPT-081 / #175:** Bancolombia + synthetic Nequi parsers + Fallback on main.
 - **PPT-080 / #174:** `GmailSource` + `GmailSettings` on main (#214).
 - **PPT-079 / #173:** core contracts, registries, `IngestionRunner` on main (#213).
 - **PPT-078 / #172:** provenance sidecar + `IngestionBridgeService` on main (#212).
-- **PPT-077 / #171:** ingestor-core + email package scaffolds on main (#211).
 
 ### In progress (ACTIVE)
 
-- **PPT-082 / #176:** Prefect hourly email flow + Compose packaging on
-  `176-featppt-082-…`. Defaults locked: H1=B (no live FK enricher; tests inject
-  FKs / assert DLQ), H2=`PAPITA_INGESTOR_OWNER_ID`, H3=AC3 DLQ-then-ack.
-  Parent epic **PPT-076 / #170**. Downstream: #177 API run-status, #178 e2e.
+- **PPT-083 / #177:** ingestion connection + run-status — model tables/Alembic,
+  email worker persist hook (`RunResult` mapped at plugin boundary), read-only
+  `GET /api/v1/ingestion/*` (401 / cross-tenant 404; no HTTP run trigger).
+  Soft-delete connection upsert reactivates natural key; serve `deployment_name`
+  wired into deps. Branch `177-featppt-083-…`. Parent epic **PPT-076 / #170**.
 
 ### Open (backlog)
 
-- **PPT-076** remaining: #177 API connection/run-status, #178 e2e/tests/docs.
+- **PPT-076** remaining: #178 e2e/tests/docs (OpenAPI web regen / packaging gate).
 - **PPT-066 follow-up:** after 1–2 releases, drop legacy `model-v*` publish trigger.
 - Alembic/`alembic check` SQLModel CHECK alignment (`chk_financing_share`, etc.).
 
 ### Next action
 
-- Commit/PR PPT-082; hand off flow name `papita-email-ingestion` /
-  `papita-email-ingestion-hourly` to PPT-083 / #177. Live account/category FK
-  enricher remains deferred (H1=B).
+- Ship PPT-083 PR; apply model migration on B0 (`l9a0b1c2d3e4`). Full OpenAPI/CI
+  web contract refresh deferred to PPT-084 / #178. Live FK enricher still H1=B.

--- a/.strata/memory/project_state.md
+++ b/.strata/memory/project_state.md
@@ -36,5 +36,6 @@ Capture with `/strata:capture` only for work in flight.
 
 ### Next action
 
-- Ship PPT-083 PR; apply model migration on B0 (`l9a0b1c2d3e4`). Full OpenAPI/CI
+- Ship PPT-083 PR (#217); Autopilot Black-fix on email `test_status_mapping`
+  for Ingestor CI. Apply model migration on B0 (`l9a0b1c2d3e4`). Full OpenAPI/CI
   web contract refresh deferred to PPT-084 / #178. Live FK enricher still H1=B.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 - [x] [_**[#176](https://github.com/Elmorralito/save-ma-money/issues/176)**_] :: **feat/PPT-082: [ingestor] Prefect hourly flow and Compose packaging** :: _<sub style="vertical-align: middle; color: #636363;">2026-08-05 01:07:51+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-12 22:38:50+00:00</sub>_
 
-  > **Closed by** [_**#216**](https://github.com/Elmorralito/save-ma-money/pull/216): **feat/PPT-082: [ingestor] Prefect hourly flow and Compose packaging**
+  > **Closed by** [\_**#216**](https://github.com/Elmorralito/save-ma-money/pull/216): **feat/PPT-082: [ingestor] Prefect hourly flow and Compose packaging**
 
   > **Branch:** 176-featppt-082-ingestor-prefect-hourly-flow-and-compose-packaging · **Base:** main · **1 commit** · **27 files**
 
@@ -108,7 +108,7 @@
 
   > - Optional Compose service (not started by make api-up)
 
-  > - CI: prefect group + Dockerfile build smoke; QC ignores docker/ingestor/**
+  > - CI: prefect group + Dockerfile build smoke; QC ignores docker/ingestor/\*\*
 
   >
 
@@ -290,7 +290,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#175](https://github.com/Elmorralito/save-ma-money/issues/175)**_] :: **feat/PPT-081: [ingestor] Bancolombia and Nequi email parsers** :: _<sub style="vertical-align: middle; color: #636363;">2026-08-05 01:07:49+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-12 17:28:48+00:00</sub>_
 
-  > **Closed by** [_**#215**](https://github.com/Elmorralito/save-ma-money/pull/215): **feat/PPT-081: [ingestor] Bancolombia and Nequi email parsers**
+  > **Closed by** [\_**#215**](https://github.com/Elmorralito/save-ma-money/pull/215): **feat/PPT-081: [ingestor] Bancolombia and Nequi email parsers**
 
   > **Branch:** 175-featppt-081-ingestor-bancolombia-and-nequi-email-parsers · **Base:** main · **1 commit** · **22 files**
 
@@ -404,7 +404,7 @@
 
   > modules/ingestors/email/tests/conftest.py | 9 +
 
-  > .../tests/fixtures/emails/*.eml | 49 +
+  > .../tests/fixtures/emails/\*.eml | 49 +
 
   > modules/ingestors/email/tests/helpers_records.py | 37 ++++
 
@@ -512,7 +512,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#174](https://github.com/Elmorralito/save-ma-money/issues/174)**_] :: **feat/PPT-080: [ingestor] Gmail OAuth2 source plugin** :: _<sub style="vertical-align: middle; color: #636363;">2026-08-05 01:07:47+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-12 01:41:14+00:00</sub>_
 
-  > **Closed by** [_**#214**](https://github.com/Elmorralito/save-ma-money/pull/214): **feat/PPT-080: [ingestor] Gmail OAuth2 source plugin**
+  > **Closed by** [\_**#214**](https://github.com/Elmorralito/save-ma-money/pull/214): **feat/PPT-080: [ingestor] Gmail OAuth2 source plugin**
 
   > **Branch:** feat/PPT-080 · **Base:** main · **1 commit** · **17 files**
 
@@ -526,7 +526,7 @@
 
   >
 
-  > Implements GmailSource in papita-ingestor-email against papita_ingestor_core contracts (PPT-080 / #174). Headless refresh-token env (GMAIL_*, R2) is the default runtime path; CI stays fully mocked with no live Google credentials. Operators can optionally bootstrap a refresh token for local smoke only.
+  > Implements GmailSource in papita-ingestor-email against papita*ingestor_core contracts (PPT-080 / #174). Headless refresh-token env (GMAIL*\*, R2) is the default runtime path; CI stays fully mocked with no live Google credentials. Operators can optionally bootstrap a refresh token for local smoke only.
 
   >
 
@@ -556,7 +556,7 @@
 
   > - Self-registers as "gmail" via @SourceRegistry.register + registry_id (matches core; not the issue draft’s unsupported positional form)
 
-  > - Compose GmailSettings with BaseIngestorSettings so GMAIL_* and PAPITA_INGESTOR_* stay distinct
+  > - Compose GmailSettings with BaseIngestorSettings so GMAIL*\* and PAPITA_INGESTOR*\* stay distinct
 
   > - Query exclusion of processed label + optional GMAIL_TOKEN_FILE secondary path
 
@@ -582,7 +582,7 @@
 
   >
 
-  > - Root + module .gitignore for token.json / credentials.json / client_secret*.json
+  > - Root + module .gitignore for token.json / credentials.json / client_secret\*.json
 
   > - .env.example names-only; README documents R2 + OAuth bootstrap
 
@@ -688,7 +688,7 @@
 
   > - [ ] Confirm SourceRegistry.get("gmail") works after import papita_ingestor_email in a clean env
 
-  > - [ ] Optional local: with GMAIL_* in environments/local/.env, fetch a few messages (no ack) and verify metadata
+  > - [ ] Optional local: with GMAIL\_\* in environments/local/.env, fetch a few messages (no ack) and verify metadata
 
   > - [ ] Confirm no token.json / credentials.json / client secrets committed
 
@@ -752,7 +752,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#173](https://github.com/Elmorralito/save-ma-money/issues/173)**_] :: **feat/PPT-079: [ingestor] Core contracts, registries, and IngestionRunner** :: _<sub style="vertical-align: middle; color: #636363;">2026-08-05 01:06:49+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-11 22:13:07+00:00</sub>_
 
-  > **Closed by** [_**#213**](https://github.com/Elmorralito/save-ma-money/pull/213): **feat/PPT-079: [ingestor] Core contracts, registries, and IngestionRunner**
+  > **Closed by** [\_**#213**](https://github.com/Elmorralito/save-ma-money/pull/213): **feat/PPT-079: [ingestor] Core contracts, registries, and IngestionRunner**
 
   > **Branch:** feat/PPT-079 · **Base:** main · **1 commit** · **34 files**
 
@@ -816,7 +816,7 @@
 
   > - IngestionRunner streams fetch; continues after ack errors; unknown bridge outcome = persist failure (no ack)
 
-  > - BaseIngestorSettings (PAPITA_INGESTOR_*) honored by runner
+  > - BaseIngestorSettings (PAPITA*INGESTOR*\*) honored by runner
 
   > - Optional build_base_ingestion_flow() behind poetry install -E prefect
 
@@ -860,7 +860,7 @@
 
   > modules/ingestor-core/pyproject.toml
 
-  > modules/ingestor-core/src/papita_ingestor_core/** (errors, flows, mapping, parsers, registry, runner, settings, sources, types)
+  > modules/ingestor-core/src/papita_ingestor_core/\*\* (errors, flows, mapping, parsers, registry, runner, settings, sources, types)
 
   > modules/ingestor-core/tests/{conftest,fakes,test_mapping,test_no_plugin_imports,test_registry,test_runner}.py
 
@@ -962,7 +962,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#172](https://github.com/Elmorralito/save-ma-money/issues/172)**_] :: **feat/PPT-078: [model] Provenance schema and ingestion upsert bridge** :: _<sub style="vertical-align: middle; color: #636363;">2026-08-05 01:06:48+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-11 20:07:14+00:00</sub>_
 
-  > **Closed by** [_**#212**](https://github.com/Elmorralito/save-ma-money/pull/212): **feat/PPT-078: [model] Provenance schema and ingestion upsert bridge**
+  > **Closed by** [\_**#212**](https://github.com/Elmorralito/save-ma-money/pull/212): **feat/PPT-078: [model] Provenance schema and ingestion upsert bridge**
 
   > **Branch:** feat/PPT-078 · **Base:** main · **1 commit** · **19 files**
 
@@ -1204,7 +1204,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#171](https://github.com/Elmorralito/save-ma-money/issues/171)**_] :: **chore/PPT-077: [ingestor] Scaffold ingestor-core + email packages in monorepo** :: _<sub style="vertical-align: middle; color: #636363;">2026-08-05 01:06:46+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-11 03:13:43+00:00</sub>_
 
-  > **Closed by** [_**#211**](https://github.com/Elmorralito/save-ma-money/pull/211): **chore/PPT-077: [ingestor] Scaffold ingestor-core + email packages**
+  > **Closed by** [\_**#211**](https://github.com/Elmorralito/save-ma-money/pull/211): **chore/PPT-077: [ingestor] Scaffold ingestor-core + email packages**
 
   > **Branch:** chore/PPT-077 · **Base:** main · **1 commit** · **77 files**
 
@@ -1284,7 +1284,7 @@
 
   >
 
-  > - Add .github/workflows/ingestor-ci.yml (skip-ingestor-ci); retarget web-ci / publish image path filters to bin/make/*.mk
+  > - Add .github/workflows/ingestor-ci.yml (skip-ingestor-ci); retarget web-ci / publish image path filters to bin/make/\*.mk
 
   > - QC ignores ingestor trees + bin/make/ingestor.mk when those are the only changes
 
@@ -1304,9 +1304,9 @@
 
   >
 
-  > modules/ingestor-core/** # new package scaffold
+  > modules/ingestor-core/\*\* # new package scaffold
 
-  > modules/ingestors/** # email plugin scaffold + hub README
+  > modules/ingestors/\*\* # email plugin scaffold + hub README
 
   > bin/bash/**, bin/python/** # language-organized ops scripts
 
@@ -1316,7 +1316,7 @@
 
   > Makefile, pyproject.toml # includes + workspace path deps
 
-  > .cursor/**, .github/CI.md, docs/**, environments/**/*.env.example
+  > .cursor/**, .github/CI.md, docs/**, environments/\*_/_.env.example
 
   > .strata/memory/learnings/ingestor-scaffold-ci-split.md
 
@@ -1378,9 +1378,9 @@
 
   > >
 
-  > > - Operator scripts moved under bin/bash/ and bin/python/ — bookmarks / local aliases using flat bin/*.sh will break until updated (docs updated in-repo)
+  > > - Operator scripts moved under bin/bash/ and bin/python/ — bookmarks / local aliases using flat bin/\*.sh will break until updated (docs updated in-repo)
 
-  > > - web-ci / publish image workflows now watch bin/make/*.mk instead of the root Makefile; root-only Make edits no longer retrigger those workflows (intentional)
+  > > - web-ci / publish image workflows now watch bin/make/\*.mk instead of the root Makefile; root-only Make edits no longer retrigger those workflows (intentional)
 
   >
 
@@ -1422,7 +1422,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#168](https://github.com/Elmorralito/save-ma-money/issues/168)**_] :: **test/PPT-075: [model] Dues tests, OpenAPI sync, and docs index** :: _<sub style="vertical-align: middle; color: #636363;">2026-08-05 00:08:36+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-10 20:56:35+00:00</sub>_
 
-  > **Closed by** [_**#207**](https://github.com/Elmorralito/save-ma-money/pull/207): **test/PPT-075: [model] Dues tests, OpenAPI sync, and docs index**
+  > **Closed by** [\_**#207**](https://github.com/Elmorralito/save-ma-money/pull/207): **test/PPT-075: [model] Dues tests, OpenAPI sync, and docs index**
 
   > **Branch:** test/PPT-075 · **Base:** main · **1 commit** · **9 files**
 
@@ -1482,7 +1482,7 @@
 
   > - Design README progress + document↔issue rows
 
-  > - ARCHITECTURE: /transaction-templates/* + dues marked **shipped** (was “post-MVP”)
+  > - ARCHITECTURE: /transaction-templates/\* + dues marked **shipped** (was “post-MVP”)
 
   >
 
@@ -1490,7 +1490,7 @@
 
   >
 
-  > - API: catalog + endpoint table for /transaction-templates/* dues actions
+  > - API: catalog + endpoint table for /transaction-templates/\* dues actions
 
   > - Model: dues service methods + PPT-072 test pointers
 
@@ -1640,7 +1640,7 @@
 
   > - [x] CSRF N/A (no mutation client changes)
 
-  > - [x] No secrets in VITE_* (README only)
+  > - [x] No secrets in VITE\_\* (README only)
 
   > - [x] pnpm web:audit N/A for this docs PR
 
@@ -1668,7 +1668,7 @@
 
 - [x] [_**[#167](https://github.com/Elmorralito/save-ma-money/issues/167)**_] :: **feat/PPT-074: [web] Payment dues UI and dashboard Due soon panel** :: _<sub style="vertical-align: middle; color: #636363;">2026-08-05 00:08:33+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-10 20:22:58+00:00</sub>_
 
-  > **Closed by** [_**#206**](https://github.com/Elmorralito/save-ma-money/pull/206): **feat/PPT-074: [web] Payment dues UI and dashboard Due soon panel**
+  > **Closed by** [\_**#206**](https://github.com/Elmorralito/save-ma-money/pull/206): **feat/PPT-074: [web] Payment dues UI and dashboard Due soon panel**
 
   > **Branch:** feat/PPT-074 · **Base:** main · **1 commit** · **21 files**
 
@@ -1708,7 +1708,7 @@
 
   >
 
-  > - Committed OpenAPI artifact regenerated so web types include /transaction-templates*
+  > - Committed OpenAPI artifact regenerated so web types include /transaction-templates\*
 
   > - Dashboard Due soon (14-day window) + mark paid from the panel
 
@@ -1868,7 +1868,7 @@
 
   > >
 
-  > > - OpenAPI artifact is large/regenerated — reviewers should confirm paths for /transaction-templates* and that unrelated contract drift is intentional from offline export
+  > > - OpenAPI artifact is large/regenerated — reviewers should confirm paths for /transaction-templates\* and that unrelated contract drift is intentional from offline export
 
   > > - Mark-paid requires a usable pay-from account when the API/model enforces from_account_id; UI surfaces API errors rather than inventing defaults
 
@@ -1902,7 +1902,7 @@
 
   > - [x] CSRF: mutations send X-Papita-CSRF; token stays in memory (not WebStorage) — uses existing apiFetch
 
-  > - [x] No secrets in VITE_* (public bundle only); gitleaks-aware for accidental embeds
+  > - [x] No secrets in VITE\_\* (public bundle only); gitleaks-aware for accidental embeds
 
   > - [ ] pnpm web:audit considered (or Dependabot npm-web); no known high prod vulns left untracked — CI soft audit still applies
 
@@ -1928,7 +1928,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#165](https://github.com/Elmorralito/save-ma-money/issues/165)**_] :: **feat/PPT-072: [model] Upcoming dues query and mark-paid services** :: _<sub style="vertical-align: middle; color: #636363;">2026-08-05 00:08:30+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-10 17:13:49+00:00</sub>_
 
-  > **Closed by** [_**#204**](https://github.com/Elmorralito/save-ma-money/pull/204): **feat/PPT-072: [model] Upcoming dues query and mark-paid services**
+  > **Closed by** [\_**#204**](https://github.com/Elmorralito/save-ma-money/pull/204): **feat/PPT-072: [model] Upcoming dues query and mark-paid services**
 
   > **Branch:** feat/PPT-072 · **Base:** main · **1 commit** · **7 files**
 
@@ -2144,7 +2144,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#164](https://github.com/Elmorralito/save-ma-money/issues/164)**_] :: **feat/PPT-071: [model] Schema and migration for payment dues on transaction_templates** :: _<sub style="vertical-align: middle; color: #636363;">2026-08-05 00:08:28+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-10 16:07:22+00:00</sub>_
 
-  > **Closed by** [_**#197**](https://github.com/Elmorralito/save-ma-money/pull/197): **feat/PPT-071: [model] Schema and migration for payment dues on transaction_templates**
+  > **Closed by** [\_**#197**](https://github.com/Elmorralito/save-ma-money/pull/197): **feat/PPT-071: [model] Schema and migration for payment dues on transaction_templates**
 
   > **Branch:** feat/PPT-071 · **Base:** main · **1 commit** · **6 files**
 
@@ -2174,7 +2174,7 @@
 
   > - API routers ([#166](https://github.com/Elmorralito/save-ma-money/issues/166)) and SPA ([#167](https://github.com/Elmorralito/save-ma-money/issues/167))
 
-  > - v4.2 recurrence_* / RRULE and paid-state columns on templates
+  > - v4.2 recurrence\_\* / RRULE and paid-state columns on templates
 
   > - Owner-match CHECK for from_account_id (service-owned in PPT-072)
 
@@ -2364,7 +2364,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#131](https://github.com/Elmorralito/save-ma-money/issues/131)**_] :: **ci/PPT-066: [infra] Language-prefixed release tags for polyglot modules** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 01:01:28+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-06 19:40:19+00:00</sub>_
 
-  > **Closed by** [_**#196**](https://github.com/Elmorralito/save-ma-money/pull/196): **ci/PPT-066: [infra] Language-prefixed release tags for polyglot modules**
+  > **Closed by** [\_**#196**](https://github.com/Elmorralito/save-ma-money/pull/196): **ci/PPT-066: [infra] Language-prefixed release tags for polyglot modules**
 
   > **Branch:** ci/PPT-066 · **Base:** main · **1 commit** · **13 files**
 
@@ -2378,7 +2378,7 @@
 
   >
 
-  > Adopts {lang}-{module}-v{semver} Git tags so Python and JS package releases stay unambiguous in this Poetry + pnpm monorepo ([#131](https://github.com/Elmorralito/save-ma-money/issues/131)). Model python-semantic-release now mints **py-model-v***; publish-model.yml dual-triggers legacy **model-v*** for a short migration window. Docs SSOT is [.github/CI.md § Release tagging](https://github.com/Elmorralito/save-ma-money/blob/ci/PPT-066/.github/CI.md#release-tagging-ppt-066).
+  > Adopts {lang}-{module}-v{semver} Git tags so Python and JS package releases stay unambiguous in this Poetry + pnpm monorepo ([#131](https://github.com/Elmorralito/save-ma-money/issues/131)). Model python-semantic-release now mints **py-model-v\***; publish-model.yml dual-triggers legacy **model-v\*** for a short migration window. Docs SSOT is [.github/CI.md § Release tagging](https://github.com/Elmorralito/save-ma-money/blob/ci/PPT-066/.github/CI.md#release-tagging-ppt-066).
 
   >
 
@@ -2394,9 +2394,9 @@
 
   > - GHCR image publish (PPT-067 / #132 — image tags already mirror the convention)
 
-  > - Retagging historical model-v* commits
+  > - Retagging historical model-v\* commits
 
-  > - Dropping the legacy model-v* trigger (follow-up after 1–2 releases)
+  > - Dropping the legacy model-v\* trigger (follow-up after 1–2 releases)
 
   > - Cutting a live PyPI release to prove the new tag (operator verify on next model bump)
 
@@ -2490,7 +2490,7 @@
 
   >
 
-  > - 7e3a623 ci(release): adopt language-prefixed py-model-v* tags (PPT-066)
+  > - 7e3a623 ci(release): adopt language-prefixed py-model-v\* tags (PPT-066)
 
   >
 
@@ -2518,7 +2518,7 @@
 
   > - [ ] Optional: human/PAT tag py-model-vX.Y.Z matching modules/model/pyproject.toml still publishes
 
-  > - [ ] After 1–2 releases: open follow-up to drop legacy model-v* trigger
+  > - [ ] After 1–2 releases: open follow-up to drop legacy model-v\* trigger
 
   >
 
@@ -2536,7 +2536,7 @@
 
   > > - First post-merge model release must mint py-model-v* (operators should not create new model-v* tags)
 
-  > > - Legacy model-v* still publishes during the dual-trigger window (skip-existing on PyPI mitigates accidental re-publish of the same version)
+  > > - Legacy model-v\* still publishes during the dual-trigger window (skip-existing on PyPI mitigates accidental re-publish of the same version)
 
   >
 
@@ -2552,7 +2552,7 @@
 
   > >
 
-  > > - Closing #131 operationally wants one successful py-model-v* release after merge; this PR lands CI + docs only
+  > > - Closing #131 operationally wants one successful py-model-v\* release after merge; this PR lands CI + docs only
 
   > > - js-web-v* / py-api-v* are documented conventions only until those release workflows exist
 
@@ -2574,7 +2574,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#132](https://github.com/Elmorralito/save-ma-money/issues/132)**_] :: **ops/PPT-067: [infra] Publish versioned Docker images for API (and optional migrate)** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 01:03:29+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-05 03:25:41+00:00</sub>_
 
-  > **Closed by** [_**#188**](https://github.com/Elmorralito/save-ma-money/pull/188): **ops/PPT-067: [infra] Publish versioned Docker images for API**
+  > **Closed by** [\_**#188**](https://github.com/Elmorralito/save-ma-money/pull/188): **ops/PPT-067: [infra] Publish versioned Docker images for API**
 
   > **Branch:** ops/PPT-067 (tracks origin/ops/PPT-067, clean) · **Base:** main · **7 commits** · **18+ files**
 
@@ -2588,7 +2588,7 @@
 
   >
 
-  > Closes the PPT-067 gap where Compose could build the API image locally but CI never published versioned runtime artifacts to a registry. Stable images now publish to GHCR from main only (edge / semver / py-api-v* / sha tags); same-repo PRs get skippable pr-* / dev-* preview tags. Pre-push Trivy CRITICAL/HIGH (rootfs gate) and /api/v1/health/live smoke gate pushes. Decision A is locked: model stays on PyPI; Compose migrate reuses the API image (no separate migrate runtime image). Helm remains out of scope.
+  > Closes the PPT-067 gap where Compose could build the API image locally but CI never published versioned runtime artifacts to a registry. Stable images now publish to GHCR from main only (edge / semver / py-api-v* / sha tags); same-repo PRs get skippable pr-* / dev-\* preview tags. Pre-push Trivy CRITICAL/HIGH (rootfs gate) and /api/v1/health/live smoke gate pushes. Decision A is locked: model stays on PyPI; Compose migrate reuses the API image (no separate migrate runtime image). Helm remains out of scope.
 
   >
 
@@ -2708,7 +2708,7 @@
 
   > .cursor/AGENTS.md
 
-  > .cursor/rules/gen-custom/*
+  > .cursor/rules/gen-custom/\*
 
   > .strata/memory/project_state.md
 
@@ -2808,7 +2808,7 @@
 
   > >
 
-  > > - Git tag events (py-api-v*) do **not** trigger this workflow; version tags come from the API package version on main publish / dispatch.
+  > > - Git tag events (py-api-v\*) do **not** trigger this workflow; version tags come from the API package version on main publish / dispatch.
 
   > > - PR preview tags are same-repo only; forks do not publish.
 
@@ -2834,7 +2834,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#140](https://github.com/Elmorralito/save-ma-money/issues/140)**_] :: **docs/PPT-069: [web] Non-goals — CRUD via #117+; no TypeScript UsersService** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-29 17:29:56+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-04 18:35:18+00:00</sub>_
 
-  > **Closed by** [_**#161**](https://github.com/Elmorralito/save-ma-money/pull/161): **docs/PPT-069: [web] Non-goals — CRUD via #117+; no TypeScript UsersService**
+  > **Closed by** [\_**#161**](https://github.com/Elmorralito/save-ma-money/pull/161): **docs/PPT-069: [web] Non-goals — CRUD via #117+; no TypeScript UsersService**
 
   > **Branch:** docs/PPT-069 · **Base:** main · **1 commit** · **4 files**
 
@@ -3006,11 +3006,11 @@
 
   > - [x] CSRF: mutations send X-Papita-CSRF — N/A (no mutation code)
 
-  > - [x] No secrets in VITE_* — N/A (no env/code changes)
+  > - [x] No secrets in VITE\_\* — N/A (no env/code changes)
 
   > - [x] pnpm web:audit considered — N/A (docs-only)
 
-  > - [x] CSP: nginx SPA headers — N/A (no docker/web/** changes)
+  > - [x] CSP: nginx SPA headers — N/A (no docker/web/\*\* changes)
 
   >
 
@@ -3032,7 +3032,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#139](https://github.com/Elmorralito/save-ma-money/issues/139)**_] :: **feat/PPT-068: [web] Email verification after Supabase registration** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-29 17:27:47+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-04 17:44:20+00:00</sub>_
 
-  > **Closed by** [_**#160**](https://github.com/Elmorralito/save-ma-money/pull/160): **feat/PPT-068: [web] Email verification after Supabase registration**
+  > **Closed by** [\_**#160**](https://github.com/Elmorralito/save-ma-money/pull/160): **feat/PPT-068: [web] Email verification after Supabase registration**
 
   > **Branch:** feat/PPT-068 · **Base:** main · **1 commit** · **36 files**
 
@@ -3314,7 +3314,7 @@
 
   > - [x] CSRF: mutations send X-Papita-CSRF; token stays in memory (not WebStorage); resend-confirmation intentionally CSRF-exempt (same posture as login/register)
 
-  > - [x] No secrets in VITE_* (public bundle only); gitleaks-aware for accidental embeds
+  > - [x] No secrets in VITE\_\* (public bundle only); gitleaks-aware for accidental embeds
 
   > - [ ] pnpm web:audit considered (or Dependabot npm-web); no known high prod vulns left untracked — **not re-run in this pass**
 
@@ -3338,7 +3338,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#128](https://github.com/Elmorralito/save-ma-money/issues/128)**_] :: **ops/PPT-063: [web] nginx CSP and SPA security headers** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:59:07+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-04 16:37:35+00:00</sub>_
 
-  > **Closed by** [_**#159**](https://github.com/Elmorralito/save-ma-money/pull/159): **ops/PPT-063: [web] nginx CSP and SPA security headers**
+  > **Closed by** [\_**#159**](https://github.com/Elmorralito/save-ma-money/pull/159): **ops/PPT-063: [web] nginx CSP and SPA security headers**
 
   > **Branch:** ops/PPT-063 · **Base:** main · **1 commit** · **14 files**
 
@@ -3486,7 +3486,7 @@
 
   > - make web-up — pass (health + CSP smoke OK on :3000)
 
-  > - Standalone image build + curl -sI / / /assets/* — CSP + baseline present
+  > - Standalone image build + curl -sI / / /assets/\* — CSP + baseline present
 
   > - Buildx tar export → docker load → header smoke (CI path) — pass
 
@@ -3558,11 +3558,11 @@
 
   > - [x] CSRF: mutations send X-Papita-CSRF; token stays in memory (not WebStorage) — untouched
 
-  > - [x] No secrets in VITE_* (public bundle only); gitleaks-aware for accidental embeds
+  > - [x] No secrets in VITE\_\* (public bundle only); gitleaks-aware for accidental embeds
 
   > - [x] pnpm web:audit considered (or Dependabot npm-web); no known high prod vulns left untracked — not re-run this PR (docs/ops only for web sources)
 
-  > - [x] CSP: nginx SPA headers reviewed when touching docker/web/** (PPT-063 / #128; Vite :5173 has no CSP meta)
+  > - [x] CSP: nginx SPA headers reviewed when touching docker/web/\*\* (PPT-063 / #128; Vite :5173 has no CSP meta)
 
   >
 
@@ -3584,7 +3584,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#122](https://github.com/Elmorralito/save-ma-money/issues/122)**_] :: **ops/PPT-057: [web] nginx Compose packaging and prod origins** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:47:55+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-04 14:31:24+00:00</sub>_
 
-  > **Closed by** [_**#158**](https://github.com/Elmorralito/save-ma-money/pull/158): **ops/PPT-057: [web] nginx Compose packaging and prod origins**
+  > **Closed by** [\_**#158**](https://github.com/Elmorralito/save-ma-money/pull/158): **ops/PPT-057: [web] nginx Compose packaging and prod origins**
 
   > **Branch:** ops/PPT-057 · **Base:** main · **1 commit** · **16 files**
 
@@ -3598,7 +3598,7 @@
 
   >
 
-  > Delivers **PPT-057 / #122**: package @papita/web as a multi-stage **nginx** image in Compose so the SPA and /api are same-origin, preserving BFF HttpOnly cookies (papita_sid, Path=/api, SameSite=Lax) without cross-site cookie CORS. Adds make web-up smoke, documents prod-oriented ALLOWED_ORIGINS / bake-time VITE_*, and teaches Web CI to build the image.
+  > Delivers **PPT-057 / #122**: package @papita/web as a multi-stage **nginx** image in Compose so the SPA and /api are same-origin, preserving BFF HttpOnly cookies (papita*sid, Path=/api, SameSite=Lax) without cross-site cookie CORS. Adds make web-up smoke, documents prod-oriented ALLOWED_ORIGINS / bake-time VITE*\*, and teaches Web CI to build the image.
 
   >
 
@@ -3638,7 +3638,7 @@
 
   >
 
-  > - docker/web/Dockerfile: Node 22 + pnpm → nginx:1.27-alpine; bake public VITE_* at build time (empty VITE_API_BASE_URL for same-origin /api)
+  > - docker/web/Dockerfile: Node 22 + pnpm → nginx:1.27-alpine; bake public VITE\_\* at build time (empty VITE_API_BASE_URL for same-origin /api)
 
   > - docker/web/nginx.conf: SPA try_files; proxy /api → api:8000; pass Set-Cookie; client_max_body_size 1m
 
@@ -3654,7 +3654,7 @@
 
   > - make web-up / web-down; stack-up includes web
 
-  > - environments/{local,staging,production}/.env.example: WEB_PORT, VITE_* bake-arg notes, explicit web origins (never * with credentials)
+  > - environments/{local,staging,production}/.env.example: WEB*PORT, VITE*_ bake-arg notes, explicit web origins (never _ with credentials)
 
   >
 
@@ -3662,7 +3662,7 @@
 
   >
 
-  > - web-ci.yml: path-filter docker/web/** + web-docker Buildx job (push: false)
+  > - web-ci.yml: path-filter docker/web/\*\* + web-docker Buildx job (push: false)
 
   > - modules/web/README.md nginx runbook; root README / AGENTS / project_structure / CI.md / strata
 
@@ -3754,7 +3754,7 @@
 
   > - [ ] Confirm CSRF mutations still send X-Papita-CSRF through the nginx proxy
 
-  > - [ ] Staging/prod-shaped env: ALLOWED_ORIGINS lists the nginx/SPA origin only (no *); Redis enabled
+  > - [ ] Staging/prod-shaped env: ALLOWED_ORIGINS lists the nginx/SPA origin only (no \*); Redis enabled
 
   > - [ ] Optional: make stack-up brings up web with the rest of the stack
 
@@ -3794,7 +3794,7 @@
 
   > >
 
-  > > - VITE_* are bake-time only — changing them requires rebuild of the web image
+  > > - VITE\_\* are bake-time only — changing them requires rebuild of the web image
 
   > > - nginx packaging smoke is not a substitute for Playwright E2E (web-e2e); cookie login QA is manual above
 
@@ -3812,7 +3812,7 @@
 
   > - [x] CSRF: mutations send X-Papita-CSRF; token stays in memory (not WebStorage) — unchanged; proxy passes headers
 
-  > - [x] No secrets in VITE_* (public bundle only); only title / breaking-changes id / empty base URL as build-args
+  > - [x] No secrets in VITE\_\* (public bundle only); only title / breaking-changes id / empty base URL as build-args
 
   > - [ ] pnpm web:audit considered (or Dependabot npm-web) — not re-run in this packaging PR; covered by existing web-ci soft audit step
 
@@ -3840,7 +3840,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#129](https://github.com/Elmorralito/save-ma-money/issues/129)**_] :: **feat/PPT-064: [web] Client guard for Papita breaking-changes contract** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:59:08+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-03 21:26:12+00:00</sub>_
 
-  > **Closed by** [_**#157**](https://github.com/Elmorralito/save-ma-money/pull/157): **feat/PPT-064: [web] Client guard for Papita breaking-changes contract**
+  > **Closed by** [\_**#157**](https://github.com/Elmorralito/save-ma-money/pull/157): **feat/PPT-064: [web] Client guard for Papita breaking-changes contract**
 
   > **Branch:** feat/PPT-064 · **Base:** main · **1 commit** · **15 files**
 
@@ -4020,7 +4020,7 @@
 
   > >
 
-  > > - Expected id is public VITE_* only — no secrets added
+  > > - Expected id is public VITE\_\* only — no secrets added
 
   > > - Does not auto-update UI behavior when the server bumps the discovery id
 
@@ -4036,7 +4036,7 @@
 
   > - [x] CSRF: mutations send X-Papita-CSRF; token stays in memory (not WebStorage) — N/A (no auth mutations)
 
-  > - [x] No secrets in VITE_* (public bundle only); gitleaks-aware for accidental embeds
+  > - [x] No secrets in VITE\_\* (public bundle only); gitleaks-aware for accidental embeds
 
   > - [ ] pnpm web:audit considered (or Dependabot npm-web); no known high prod vulns left untracked — not run this PR
 
@@ -4060,7 +4060,7 @@
 
 - [x] [_**[#123](https://github.com/Elmorralito/save-ma-money/issues/123)**_] :: **docs/PPT-058: [web] Document modules/web in monorepo indexes** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:59:00+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-03 19:28:54+00:00</sub>_
 
-  > **Closed by** [_**#155**](https://github.com/Elmorralito/save-ma-money/pull/155): **docs/PPT-058: [web] Document modules/web in monorepo indexes**
+  > **Closed by** [\_**#155**](https://github.com/Elmorralito/save-ma-money/pull/155): **docs/PPT-058: [web] Document modules/web in monorepo indexes**
 
   > **Branch:** docs/PPT-058 · **Base:** main · **1 commit** · **8 files**
 
@@ -4262,7 +4262,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#121](https://github.com/Elmorralito/save-ma-money/issues/121)**_] :: **test/PPT-056: [web] Vitest Playwright a11y and security hardening** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:47:53+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-03 18:29:14+00:00</sub>_
 
-  > **Closed by** [_**#154**](https://github.com/Elmorralito/save-ma-money/pull/154): **test/PPT-056: [web] Add Vitest coverage, Playwright a11y, and security hardening**
+  > **Closed by** [\_**#154**](https://github.com/Elmorralito/save-ma-money/pull/154): **test/PPT-056: [web] Add Vitest coverage, Playwright a11y, and security hardening**
 
   > **Branch:** test/PPT-056 (tracks origin/test/PPT-056, clean) · **Base:** main · **1 commit** · **35 files**
 
@@ -4338,7 +4338,7 @@
 
   > - Playwright config + e2e/ critical path, axe, optional live register (E2E_LIVE_REGISTER)
 
-  > - Vitest v8 coverage thresholds in vite.config.ts (pragmatic floor on gated src/**)
+  > - Vitest v8 coverage thresholds in vite.config.ts (pragmatic floor on gated src/\*\*)
 
   > - Unit: CSRF memory-only; BFF login does not persist JWTs; applyMutationError 422 vs 429
 
@@ -4498,7 +4498,7 @@
 
   > - [ ] Sign off **Web security checklist** below
 
-  > - [ ] CI: path-filtered PR should run web-ci; web-e2e should run because this PR touches modules/web/e2e/**
+  > - [ ] CI: path-filtered PR should run web-ci; web-e2e should run because this PR touches modules/web/e2e/\*\*
 
   >
 
@@ -4514,7 +4514,7 @@
 
   > >
 
-  > > - Vitest coverage thresholds can fail web-ci if new ungated src/** code lands without tests — keep dialog shells excluded or raise coverage with the change.
+  > > - Vitest coverage thresholds can fail web-ci if new ungated src/\*\* code lands without tests — keep dialog shells excluded or raise coverage with the change.
 
   > > - web-e2e.yml stands up full Compose; flaky local rate limits / cold runners can fail Playwright or Lighthouse (LHCI is continue-on-error; Playwright is not).
 
@@ -4554,7 +4554,7 @@
 
   > - [ ] CSRF: mutations send X-Papita-CSRF; token stays in memory (not WebStorage)
 
-  > - [ ] No secrets in VITE_* (public bundle only); gitleaks-aware for accidental embeds
+  > - [ ] No secrets in VITE\_\* (public bundle only); gitleaks-aware for accidental embeds
 
   > - [ ] pnpm web:audit considered (or Dependabot npm-web); no known high prod vulns left untracked
 
@@ -4584,7 +4584,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#127](https://github.com/Elmorralito/save-ma-money/issues/127)**_] :: **feat/PPT-062: [web] Minimal session user chip and logout in app shell** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:59:06+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-03 18:26:02+00:00</sub>_
 
-  > **Closed by** [_**#152**](https://github.com/Elmorralito/save-ma-money/pull/152): **feat/PPT-062: [web] Minimal session user chip and logout in app shell**
+  > **Closed by** [\_**#152**](https://github.com/Elmorralito/save-ma-money/pull/152): **feat/PPT-062: [web] Minimal session user chip and logout in app shell**
 
   > **Branch:** feat/PPT-062 · **Base:** main · **1 commit** · **7 files**
 
@@ -4790,7 +4790,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#124](https://github.com/Elmorralito/save-ma-money/issues/124)**_] :: **ops/PPT-059: [web] BFF session durability vs Redis PPT-043** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:59:01+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-03 18:13:42+00:00</sub>_
 
-  > **Closed by** [_**#153**](https://github.com/Elmorralito/save-ma-money/pull/153): **ops/PPT-059: [api] Lock BFF session durability contract vs Redis**
+  > **Closed by** [\_**#153**](https://github.com/Elmorralito/save-ma-money/pull/153): **ops/PPT-059: [api] Lock BFF session durability contract vs Redis**
 
   > **Branch:** ops/PPT-059 · **Base:** main · **1 commit** · **35 files**
 
@@ -5046,7 +5046,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#126](https://github.com/Elmorralito/save-ma-money/issues/126)**_] :: **test/PPT-061: [web] E2E seed fixtures for Playwright critical path** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:59:04+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-03 17:40:24+00:00</sub>_
 
-  > **Closed by** [_**#151**](https://github.com/Elmorralito/save-ma-money/pull/151): **test/PPT-061: [web] E2E seed fixtures for Playwright critical path**
+  > **Closed by** [\_**#151**](https://github.com/Elmorralito/save-ma-money/pull/151): **test/PPT-061: [web] E2E seed fixtures for Playwright critical path**
 
   > **Branch:** test/PPT-061 · **Base:** main · **1 commit** · **11 files**
 
@@ -5114,7 +5114,7 @@
 
   >
 
-  > - modules/web/README.md + modules/web/e2e/README.md: strategy, contract, env knobs (E2E_*), CI placement
+  > - modules/web/README.md + modules/web/e2e/README.md: strategy, contract, env knobs (E2E\_\*), CI placement
 
   > - .strata issue 20260803-05 + project_state / MEMORY pointers for PPT-061 → #121 handoff
 
@@ -5260,7 +5260,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#120](https://github.com/Elmorralito/save-ma-money/issues/120)**_] :: **feat/PPT-055: [web] Forms validation and loading UX standards** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:47:52+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-03 17:22:43+00:00</sub>_
 
-  > **Closed by** [_**#149**](https://github.com/Elmorralito/save-ma-money/pull/149): **feat/PPT-055: [web] Forms validation and loading UX standards**
+  > **Closed by** [\_**#149**](https://github.com/Elmorralito/save-ma-money/pull/149): **feat/PPT-055: [web] Forms validation and loading UX standards**
 
   > **Branch:** feat/PPT-055 · **Base:** main · **1 commit** · **24 files**
 
@@ -5508,7 +5508,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#125](https://github.com/Elmorralito/save-ma-money/issues/125)**_] :: **feat/PPT-060: [web] Supabase auth edge-case MVP matrix for BFF** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:59:03+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-03 17:09:37+00:00</sub>_
 
-  > **Closed by** [_**#150**](https://github.com/Elmorralito/save-ma-money/pull/150): **feat/PPT-060: [web] Lock Supabase auth edge-case MVP matrix for BFF**
+  > **Closed by** [\_**#150**](https://github.com/Elmorralito/save-ma-money/pull/150): **feat/PPT-060: [web] Lock Supabase auth edge-case MVP matrix for BFF**
 
   > **Branch:** feat/PPT-060 (tracks origin/feat/PPT-060) · **Base:** main · **1 commit** · **9 files**
 
@@ -5662,7 +5662,7 @@
 
   > - [ ] Confirm Web CI green on the PR
 
-  > - [ ] No secrets / VITE_* credentials in the diff
+  > - [ ] No secrets / VITE\_\* credentials in the diff
 
   >
 
@@ -5722,7 +5722,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#119](https://github.com/Elmorralito/save-ma-money/issues/119)**_] :: **feat/PPT-054: [web] Dashboard and reports UI on existing API** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:47:51+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-03 16:19:06+00:00</sub>_
 
-  > **Closed by** [_**#148**](https://github.com/Elmorralito/save-ma-money/pull/148): **feat/PPT-054: [web] Dashboard and reports UI on existing API**
+  > **Closed by** [\_**#148**](https://github.com/Elmorralito/save-ma-money/pull/148): **feat/PPT-054: [web] Dashboard and reports UI on existing API**
 
   > **Branch:** feat/PPT-054 · **Base:** main · **1 commit** · **20 files**
 
@@ -5962,7 +5962,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#118](https://github.com/Elmorralito/save-ma-money/issues/118)**_] :: **feat/PPT-053: [web] Transactions and movements UI on existing API** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:47:50+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-03 16:02:54+00:00</sub>_
 
-  > **Closed by** [_**#147**](https://github.com/Elmorralito/save-ma-money/pull/147): **feat/PPT-053: [web] Transactions and movements UI on existing API**
+  > **Closed by** [\_**#147**](https://github.com/Elmorralito/save-ma-money/pull/147): **feat/PPT-053: [web] Transactions and movements UI on existing API**
 
   > **Branch:** feat/PPT-053 · **Base:** main · **2 commits** · **44 files**
 
@@ -6112,11 +6112,11 @@
 
   > modules/web/README.md | 59 ++--
 
-  > modules/web/src/api/** | transactions/movements/idempotency/errors/queryKeys
+  > modules/web/src/api/\*\* | transactions/movements/idempotency/errors/queryKeys
 
-  > modules/web/src/components/{transactions,movements}/**
+  > modules/web/src/components/{transactions,movements}/\*\*
 
-  > modules/web/src/pages/{Transactions,Movements}Page*
+  > modules/web/src/pages/{Transactions,Movements}Page\*
 
   > modules/web/src/types/domain.ts | Transaction*/Movement* aliases
 
@@ -6168,7 +6168,7 @@
 
   > - [ ] Confirm no Split control in Transactions UI
 
-  > - [ ] Stage a modules/web TS change and confirm local web-* pre-commit hooks run (pnpm install required)
+  > - [ ] Stage a modules/web TS change and confirm local web-\* pre-commit hooks run (pnpm install required)
 
   > - [ ] Web CI green on the PR
 
@@ -6232,7 +6232,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#117](https://github.com/Elmorralito/save-ma-money/issues/117)**_] :: **feat/PPT-052: [web] Accounts and categories UI on existing API** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:47:49+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-08-03 15:01:45+00:00</sub>_
 
-  > **Closed by** [_**#143**](https://github.com/Elmorralito/save-ma-money/pull/143): **feat/PPT-052: [web] Accounts and categories UI with local Supabase auth DX**
+  > **Closed by** [\_**#143**](https://github.com/Elmorralito/save-ma-money/pull/143): **feat/PPT-052: [web] Accounts and categories UI with local Supabase auth DX**
 
   > **Branch:** feat/PPT-052 · **Base:** main · **1 commit** · **56 files**
 
@@ -6406,9 +6406,9 @@
 
   > modules/web/src/components/QueryState.tsx | 61 +
 
-  > modules/web/src/components/accounts/* | ~828 +
+  > modules/web/src/components/accounts/\* | ~828 +
 
-  > modules/web/src/components/categories/* | ~323 +
+  > modules/web/src/components/categories/\* | ~323 +
 
   > modules/web/src/components/layout/navItems.ts | 2 +-
 
@@ -6416,9 +6416,9 @@
 
   > modules/web/src/components/ui/password-input.tsx | 40 +
 
-  > modules/web/src/lib/* | ~230 +
+  > modules/web/src/lib/\* | ~230 +
 
-  > modules/web/src/pages/* | ~900 +-
+  > modules/web/src/pages/\* | ~900 +-
 
   > modules/web/src/types/domain.ts | 16 +
 
@@ -6478,7 +6478,7 @@
 
   > - [ ] Wrong password still fails (no Admin confirm on already-confirmed users)
 
-  > - [ ] Confirm environments/**/.env secrets are **not** in the PR
+  > - [ ] Confirm environments/**/.env secrets are **not\*\* in the PR
 
   > - [ ] CI: web-ci + quality-control green on this branch
 
@@ -6542,7 +6542,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#116](https://github.com/Elmorralito/save-ma-money/issues/116)**_] :: **feat/PPT-051: [web] Tailwind + shadcn design system and app shell** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:47:48+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-30 18:02:53+00:00</sub>_
 
-  > **Closed by** [_**#142**](https://github.com/Elmorralito/save-ma-money/pull/142): **feat/PPT-051: [web] Tailwind + shadcn design system and app shell**
+  > **Closed by** [\_**#142**](https://github.com/Elmorralito/save-ma-money/pull/142): **feat/PPT-051: [web] Tailwind + shadcn design system and app shell**
 
   > **Branch:** feat/PPT-051 · **Base:** main · **1 commit** · **39 files**
 
@@ -6664,7 +6664,7 @@
 
   > modules/web/src/components/layout/navItems.ts | 14 +
 
-  > modules/web/src/components/ui/* | (primitives)
+  > modules/web/src/components/ui/\* | (primitives)
 
   > modules/web/src/index.css | 126 +-
 
@@ -6672,7 +6672,7 @@
 
   > modules/web/src/main.tsx | 2 +
 
-  > modules/web/src/pages/* | (stubs + auth restyle)
+  > modules/web/src/pages/\* | (stubs + auth restyle)
 
   > modules/web/vite.config.ts | 3 +-
 
@@ -6776,7 +6776,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#115](https://github.com/Elmorralito/save-ma-money/issues/115)**_] :: **feat/PPT-049: [web] BFF HttpOnly cookie session with Supabase IdP** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:47:46+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-30 15:04:32+00:00</sub>_
 
-  > **Closed by** [_**#141**](https://github.com/Elmorralito/save-ma-money/pull/141): **feat/PPT-049: [web] BFF HttpOnly cookie session with Supabase IdP**
+  > **Closed by** [\_**#141**](https://github.com/Elmorralito/save-ma-money/pull/141): **feat/PPT-049: [web] BFF HttpOnly cookie session with Supabase IdP**
 
   > **Branch:** feat/PPT-049 · **Base:** main · **1 commit** · **35 files**
 
@@ -6836,7 +6836,7 @@
 
   >
 
-  > - New /api/v1/bff/auth/* (login, register, session, refresh, logout)
+  > - New /api/v1/bff/auth/\* (login, register, session, refresh, logout)
 
   > - BffSessionStore (Redis when REDIS_ENABLED, else memory)
 
@@ -6952,9 +6952,9 @@
 
   > modules/web/src/api/queryKeys.ts | 4 +
 
-  > modules/web/src/auth/* | new
+  > modules/web/src/auth/\* | new
 
-  > modules/web/src/pages/* | new
+  > modules/web/src/pages/\* | new
 
   > modules/web/src/types/api.d.ts | 285 +
 
@@ -7060,7 +7060,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#114](https://github.com/Elmorralito/save-ma-money/issues/114)**_] :: **feat/PPT-048: [web] OpenAPI types + thin API client (no domain logic)** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:47:45+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-29 14:56:34+00:00</sub>_
 
-  > **Closed by** [_**#138**](https://github.com/Elmorralito/save-ma-money/pull/138): **feat/PPT-048: [web] OpenAPI types + thin API client (no domain logic)**
+  > **Closed by** [\_**#138**](https://github.com/Elmorralito/save-ma-money/pull/138): **feat/PPT-048: [web] OpenAPI types + thin API client (no domain logic)**
 
   > **Branch:** feat/PPT-048 · **Base:** main · **1 commit** · **26 files**
 
@@ -7172,7 +7172,7 @@
 
   > modules/web/src/App.tsx | 48 ++++++++++++++--
 
-  > modules/web/src/api/* | thin client + unit tests
+  > modules/web/src/api/\* | thin client + unit tests
 
   > modules/web/src/main.tsx | 8 ++-
 
@@ -7288,7 +7288,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#130](https://github.com/Elmorralito/save-ma-money/issues/130)**_] :: **ci/PPT-065: [web] Lock OpenAPI typegen CI strategy** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:59:10+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 20:25:37+00:00</sub>_
 
-  > **Closed by** [_**#137**](https://github.com/Elmorralito/save-ma-money/pull/137): **ci/PPT-065: [web] Lock OpenAPI typegen strategy B with dual CI gates**
+  > **Closed by** [\_**#137**](https://github.com/Elmorralito/save-ma-money/pull/137): **ci/PPT-065: [web] Lock OpenAPI typegen strategy B with dual CI gates**
 
   > **Branch:** ci/PPT-065 · **Base:** main · **1 commit** · **20 files**
 
@@ -7520,7 +7520,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#113](https://github.com/Elmorralito/save-ma-money/issues/113)**_] :: **chore/PPT-047: [web] Scaffold modules/web + pnpm + Web CI** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 00:47:44+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-28 17:34:16+00:00</sub>_
 
-  > **Closed by** [_**#133**](https://github.com/Elmorralito/save-ma-money/pull/133): **chore/PPT-047: [web] Scaffold modules/web + pnpm + Web CI**
+  > **Closed by** [\_**#133**](https://github.com/Elmorralito/save-ma-money/pull/133): **chore/PPT-047: [web] Scaffold modules/web + pnpm + Web CI**
 
   > **Branch:** chore/PPT-047 · **Base:** main · **1 commit** · **37 files**
 
@@ -7580,9 +7580,9 @@
 
   >
 
-  > - modules/web: Vite React-TS app, TS strict + noUncheckedIndexedAccess, @/* path alias
+  > - modules/web: Vite React-TS app, TS strict + noUncheckedIndexedAccess, @/\* path alias
 
-  > - Public-only modules/web/.env.example (VITE_*); README covers Node 22 / pnpm 9, proxy, ALLOWED_ORIGINS
+  > - Public-only modules/web/.env.example (VITE\_\*); README covers Node 22 / pnpm 9, proxy, ALLOWED_ORIGINS
 
   >
 
@@ -7590,7 +7590,7 @@
 
   >
 
-  > - Root pnpm-workspace.yaml, package.json (web:* scripts), Makefile web-dev|lint|test|build
+  > - Root pnpm-workspace.yaml, package.json (web:\* scripts), Makefile web-dev|lint|test|build
 
   > - .nvmrc / .node-version pin Node 22
 
@@ -7656,7 +7656,7 @@
 
   > Makefile | 14 +
 
-  > modules/web/** | scaffold (Vite React-TS + tooling)
+  > modules/web/\*\* | scaffold (Vite React-TS + tooling)
 
   > package.json | 15 +
 
@@ -7770,7 +7770,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#11](https://github.com/Elmorralito/save-ma-money/issues/11)**_] :: **feat/PPT-024: [model] Package papita-transactions-model and publish to PyPI** :: _<sub style="vertical-align: middle; color: #636363;">2025-10-01 21:22:00+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-24 21:19:52+00:00</sub>_
 
-  > **Closed by** [_**#104**](https://github.com/Elmorralito/save-ma-money/pull/104): **feat(PPT-024): [model] Package papita-transactions-model and publish to PyPI**
+  > **Closed by** [\_**#104**](https://github.com/Elmorralito/save-ma-money/pull/104): **feat(PPT-024): [model] Package papita-transactions-model and publish to PyPI**
 
   > ## Summary
 
@@ -7778,7 +7778,7 @@
 
   > - Harden modules/model/pyproject.toml for public install; move pytest to Poetry dev group; **meta** reads version via importlib.metadata when installed from a wheel.
 
-  > - Add OIDC publish workflow (TestPyPI via dispatch; PyPI via model-v* tag or confirmed dispatch) with clean-venv import smoke.
+  > - Add OIDC publish workflow (TestPyPI via dispatch; PyPI via model-v\* tag or confirmed dispatch) with clean-venv import smoke.
 
   >
 
@@ -7806,7 +7806,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#93](https://github.com/Elmorralito/save-ma-money/issues/93)**_] :: **ops/PPT-045: [api] Standardize uvicorn process packaging for host and Compose** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-17 20:22:50+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-24 19:30:18+00:00</sub>_
 
-  > **Closed by** [_**#103**](https://github.com/Elmorralito/save-ma-money/pull/103): **ops/PPT-045: [api] Standardize uvicorn process packaging for host and Compose**
+  > **Closed by** [\_**#103**](https://github.com/Elmorralito/save-ma-money/pull/103): **ops/PPT-045: [api] Standardize uvicorn process packaging for host and Compose**
 
   > ## Summary
 
@@ -7840,7 +7840,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#89](https://github.com/Elmorralito/save-ma-money/issues/89)**_] :: **fix/PPT-044: [api] Post-MVP API security and operational hardening** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-13 21:16:14+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-23 22:12:18+00:00</sub>_
 
-  > **Closed by** [_**#102**](https://github.com/Elmorralito/save-ma-money/pull/102): **fix/PPT-044: [api] Post-MVP hardening, efficiency, and design SSOT**
+  > **Closed by** [\_**#102**](https://github.com/Elmorralito/save-ma-money/pull/102): **fix/PPT-044: [api] Post-MVP hardening, efficiency, and design SSOT**
 
   > **Branch:** docs/create-issue-skill · **Base:** main (83d5c66) · **10 commits** · **90 files**
 
@@ -7920,7 +7920,7 @@
 
   > - SQL pagination for account/category lists; digest idempotency request bodies
 
-  > - Security pack: headers, TrustedHost, CORS fail-fast on * when not DEBUG, docs gated by DEBUG/DOCS_ENABLED
+  > - Security pack: headers, TrustedHost, CORS fail-fast on \* when not DEBUG, docs gated by DEBUG/DOCS_ENABLED
 
   > - Client-contract middleware/meta; rate limits on auth/budgets/health; Redis cache/RL polish
 
@@ -7936,7 +7936,7 @@
 
   > - ARCHITECTURE Part VIII (PPT-044); design README § Ops (Redis + B1 pooler)
 
-  > - Delete docs/ops/* checklists and docs/issues/PPT-044-api-hardening-brief.md; retarget AGENTS/strata/API/env READMEs
+  > - Delete docs/ops/\* checklists and docs/issues/PPT-044-api-hardening-brief.md; retarget AGENTS/strata/API/env READMEs
 
   >
 
@@ -7970,7 +7970,7 @@
 
   > .strata/MANIFEST.md
 
-  > .strata/docs/ops/*
+  > .strata/docs/ops/\*
 
   > .strata/issues/20260713-03-ppt044-api-hardening.md
 
@@ -7982,19 +7982,19 @@
 
   > docs/issues/PPT-044-api-hardening-brief.md (deleted)
 
-  > docs/ops/* (deleted)
+  > docs/ops/\* (deleted)
 
   > environments/{local,staging,production}/.env.example
 
   > modules/api/README.md
 
-  > modules/api/src/papita_txnsapi/** (settings, cache, rate_limit, client_contract, middleware, routers, schemas)
+  > modules/api/src/papita_txnsapi/\*\* (settings, cache, rate_limit, client_contract, middleware, routers, schemas)
 
-  > modules/api/tests/** (security_pack, client_contract, redis, RL, …)
+  > modules/api/tests/\*\* (security_pack, client_contract, redis, RL, …)
 
-  > modules/model/src/papita_txnsmodel/** (base repository, categories, reports, transactions, accounts, balances)
+  > modules/model/src/papita_txnsmodel/\*\* (base repository, categories, reports, transactions, accounts, balances)
 
-  > modules/model/tests_papita_txnsmodel/** (ppt041, prf_efficiency, repository)
+  > modules/model/tests_papita_txnsmodel/\*\* (ppt041, prf_efficiency, repository)
 
   >
 
@@ -8060,7 +8060,7 @@
 
   > - [ ] CI green on this PR (API + model unit jobs)
 
-  > - [ ] With DEBUG=false: docs off, CORS rejects *, TrustedHost enforces ALLOWED_HOSTS, security headers present
+  > - [ ] With DEBUG=false: docs off, CORS rejects \*, TrustedHost enforces ALLOWED_HOSTS, security headers present
 
   > - [ ] Soft-deleted accounts/categories/txns stay hidden on list/get; upsert does not revive
 
@@ -8074,7 +8074,7 @@
 
   > - [ ] Optional Redis: cache version reuse + rate limits when REDIS_ENABLED=true and REDIS_URL set (names only; values in local .env, not committed)
 
-  > - [ ] Confirm environments/**/.env secrets are **not** in the PR
+  > - [ ] Confirm environments/**/.env secrets are **not\*\* in the PR
 
   > - [ ] Skim design Part VIII / README § Ops vs deleted docs/ops — links from AGENTS/API README resolve
 
@@ -8146,7 +8146,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#42](https://github.com/Elmorralito/save-ma-money/issues/42)**_] :: **feat/PPT-032: [EPIC][api] FastAPI MVP on v3 model + Supabase Auth** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-07 23:54:37+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-17 23:17:31+00:00</sub>_
 
-  > **Closed by** [_**#95**](https://github.com/Elmorralito/save-ma-money/pull/95): **docs/PPT-032: [api] Consolidate API and issue documentation for epic close-out**
+  > **Closed by** [\_**#95**](https://github.com/Elmorralito/save-ma-money/pull/95): **docs/PPT-032: [api] Consolidate API and issue documentation for epic close-out**
 
   > ## Summary
 
@@ -8218,7 +8218,7 @@
 
   > - Expand docs/issues/README.md Parts I–V (simplify, Supabase G7, epic #42, PPT-039, Redis)
 
-  > - Remove standalone: simplify, PPT-031-C, PPT-039 reissue, PPT-043 Redis, _gh_body_PPT-032, _gh_body_PPT-039
+  > - Remove standalone: simplify, PPT-031-C, PPT-039 reissue, PPT-043 Redis, \_gh_body_PPT-032, \_gh_body_PPT-039
 
   >
 
@@ -8274,9 +8274,9 @@
 
   > docs/issues/README.md
 
-  > docs/issues/_gh_body_PPT-032-epic.md (deleted)
+  > docs/issues/\_gh_body_PPT-032-epic.md (deleted)
 
-  > docs/issues/_gh_body_PPT-039.md (deleted)
+  > docs/issues/\_gh_body_PPT-039.md (deleted)
 
   > docs/ops/b1-supabase-deploy-checklist.md
 
@@ -8372,7 +8372,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#83](https://github.com/Elmorralito/save-ma-money/issues/83)**_] :: **feat/PPT-043: [api] Redis integration for distributed cache, sessions, and rate limiting** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-10 16:03:54+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-17 22:40:06+00:00</sub>_
 
-  > **Closed by** [_**#94**](https://github.com/Elmorralito/save-ma-money/pull/94): **feat(PPT-043): integrate Redis for cache, sessions, and rate limits (PPT-…**
+  > **Closed by** [\_**#94**](https://github.com/Elmorralito/save-ma-money/pull/94): **feat(PPT-043): integrate Redis for cache, sessions, and rate limits (PPT-…**
 
   > ## Summary
 
@@ -8406,7 +8406,7 @@
 
   > - Versioned tenant cache (papita:{PAPITA_ENV}:…) with per-route TTLs and X-Cache
 
-  > - Atomic Lua sliding-window rate limits; tenant Free/Pro/Enterprise quotas + X-RateLimit-*
+  > - Atomic Lua sliding-window rate limits; tenant Free/Pro/Enterprise quotas + X-RateLimit-\*
 
   > - Logout JWT denylist fail-closed when Redis is required (503 if unavailable)
 
@@ -8426,7 +8426,7 @@
 
   > - Atomic Redis rate limiter (auth + tenant API); in-memory fallback when Redis off
 
-  > - Settings: REDIS__, per-namespace cache TTLs, idempotency TTL, API_RATE_LIMIT__
+  > - Settings: REDIS**, per-namespace cache TTLs, idempotency TTL, API_RATE_LIMIT**
 
   >
 
@@ -8460,7 +8460,7 @@
 
   >
 
-  > - environments/*/.env.example, environments/README.md, modules/api/README.md
+  > - environments/\*/.env.example, environments/README.md, modules/api/README.md
 
   > - PPT-045 brief + issues README map; strata architecture/project_state notes
 
@@ -8484,7 +8484,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#50](https://github.com/Elmorralito/save-ma-money/issues/50)**_] :: **test/PPT-040: [api] Integration test suite and B0 CI gate (Auth-first)** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-07 23:55:06+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-16 14:10:20+00:00</sub>_
 
-  > **Closed by** [_**#92**](https://github.com/Elmorralito/save-ma-money/pull/92): **test/PPT-040: [api] Integration suite and B0 CI (Auth-first)**
+  > **Closed by** [\_**#92**](https://github.com/Elmorralito/save-ma-money/pull/92): **test/PPT-040: [api] Integration suite and B0 CI (Auth-first)**
 
   > ## Summary
 
@@ -8528,7 +8528,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#49](https://github.com/Elmorralito/save-ma-money/issues/49)**_] :: **feat/PPT-039: [api] Supabase Auth (replace local JWT issuance)** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-07 23:55:05+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-15 17:45:38+00:00</sub>_
 
-  > **Closed by** [_**#91**](https://github.com/Elmorralito/save-ma-money/pull/91): **ops/PPT-039: [api] Supabase Auth (JWKS, OAuth, tenant link)**
+  > **Closed by** [\_**#91**](https://github.com/Elmorralito/save-ma-money/pull/91): **ops/PPT-039: [api] Supabase Auth (JWKS, OAuth, tenant link)**
 
   > **Branch:** ops/PPT-039 (tracks origin/ops/PPT-039, clean)
 
@@ -8556,7 +8556,7 @@
 
   > - environments/{local,staging,production}/.env.example, environments/README.md, settings/PAPITA_ENV loading
 
-  > - Compose injects SUPABASE_* (incl. service role / OAuth) into the API service
+  > - Compose injects SUPABASE\_\* (incl. service role / OAuth) into the API service
 
   > - deploy/auth_smoke.sh, B1/deploy helpers, untrack generated docs/coverage.xml
 
@@ -8668,7 +8668,7 @@
 
   > - [ ] Compose API receives SUPABASE_URL / anon / service-role / OAuth redirect env
 
-  > - [ ] Confirm environments/**/.env (secrets) are **not** in the PR
+  > - [ ] Confirm environments/**/.env (secrets) are **not\*\* in the PR
 
   > - [ ] CI secrets path deferred to #50 — note any local-only Auth keys in review comments
 
@@ -8706,7 +8706,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#48](https://github.com/Elmorralito/save-ma-money/issues/48)**_] :: **feat/PPT-038: [api] Reports read models (spending, cash-flow, trends, export)** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-07 23:55:04+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-13 21:49:15+00:00</sub>_
 
-  > **Closed by** [_**#90**](https://github.com/Elmorralito/save-ma-money/pull/90): **feat(api): add tenant-scoped reports and structured DB health probes (PPT-038)**
+  > **Closed by** [\_**#90**](https://github.com/Elmorralito/save-ma-money/pull/90): **feat(api): add tenant-scoped reports and structured DB health probes (PPT-038)**
 
   > Wire FR-12 report endpoints under /api/v1/reports so authenticated tenants can query spending, cash flow, trends, and CSV/JSON exports via ReportService, while budget performance remains a JWT-gated 501. At the same time, harden health database probing with allowlisted details and latency, and document follow-on API hardening (PPT-044 / #89) plus Conventional Commit issue-title guidance.
 
@@ -8770,7 +8770,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#47](https://github.com/Elmorralito/save-ma-money/issues/47)**_] :: **feat/PPT-037: [api] Transactions CRUD and movements TRANSFER alias router** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-07 23:55:00+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-13 17:01:10+00:00</sub>_
 
-  > **Closed by** [_**#88**](https://github.com/Elmorralito/save-ma-money/pull/88): **feat(api): add transactions and movements CRUD endpoints (PPT-037)**
+  > **Closed by** [\_**#88**](https://github.com/Elmorralito/save-ma-money/pull/88): **feat(api): add transactions and movements CRUD endpoints (PPT-037)**
 
   > ## Summary
 
@@ -8848,7 +8848,7 @@
 
   > - **Symlinks**: .agents/AGENTS.md → .cursor/AGENTS.md, .agents/CLAUDE.md → .cursor/CLAUDE.md
 
-  > - strata_check.sh validates .agents/ paths; strict pairing accepts .agents/** or .cursor/AGENTS.md / .cursor/CLAUDE.md
+  > - strata_check.sh validates .agents/ paths; strict pairing accepts .agents/\*\* or .cursor/AGENTS.md / .cursor/CLAUDE.md
 
   > - Updated: .github/CI.md, README.md, .strata/MANIFEST.md, strata-strict-pairing.md, project_adapters.mdc
 
@@ -8860,7 +8860,7 @@
 
   > - **Separation of concerns:** /transactions rejects TRANSFER updates with **422** → use /movements; business logic stays in TransactionsService.
 
-  > - **List filters:** Query params bundled into Pydantic dependency classes; service kwargs use TypedDicts to satisfy mypy through **kwargs unpacking.
+  > - **List filters:** Query params bundled into Pydantic dependency classes; service kwargs use TypedDicts to satisfy mypy through \*\*kwargs unpacking.
 
   > - **Pagination:** Count + fetch happen in SQL, not in-memory DataFrame slicing.
 
@@ -8874,7 +8874,7 @@
 
   > - Transaction split (501)
 
-  > - /reports/* ([#48](https://github.com/Elmorralito/save-ma-money/issues/48))
+  > - /reports/\* ([#48](https://github.com/Elmorralito/save-ma-money/issues/48))
 
   > - Supabase B1 wiring ([#49](https://github.com/Elmorralito/save-ma-money/issues/49))
 
@@ -8918,7 +8918,7 @@
 
 - [x] [_**[#46](https://github.com/Elmorralito/save-ma-money/issues/46)**_] :: **feat/PPT-036: [api] Accounts and categories CRUD (v3 model)** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-07 23:54:52+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-10 20:28:06+00:00</sub>_
 
-  > **Closed by** [_**#84**](https://github.com/Elmorralito/save-ma-money/pull/84): **feat(api): add accounts and categories CRUD endpoints (PPT-036)**
+  > **Closed by** [\_**#84**](https://github.com/Elmorralito/save-ma-money/pull/84): **feat(api): add accounts and categories CRUD endpoints (PPT-036)**
 
   > Implement PPT-036 / #46: eleven tenant-scoped REST routes for accounts and categories, wired through existing model services with pagination, enum slug conversion, extension fields (G1), MV-backed balances with G8 initial_value fallback, list filters (G4), and global category immutability (G7). Before this change the API had health, auth, and deferred budgets only; account and category CRUD lived solely in the model layer. After this change authenticated tenants can manage accounts and categories via /api/v1/accounts and /api/v1/categories, with cross-tenant access returning 404 and inactive records hidden on GET.
 
@@ -8982,7 +8982,7 @@
 
 - [x] [_**[#44](https://github.com/Elmorralito/save-ma-money/issues/44)**_] :: **feat/PPT-035: [api] Auth routes and tenant context module (local JWT)** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-07 23:54:49+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-10 16:14:39+00:00</sub>_
 
-  > **Closed by** [_**#82**](https://github.com/Elmorralito/save-ma-money/pull/82): **feat/PPT-035: [api] Auth routes and tenant context**
+  > **Closed by** [\_**#82**](https://github.com/Elmorralito/save-ma-money/pull/82): **feat/PPT-035: [api] Auth routes and tenant context**
 
   > ## Summary
 
@@ -9004,7 +9004,7 @@
 
   > ### Auth hardening (post-PPT-035)
 
-  > - **Rate limiting** — in-memory sliding-window limiter on /auth/register and /auth/login; returns 429 with X-RateLimit-* headers; configurable via AUTH_RATE_LIMIT_* env vars (B0 single-instance; Redis deferred to PPT-043)
+  > - **Rate limiting** — in-memory sliding-window limiter on /auth/register and /auth/login; returns 429 with X-RateLimit-_ headers; configurable via AUTH*RATE_LIMIT*_ env vars (B0 single-instance; Redis deferred to PPT-043)
 
   > - **JWT type validation** — decode_token(..., expected_type=...) and get_current_owner() reject tokens with wrong type claim
 
@@ -9020,7 +9020,7 @@
 
   > - strata-validate pre-commit hook now uses always_run: true (evaluates full staged diff on every commit)
 
-  > - Strata Check workflow installs Poetry/pre-commit and enables code review; path triggers include .github/scripts/**
+  > - Strata Check workflow installs Poetry/pre-commit and enables code review; path triggers include .github/scripts/\*\*
 
   >
 
@@ -9048,7 +9048,7 @@
 
   > - [x] pre-commit run strata-validate / Strata code review on changed Python and Bash files
 
-  > - [x] Rebuild Docker API image so :8000 serves /auth/* routes (docker compose -f docker/docker-compose.yml up --build -d api)
+  > - [x] Rebuild Docker API image so :8000 serves /auth/\* routes (docker compose -f docker/docker-compose.yml up --build -d api)
 
   > - [ ] B1 Supabase pooler smoke (manual, post-merge)
 
@@ -9076,7 +9076,7 @@
 
   > - [x] modules/api/src/papita_txnsapi/dependencies/rate_limit.py
 
-  > - [x] modules/api/src/papita_txnsapi/config/settings.py — AUTH_RATE_LIMIT_*
+  > - [x] modules/api/src/papita*txnsapi/config/settings.py — AUTH_RATE_LIMIT*\*
 
   > - [x] modules/api/src/papita_txnsapi/core/security.py — JWT type claim validation
 
@@ -9136,7 +9136,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#43](https://github.com/Elmorralito/save-ma-money/issues/43)**_] :: **docs/PPT-033: [api] Validate API spec against v3 model implementation** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-07 23:54:48+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-09 18:05:24+00:00</sub>_
 
-  > **Closed by** [_**#80**](https://github.com/Elmorralito/save-ma-money/pull/80): **docs/PPT-033: [api] Validate API spec against v3 model implementation**
+  > **Closed by** [\_**#80**](https://github.com/Elmorralito/save-ma-money/pull/80): **docs/PPT-033: [api] Validate API spec against v3 model implementation**
 
   > ## Summary
 
@@ -9188,7 +9188,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#52](https://github.com/Elmorralito/save-ma-money/issues/52)**_] :: **ops/PPT-042: [infra] CI adoption badge GitHub Action** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-08 01:30:57+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-08 20:36:13+00:00</sub>_
 
-  > **Closed by** [_**#56**](https://github.com/Elmorralito/save-ma-money/pull/56): **ci(badge): add CI adoption scoring workflow and README badge (PPT-042)**
+  > **Closed by** [\_**#56**](https://github.com/Elmorralito/save-ma-money/pull/56): **ci(badge): add CI adoption scoring workflow and README badge (PPT-042)**
 
   > Implement ops/PPT-042 (#52): a config-file-based CI maturity evaluator that scores repository adoption signals, maintains a dynamic shields.io badge in README.md, and gives developers optional local pre-push feedback. Before this change, CI maturity was documented only in .github/CI.md with no automated visibility in the README or repeatable rubric.
 
@@ -9220,7 +9220,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#51](https://github.com/Elmorralito/save-ma-money/issues/51)**_] :: **perf/PPT-041: [model] Harden v3 data model for API readiness** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-08 00:27:45+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-08 18:07:44+00:00</sub>_
 
-  > **Closed by** [_**#54**](https://github.com/Elmorralito/save-ma-money/pull/54): **feat(model): harden v3 services for PPT-041 API readiness**
+  > **Closed by** [\_**#54**](https://github.com/Elmorralito/save-ma-money/pull/54): **feat(model): harden v3 services for PPT-041 API readiness**
 
   > Close model-layer gaps from the PPT-032 coverage audit (G1, G3, G5) so the FastAPI epic can wire routers against a complete service surface. Before this change, AccountsService only exposed base CRUD, TransactionsService refreshed balance MVs only on bulk upsert, ReportService did not exist, tenancy was mock-tested only, and repository upserts could fail for owned tables due to a missing owner context on pre-read. The root README still described a legacy monorepo layout (registrar/plugins, 228 tests, issue #25) and lacked a business/technical overview aligned with PPT-031 and PPT-032.
 
@@ -9242,13 +9242,13 @@
 
   > - modules/model/src/papita_txnsmodel/services/reports.py (new): implement ReportService.spending, cash_flow, trends, and export per mapping §5.8 / FR-12
 
-  > - modules/model/src/papita_txnsmodel/services/categories.py: block tenant writes to global categories (owner_id IS NULL) via _reject_global_category_write and _existing_category_owner_id
+  > - modules/model/src/papita_txnsmodel/services/categories.py: block tenant writes to global categories (owner_id IS NULL) via \_reject_global_category_write and \_existing_category_owner_id
 
   > - modules/model/src/papita_txnsmodel/services/**init**.py: export ReportService, owner balance services, and refresh_balance_materialized_views
 
   > - modules/model/src/papita_txnsmodel/access/base/repository.py: fix upsert_record to pass dto_type to get_record_by_id, use add when no row exists / merge when found, and forward owner from OwnedTableRepository.upsert_record
 
-  > - modules/model/src/papita_txnsmodel/access/categories/repository.py: use SQLAlchemy .is_(None) so global category rows are readable in live queries
+  > - modules/model/src/papita*txnsmodel/access/categories/repository.py: use SQLAlchemy .is*(None) so global category rows are readable in live queries
 
   > - modules/model/tests/tests_papita_txnsmodel/services/test_ppt041_services.py (new): unit tests for account orchestration, transfer helpers, ReportService, and global-category write guard
 
@@ -9268,7 +9268,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#34](https://github.com/Elmorralito/save-ma-money/issues/34)**_] :: **PPT-031-E: Alembic migration + Supabase PostgreSQL validation** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-02 00:20:38+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-08 01:51:39+00:00</sub>_
 
-  > **Closed by** [_**#53**](https://github.com/Elmorralito/save-ma-money/pull/53): **feat(model)!: implement PPT-031 v3 schema, balance reports, and trans…**
+  > **Closed by** [\_**#53**](https://github.com/Elmorralito/save-ma-money/pull/53): **feat(model)!: implement PPT-031 v3 schema, balance reports, and trans…**
 
   > feat(model)!: implement PPT-031 v3 schema, balance reports, and transaction partitioning
 
@@ -9320,7 +9320,7 @@
 
   > workflows/quality-control.yml, and five reformatted views/balance_reports/
 
-  > *.sql files. Stage them before commit or land in a follow-up chore commit.
+  > \*.sql files. Stage them before commit or land in a follow-up chore commit.
 
   >
 
@@ -9746,9 +9746,9 @@
 
 - [x] [_**[#41](https://github.com/Elmorralito/save-ma-money/issues/41)**_] :: **Add GitHub Actions security scanning, Strata validation, and local pre-commit guardrails** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-06 21:59:30+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-06 22:00:49+00:00</sub>_
 
-  > **Closed by** [_**#40**](https://github.com/Elmorralito/save-ma-money/pull/40): **ci(security): add GitHub security workflows, Strata scaffold, and agent docs**
+  > **Closed by** [\_**#40**](https://github.com/Elmorralito/save-ma-money/pull/40): **ci(security): add GitHub security workflows, Strata scaffold, and agent docs**
 
-  > Previously, CI covered quality (pre-commit/pytest), migrations, and supply-chain auditing via pip-audit only. There was no SAST, secret scanning, filesystem CVE/IaC scanning, or validation of agent project memory. Supply-chain path filters still referenced gitignored poetry.lock; quality-control ignored a non-existent .docs/* path.
+  > Previously, CI covered quality (pre-commit/pytest), migrations, and supply-chain auditing via pip-audit only. There was no SAST, secret scanning, filesystem CVE/IaC scanning, or validation of agent project memory. Supply-chain path filters still referenced gitignored poetry.lock; quality-control ignored a non-existent .docs/\* path.
 
   >
 
@@ -9760,13 +9760,13 @@
 
   > - Secret leaks: undetected in CI → full-history Gitleaks scan on every PR
 
-  > - Code vulnerabilities: none → CodeQL security-extended on modules/** changes
+  > - Code vulnerabilities: none → CodeQL security-extended on modules/\*\* changes
 
   > - CVE/IaC: pip-audit onrivy filesystem scan + SARIF on manifest/docker paths
 
   > - Agent memory: none → .strata/ scaffold with PR validation (strict module pairing)
 
-  > - Docs-only PRs: ran full QC → skipped via paths-ignore: docs/**
+  > - Docs-only PRs: ran full QC → skipped via paths-ignore: docs/\*\*
 
   > - Supply-chain: dead poetry.lock path filter → removed; weekly schedule retained
 
@@ -9776,13 +9776,13 @@
 
   > - .github/workflows/gitleaks.yml: new workflow — PR/push/weekly secret scan; full git history; gitleaks-action pinned to SHA e0c47f4f... (v3)
 
-  > - .github/workflows/codeql.yml: new workflow — Python SAST with Poetry install; path-filtered to modules/**; init/analyze pinned to CodeQL v3 SHA
+  > - .github/workflows/codeql.yml: new workflow — Python SAST with Poetry install; path-filtered to modules/\*\*; init/analyze pinned to CodeQL v3 SHA
 
   > - .github/workflows/trivy.yml: new workflow — filesystem vuln+misconfig scan; trivy-action SHA-pinned (v0.36.0); SARIF upload via upload-sarif v4 SHA; secrets scanner omitted (Gitleaks is primary)
 
-  > - .github/workflows/strata-check.yml: new workflow — validates .strata/ layout on code-path PRs; strict mode requires .strata/ updates when modules/** changes
+  > - .github/workflows/strata-check.yml: new workflow — validates .strata/ layout on code-path PRs; strict mode requires .strata/ updates when modules/\*\* changes
 
-  > - .github/workflows/quali: fix paths-ignore to docs/**; add concurrency group
+  > - .github/workflows/quali: fix paths-ignore to docs/\*\*; add concurrency group
 
   > - .github/workflows/supply-chain-check.yml: remove dead poetry.lock paths; add concurrency, weekly schedule, and workflow_dispatch
 
@@ -9792,7 +9792,7 @@
 
   > - .gitleaks.toml: allowlist .env.example placeholders and template strings
 
-  > - .strata/**: initialize Strata layout v3 scaffold (memory, issues, docs tiers); MANIFEST and ARCHITECTURE customized for this monorepo
+  > - .strata/\*\*: initialize Strata layout v3 scaffold (memory, issues, docs tiers); MANIFEST and ARCHITECTURE customized for this monorepo
 
   > - AGENTS.md: new operational hub — repo map, layers, env, CI matrix, PR checklist
 
@@ -9806,7 +9806,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#33](https://github.com/Elmorralito/save-ma-money/issues/33)**_] :: **PPT-031-D: API spec realignment to v3 model** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-02 00:20:36+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-06 21:15:11+00:00</sub>_
 
-  > **Closed by** [_**#39**](https://github.com/Elmorralito/save-ma-money/pull/39): **docs(PPT-031-D)!: align API specs to v3 model and document auth contract**
+  > **Closed by** [\_**#39**](https://github.com/Elmorralito/save-ma-money/pull/39): **docs(PPT-031-D)!: align API specs to v3 model and document auth contract**
 
   > Deliver PPT-031 Track C (#33) and partial Track E (G5): canonical API endpoint mapping to the v3 schema, rewritten integration guide (FR-17), local-JWT auth contract (FR-10/FR-11), and UsersService register/login business logic for #25.
 
@@ -9834,7 +9834,7 @@
 
   > - docs/design/PPT-031-v1-schema.md: Resolve “needs #33” markers in §2.1– §2.2; link to mapping doc for categories/movements decisions
 
-  > - modules/model/src/papita_txnsmodel/services/users.py: Add ensure_password_manager(), verify_credentials(), register(), and _find_by_login_identifier() (Argon2 verify, duplicate checks, inactive user guard)
+  > - modules/model/src/papita_txnsmodel/services/users.py: Add ensure_password_manager(), verify_credentials(), register(), and \_find_by_login_identifier() (Argon2 verify, duplicate checks, inactive user guard)
 
   > - modules/model/tests/tests_papita_txnsmodel/services/test_users.py (new): Unit tests for auth methods (9 cases)
 
@@ -9848,11 +9848,11 @@
 
   >
 
-  > BREAKING CHANGE: API spec aligned to v3 — register uses username (not full_name); account_type → account_kind; initial_balance → initial_value; budget_id removed from transactions; /budgets/* and /auth/refresh|logout return 501 in MVP; /movements backed by TRANSFER transactions. See docs/design/PPT-031-api-model-mapping.md §8 for consumer migration notes.
+  > BREAKING CHANGE: API spec aligned to v3 — register uses username (not full_name); account_type → account_kind; initial_balance → initial_value; budget_id removed from transactions; /budgets/\* and /auth/refresh|logout return 501 in MVP; /movements backed by TRANSFER transactions. See docs/design/PPT-031-api-model-mapping.md §8 for consumer migration notes.
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#31](https://github.com/Elmorralito/save-ma-money/issues/31)**_] :: **PPT-031-C: Supabase × FastAPI integration decision record** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-02 00:20:35+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-06 20:45:43+00:00</sub>_
 
-  > **Closed by** [_**#38**](https://github.com/Elmorralito/save-ma-money/pull/38): **docs(PPT-031-C): complete Supabase decision record and deprecate DuckDB upserter**
+  > **Closed by** [\_**#38**](https://github.com/Elmorralito/save-ma-money/pull/38): **docs(PPT-031-C): complete Supabase decision record and deprecate DuckDB upserter**
 
   > Closes the Track B deliverable for GitHub issue #31 by expanding the skeleton decision brief into a full Supabase × FastAPI integration record, adding a root .env.example template, and aligning registry docs with proposed gate G7 (B0 local Docker Postgres + B1 Supabase for staging/prod; B2/B3 deferred pending G5 auth contract and #34 RLS work). Also deprecates DuckDBUpserter in the code to align with the documented PostgreSQL-only platform decision.
 
@@ -9894,7 +9894,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#32](https://github.com/Elmorralito/save-ma-money/issues/32)**_] :: **PPT-031-B: Target schema iterations v1–v3 + ER diagram** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-02 00:20:35+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-06 19:28:43+00:00</sub>_
 
-  > **Closed by** [_**#37**](https://github.com/Elmorralito/save-ma-money/pull/37): **docs(PPT-031-B): add v1–v3 target schema, v4 extensions, and ER diagrams**
+  > **Closed by** [\_**#37**](https://github.com/Elmorralito/save-ma-money/pull/37): **docs(PPT-031-B): add v1–v3 target schema, v4 extensions, and ER diagrams**
 
   > Deliver PPT-031 Track A steps A2–A4 ([#32](https://github.com/Elmorralito/save-ma-money/issues/32)) and post-MVP additive schema design on top of the v0 audit ([#30](https://github.com/Elmorralito/save-ma-money/issues/30)). Before this change, #32 deliverables were marked “pending” in the design index with no frozen target schema, migration outline, or ER artifacts. After this change, v3 is documented for G1 maintainer sign-off on [#28](https://github.com/Elmorralito/save-ma-money/issues/28), and v4 extensions are specified as a separate post-G1 migration wave without reopening the v3 freeze.
 
@@ -9946,7 +9946,7 @@
 
 - [x] [_**[#30](https://github.com/Elmorralito/save-ma-money/issues/30)**_] :: **PPT-031-A: Data model audit and 3NF gap analysis (v0)** :: _<sub style="vertical-align: middle; color: #636363;">2026-07-02 00:20:33+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-07-06 14:38:22+00:00</sub>_
 
-  > **Closed by** [_**#35**](https://github.com/Elmorralito/save-ma-money/pull/35): **docs(PPT-031-A): Data model audit and 3NF gap analysis (v0)**
+  > **Closed by** [\_**#35**](https://github.com/Elmorralito/save-ma-money/pull/35): **docs(PPT-031-A): Data model audit and 3NF gap analysis (v0)**
 
   > docs(PPT-031): add expert-review findings register to v0 audit
 
@@ -10026,7 +10026,7 @@
 
 - [x] [_**[#26](https://github.com/Elmorralito/save-ma-money/issues/26)**_] :: **feature/PPT-031: Add users to the data model** :: _<sub style="vertical-align: middle; color: #636363;">2026-01-28 00:17:05+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-02-04 23:31:20+00:00</sub>_
 
-  > **Closed by** [_**#27**](https://github.com/Elmorralito/save-ma-money/pull/27): **Feat/ppt 031**
+  > **Closed by** [\_**#27**](https://github.com/Elmorralito/save-ma-money/pull/27): **Feat/ppt 031**
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#5](https://github.com/Elmorralito/save-ma-money/issues/5)**_] :: **feature/PPT-019** :: _<sub style="vertical-align: middle; color: #636363;">2025-09-19 00:44:08+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-01-07 22:44:59+00:00</sub>_
 
@@ -10034,11 +10034,11 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#10](https://github.com/Elmorralito/save-ma-money/issues/10)**_] :: **docs/PPT-023: API Documentation** :: _<sub style="vertical-align: middle; color: #636363;">2025-10-01 15:41:26+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2026-01-02 23:06:15+00:00</sub>_
 
-  > **Closed by** [_**#23**](https://github.com/Elmorralito/save-ma-money/pull/23): **docs(PPT-023): Finishing documentation. TODO: API documentation, it'l…**
+  > **Closed by** [\_**#23**](https://github.com/Elmorralito/save-ma-money/pull/23): **docs(PPT-023): Finishing documentation. TODO: API documentation, it'l…**
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#18](https://github.com/Elmorralito/save-ma-money/issues/18)**_] :: **feat/PPT-027: Update the file system accessors to use smart-open instead.** :: _<sub style="vertical-align: middle; color: #636363;">2025-12-22 22:31:51+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2025-12-27 04:07:55+00:00</sub>_
 
-  > **Closed by** [_**#22**](https://github.com/Elmorralito/save-ma-money/pull/22): **feat(PPT-027): Introduce CSV file plugin and CLI support**
+  > **Closed by** [\_**#22**](https://github.com/Elmorralito/save-ma-money/pull/22): **feat(PPT-027): Introduce CSV file plugin and CLI support**
 
   > - Added CSVFilePlugin for loading and processing CSV files, integrating with the transaction tracking system.
 
@@ -10050,7 +10050,7 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#20](https://github.com/Elmorralito/save-ma-money/issues/20)**_] :: **feat/PPT-028: Add feature to list available plugins** :: _<sub style="vertical-align: middle; color: #636363;">2025-12-27 00:25:15+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2025-12-27 02:42:12+00:00</sub>_
 
-  > **Closed by** [_**#21**](https://github.com/Elmorralito/save-ma-money/pull/21): **feat(PPT-028): Enhance plugin metadata and CLI utilities**
+  > **Closed by** [\_**#21**](https://github.com/Elmorralito/save-ma-money/pull/21): **feat(PPT-028): Enhance plugin metadata and CLI utilities**
 
   > - Introduced author information in the plugin metadata model, allowing for detailed author attribution.
 
@@ -10062,24 +10062,24 @@
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#14](https://github.com/Elmorralito/save-ma-money/issues/14)**_] :: **test/PPT-025: Unit test design, implementation and code refinement** :: _<sub style="vertical-align: middle; color: #636363;">2025-10-05 20:07:41+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2025-12-27 01:05:24+00:00</sub>_
 
-  > **Closed by** [_**#19**](https://github.com/Elmorralito/save-ma-money/pull/19): **test(PPT-025)**
+  > **Closed by** [\_**#19**](https://github.com/Elmorralito/save-ma-money/pull/19): **test(PPT-025)**
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#4](https://github.com/Elmorralito/save-ma-money/issues/4)**_] :: **feature/PPT-018** :: _<sub style="vertical-align: middle; color: #636363;">2025-09-19 00:29:57+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2025-11-29 15:46:35+00:00</sub>_
 
-  > **Closed by** [_**#16**](https://github.com/Elmorralito/save-ma-money/pull/16): **feat(PPT-018): Registrar**
+  > **Closed by** [\_**#16**](https://github.com/Elmorralito/save-ma-money/pull/16): **feat(PPT-018): Registrar**
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#8](https://github.com/Elmorralito/save-ma-money/issues/8)**_] :: **docs/PPT-021: Tracker/Loader Documentation** :: _<sub style="vertical-align: middle; color: #636363;">2025-10-01 15:39:56+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2025-10-10 01:41:35+00:00</sub>_
 
-  > **Closed by** [_**#15**](https://github.com/Elmorralito/save-ma-money/pull/15): **docs(PPT-021): Defining the design of the tracker/registrar module**
+  > **Closed by** [\_**#15**](https://github.com/Elmorralito/save-ma-money/pull/15): **docs(PPT-021): Defining the design of the tracker/registrar module**
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#9](https://github.com/Elmorralito/save-ma-money/issues/9)**_] :: **build/PPT-022: Data model indexer** :: _<sub style="vertical-align: middle; color: #636363;">2025-10-01 15:40:47+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2025-10-05 20:03:12+00:00</sub>_
 
-  > **Closed by** [_**#12**](https://github.com/Elmorralito/save-ma-money/pull/12): **build(PPT-022): Data model indexer**
+  > **Closed by** [\_**#12**](https://github.com/Elmorralito/save-ma-money/pull/12): **build(PPT-022): Data model indexer**
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#3](https://github.com/Elmorralito/save-ma-money/issues/3)**_] :: **build/PPT-017** :: _<sub style="vertical-align: middle; color: #636363;">2025-09-19 00:19:36+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2025-10-01 02:18:51+00:00</sub>_
 
-  > **Closed by** [_**#6**](https://github.com/Elmorralito/save-ma-money/pull/6): **build(PPT-017): Creating CI actions**
+  > **Closed by** [\_**#6**](https://github.com/Elmorralito/save-ma-money/pull/6): **build(PPT-017): Creating CI actions**
 
 - [x] <img src="https://avatars.githubusercontent.com/u/233175807?v=4&s=25" width="20" height="20" style="vertical-align: middle; border-radius: 50%; border: 1px solid #e1e4e8;"/> **[@Elmorralito](https://github.com/Elmorralito)** [_**[#1](https://github.com/Elmorralito/save-ma-money/issues/1)**_] :: **feature/PPT-016** :: _<sub style="vertical-align: middle; color: #636363;">2025-09-18 23:46:39+00:00</sub>_ :weary: → :laughing: _<sub style="vertical-align: middle; color: #636363;">2025-09-22 22:16:22+00:00</sub>_
 
-  > **Closed by** [_**#2**](https://github.com/Elmorralito/save-ma-money/pull/2): **feat(PPT-016): Adding data model.**
+  > **Closed by** [\_**#2**](https://github.com/Elmorralito/save-ma-money/pull/2): **feat(PPT-016): Adding data model.**

--- a/docs/interrogate_badge.svg
+++ b/docs/interrogate_badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="20" role="img" aria-label="interrogate: 97.7%">
-    <title>interrogate: 97.7%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="20" role="img" aria-label="interrogate: 97.8%">
+    <title>interrogate: 97.8%</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -15,8 +15,8 @@
     <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
         <text aria-hidden="true" x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" fill="#fff" textLength="610">interrogate</text>
-        <text aria-hidden="true" x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">97.7%</text>
-        <text x="1160" y="140" transform="scale(.1)" fill="#fff" textLength="370" data-interrogate="result">97.7%</text>
+        <text aria-hidden="true" x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">97.8%</text>
+        <text x="1160" y="140" transform="scale(.1)" fill="#fff" textLength="370" data-interrogate="result">97.8%</text>
     </g>
     <g id="logo-shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -42,6 +42,7 @@ The API manages personal finance data aligned to the **v3 PostgreSQL schema** (`
 | `/transaction-templates/*`               | `transaction_templates` — CRUD + upcoming-dues / mark-paid / clear-paid (PPT-070 / [#163](https://github.com/Elmorralito/save-ma-money/issues/163))                        | Yes |
 | `/movements/*`                           | **Alias** — same rows where `transaction_kind = TRANSFER`                                                                                                                  | Yes |
 | `/reports/*` (except budget-performance) | `ReportService` aggregations over ledger + categories                                                                                                                      | Yes |
+| `/ingestion/*`                           | Read-only connection + run status (PPT-083 / [#177](https://github.com/Elmorralito/save-ma-money/issues/177)); worker/Prefect writes rows                                  | Yes |
 | `/budgets/*`                             | Deferred — v4.1 ([`ARCHITECTURE.md#part-iii--post-mvp-v4-extensions-ppt-031-track-a`](../../docs/design/ARCHITECTURE.md#part-iii--post-mvp-v4-extensions-ppt-031-track-a)) | 501 |
 | `/auth/refresh`, `/auth/logout`          | **Supabase:** implemented (session rotate / sign-out + optional Redis denylist). **Local HS256:** 501                                                                      | —   |
 | `/bff/auth/*`                            | PPT-049 browser BFF: HttpOnly `papita_sid` session cookie; JWTs server-side; CSRF `X-Papita-CSRF`. Coexists with Bearer `/auth/*` (`make auth-smoke`)                      | Yes |
@@ -84,6 +85,7 @@ Further mapping: [`docs/design/ARCHITECTURE.md#part-iv--api--model-mapping-ppt-0
 | Templates/dues | `routers/v1/transaction_templates.py` — CRUD + upcoming-dues / mark-paid / clear-paid (PPT-073) |
 | Movements      | `routers/v1/movements.py` — TRANSFER alias + execute                                            |
 | Reports        | `routers/v1/reports.py` — budget-performance → 501                                              |
+| Ingestion      | `routers/v1/ingestion.py` — connection + run-status reads (PPT-083); no HTTP run trigger        |
 | Deferred 501   | `routers/v1/budgets.py`; split; budget-performance; refresh/logout when `AUTH_PROVIDER=local`   |
 | Schemas / deps | `schemas/*`, `dependencies/auth.py`, `pagination.py`, `services.py`, `tenant.py`                |
 | Tests          | `modules/api/tests/` — unit + B0 live-DB; Auth mock + `make auth-smoke`                         |
@@ -421,6 +423,7 @@ Webhooks are **not implemented** (future: `transaction.created`, etc.).
 | Transactions   | `/transactions/*`          | GET, POST, PUT, DELETE | ✓ (no split)                |
 | Templates/dues | `/transaction-templates/*` | GET, POST, PUT, DELETE | ✓ (PPT-070; + dues actions) |
 | Movements      | `/movements/*`             | GET, POST, PUT, DELETE | ✓ (alias)                   |
+| Ingestion      | `/ingestion/*`             | GET                    | ✓ (PPT-083; status reads)   |
 | Reports        | `/reports/*`               | GET                    | ✓ (no budget-performance)   |
 
 ---
@@ -1399,6 +1402,34 @@ Tenant-scoped CRUD on `transaction_templates` plus upcoming-dues window and mark
 | POST   | `/transaction-templates/{template_id}/clear-paid` | Soft-deletes the paid posting for the period      |
 
 **Tests:** `modules/api/tests/test_transaction_templates.py` (mocked) · `test_transaction_templates_live_db.py` (B0). OpenAPI: committed `modules/web/openapi/openapi.json` — `make check-openapi`.
+
+---
+
+## Ingestion status endpoints (PPT-083)
+
+Read-only owner-scoped status for ingestion **connections** and **runs**. Routers map schemas + `owner` only; persistence lives in `IngestionConnectionService` / `IngestionRunService` (`papita_txnsmodel`). Responses are allowlisted (no OAuth tokens, Gmail credentials, or DLQ `raw_payload`).
+
+| Method | Path                                     | Notes                                                              |
+| ------ | ---------------------------------------- | ------------------------------------------------------------------ |
+| GET    | `/ingestion/connections`                 | Paginated non-secret connection metadata                           |
+| GET    | `/ingestion/connections/{connection_id}` | Single connection; cross-tenant → **404** (not 403)                |
+| GET    | `/ingestion/runs/latest`                 | Most recently started run; optional `connection_id` query          |
+| GET    | `/ingestion/runs`                        | Paginated recent runs (`skip` / `limit`); optional `connection_id` |
+
+**Auth:** JWT / BFF session via `get_current_owner` → **401** when unauthenticated.
+
+**Run status slugs (API JSON):** `started`, `succeeded`, `failed`, `partial` (DB stores uppercase enums).
+
+**Who writes / who triggers (SSOT):**
+
+| Concern                                | Owner                                                                                     | Not this API                                                            |
+| -------------------------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Upsert connection + append/finish runs | Email Prefect worker (`papita_ingestor_email`) after mapping `RunResult` counters         | No `POST /ingestion/.../run` (or similar)                               |
+| Schedule / one-shot                    | Prefect flow `papita-email-ingestion` · deployment `papita-email-ingestion-hourly`        | Do not add an HTTP “run once” trigger here                              |
+| Local ops                              | `make ingestor-flow` (`--once`) · `make ingestor-flow-serve` · Compose profile `ingestor` | See [`modules/ingestors/email/README.md`](../ingestors/email/README.md) |
+| Packaging / OpenAPI web regen gate     | Deferred to PPT-084 / [#178](https://github.com/Elmorralito/save-ma-money/issues/178)     | Runtime OpenAPI already lists these paths                               |
+
+**Tests:** `modules/api/tests/test_ingestion_schemas.py` · `test_ingestion.py` (mocked auth + services). Full web OpenAPI artifact refresh → PPT-084.
 
 ---
 

--- a/modules/api/src/papita_txnsapi/dependencies/services.py
+++ b/modules/api/src/papita_txnsapi/dependencies/services.py
@@ -7,7 +7,8 @@ function is a thin FastAPI dependency over a shared connector.
 Key exports:
     get_connector: Resolve and validate the SQLAlchemy connector class.
     get_users_service, get_accounts_service, get_categories_service,
-    get_transaction_templates_service, get_transactions_service, get_report_service:
+    get_transaction_templates_service, get_transactions_service, get_report_service,
+    get_ingestion_connection_service, get_ingestion_run_service:
     Domain service factories.
     clear_transactions_service_cache / clear_transaction_templates_service_cache:
     Drop module-scoped DI caches.
@@ -24,6 +25,7 @@ from papita_txnsapi.config.settings import Settings, get_settings
 from papita_txnsmodel.database.connector import SQLDatabaseConnector
 from papita_txnsmodel.services.accounts import AccountsService
 from papita_txnsmodel.services.categories import CategoriesService
+from papita_txnsmodel.services.ingestion_status import IngestionConnectionService, IngestionRunService
 from papita_txnsmodel.services.reports import ReportService
 from papita_txnsmodel.services.transactions import TransactionsService, TransactionTemplatesService
 from papita_txnsmodel.services.users import UsersService
@@ -189,3 +191,33 @@ def get_report_service(connector: Annotated[Type[SQLDatabaseConnector], Depends(
         Configured ``ReportService`` instance.
     """
     return _service_factory(ReportService, connector)
+
+
+def get_ingestion_connection_service(
+    connector: Annotated[Type[SQLDatabaseConnector], Depends(get_connector)],
+) -> IngestionConnectionService:
+    """Build ``IngestionConnectionService`` for read-only connection status routes (PPT-083).
+
+    Args:
+        connector: Injected model database connector.
+
+    Returns:
+        Configured ``IngestionConnectionService`` instance.
+    """
+    return _service_factory(IngestionConnectionService, connector)
+
+
+def get_ingestion_run_service(
+    connector: Annotated[Type[SQLDatabaseConnector], Depends(get_connector)],
+) -> IngestionRunService:
+    """Build ``IngestionRunService`` for read-only run-status routes (PPT-083).
+
+    Worker/Prefect remains the writer; API handlers only call list/get helpers.
+
+    Args:
+        connector: Injected model database connector.
+
+    Returns:
+        Configured ``IngestionRunService`` instance.
+    """
+    return _service_factory(IngestionRunService, connector)

--- a/modules/api/src/papita_txnsapi/routers/v1/__init__.py
+++ b/modules/api/src/papita_txnsapi/routers/v1/__init__.py
@@ -17,6 +17,9 @@ Routes exposed (prefix relative to app mount):
         via :class:`~papita_txnsmodel.services.transactions.TransactionTemplatesService`.
     ``/movements`` — TRANSFER alias over the same transactions service.
     ``/reports`` — FR-12 read models via :class:`~papita_txnsmodel.services.reports.ReportService`.
+    ``/ingestion`` — connection + run-status reads (PPT-083) via
+        :class:`~papita_txnsmodel.services.ingestion_status.IngestionConnectionService` /
+        :class:`~papita_txnsmodel.services.ingestion_status.IngestionRunService`.
     ``/budgets`` — placeholder 501 responses (FR-09 deferred to v4.1).
 
 Tenant scoping:
@@ -34,6 +37,7 @@ from papita_txnsapi.routers.v1 import (
     budgets,
     categories,
     health,
+    ingestion,
     meta,
     movements,
     reports,
@@ -52,4 +56,5 @@ api_v1_router.include_router(transactions.router)
 api_v1_router.include_router(transaction_templates.router)
 api_v1_router.include_router(movements.router)
 api_v1_router.include_router(reports.router)
+api_v1_router.include_router(ingestion.router)
 api_v1_router.include_router(budgets.router)

--- a/modules/api/src/papita_txnsapi/routers/v1/ingestion.py
+++ b/modules/api/src/papita_txnsapi/routers/v1/ingestion.py
@@ -1,0 +1,172 @@
+"""Ingestion connection and run-status routes — PPT-083 / #177.
+
+Read-only status APIs under ``/ingestion``. Handlers require JWT auth via
+``get_current_owner`` and delegate to model services. Workers (Prefect email
+flow) own writes; this router never triggers runs or exposes OAuth/DLQ secrets.
+
+Routes:
+    ``GET /ingestion/connections`` — paginated non-secret connection metadata.
+    ``GET /ingestion/connections/{connection_id}`` — single connection.
+    ``GET /ingestion/runs/latest`` — most recently started run.
+    ``GET /ingestion/runs`` — paginated recent runs (optional ``connection_id``).
+
+Tenant scoping:
+    Cross-tenant ids resolve as 404 (not 403). Unauthenticated requests → 401.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from papita_txnsapi.dependencies.auth import get_current_owner
+from papita_txnsapi.dependencies.pagination import PaginationParams, get_pagination
+from papita_txnsapi.dependencies.rate_limit import enforce_tenant_api_rate_limit
+from papita_txnsapi.dependencies.services import get_ingestion_connection_service, get_ingestion_run_service
+from papita_txnsapi.schemas.common import PaginatedResponse
+from papita_txnsapi.schemas.ingestion import IngestionConnectionResponse, IngestionRunResponse
+from papita_txnsmodel.access.ingestion.dto import IngestionRunDTO
+from papita_txnsmodel.access.users.dto import UsersDTO
+from papita_txnsmodel.services.ingestion_status import IngestionConnectionService, IngestionRunService
+
+router = APIRouter(
+    prefix="/ingestion",
+    tags=["Ingestion"],
+    dependencies=[Depends(enforce_tenant_api_rate_limit)],
+)
+
+
+def _connection_not_found() -> HTTPException:
+    """Build a 404 that avoids leaking cross-tenant connection existence."""
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ingestion connection not found")
+
+
+def _run_not_found() -> HTTPException:
+    """Build a 404 that avoids leaking cross-tenant run existence."""
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ingestion run not found")
+
+
+def _run_filter_dto(connection_id: uuid.UUID | None) -> IngestionRunDTO | None:
+    """Build a partial filter DTO for run list/count when ``connection_id`` is set."""
+    if connection_id is None:
+        return None
+    return IngestionRunDTO.model_construct(connection_id=connection_id)
+
+
+@router.get("/connections", response_model=PaginatedResponse[IngestionConnectionResponse])
+def list_ingestion_connections(
+    owner: Annotated[UsersDTO, Depends(get_current_owner)],
+    pagination: Annotated[PaginationParams, Depends(get_pagination)],
+    connection_service: Annotated[IngestionConnectionService, Depends(get_ingestion_connection_service)],
+) -> PaginatedResponse[IngestionConnectionResponse]:
+    """List non-secret ingestion connections for the authenticated owner.
+
+    Args:
+        owner: Authenticated tenant from JWT.
+        pagination: Skip/limit window for the response page.
+        connection_service: Injected connection status service.
+
+    Returns:
+        Paginated allowlisted connection resources.
+    """
+    total = connection_service.count_records(dto=None, owner=owner)
+    rows = connection_service.list_connections(
+        owner=owner,
+        skip=pagination.skip,
+        limit=pagination.limit,
+    )
+    return PaginatedResponse(
+        items=[IngestionConnectionResponse.from_dto(row) for row in rows],
+        total=total,
+        skip=pagination.skip,
+        limit=pagination.limit,
+    )
+
+
+@router.get("/connections/{connection_id}", response_model=IngestionConnectionResponse)
+def get_ingestion_connection(
+    connection_id: uuid.UUID,
+    owner: Annotated[UsersDTO, Depends(get_current_owner)],
+    connection_service: Annotated[IngestionConnectionService, Depends(get_ingestion_connection_service)],
+) -> IngestionConnectionResponse:
+    """Return one connection when owned by the caller; else 404.
+
+    Args:
+        connection_id: Connection primary key.
+        owner: Authenticated tenant from JWT.
+        connection_service: Injected connection status service.
+
+    Returns:
+        Allowlisted connection resource.
+    """
+    connection = connection_service.get_connection(owner=owner, connection_id=connection_id)
+    if connection is None:
+        raise _connection_not_found()
+    return IngestionConnectionResponse.from_dto(connection)
+
+
+@router.get("/runs/latest", response_model=IngestionRunResponse)
+def get_latest_ingestion_run(
+    owner: Annotated[UsersDTO, Depends(get_current_owner)],
+    run_service: Annotated[IngestionRunService, Depends(get_ingestion_run_service)],
+    connection_id: Annotated[
+        uuid.UUID | None,
+        Query(description="Optional connection filter for the latest run"),
+    ] = None,
+) -> IngestionRunResponse:
+    """Return the most recently started run for the owner.
+
+    Args:
+        owner: Authenticated tenant from JWT.
+        run_service: Injected run status service.
+        connection_id: Optional filter to a single connection.
+
+    Returns:
+        Allowlisted run resource.
+
+    Raises:
+        HTTPException: 404 when no runs exist for the scope.
+    """
+    run = run_service.get_latest_run(owner=owner, connection_id=connection_id)
+    if run is None:
+        raise _run_not_found()
+    return IngestionRunResponse.from_dto(run)
+
+
+@router.get("/runs", response_model=PaginatedResponse[IngestionRunResponse])
+def list_ingestion_runs(
+    owner: Annotated[UsersDTO, Depends(get_current_owner)],
+    pagination: Annotated[PaginationParams, Depends(get_pagination)],
+    run_service: Annotated[IngestionRunService, Depends(get_ingestion_run_service)],
+    connection_id: Annotated[
+        uuid.UUID | None,
+        Query(description="Optional filter by connection id"),
+    ] = None,
+) -> PaginatedResponse[IngestionRunResponse]:
+    """List recent ingestion runs for the authenticated owner.
+
+    Args:
+        owner: Authenticated tenant from JWT.
+        pagination: Skip/limit window for the response page.
+        run_service: Injected run status service.
+        connection_id: Optional filter by connection id.
+
+    Returns:
+        Paginated allowlisted run resources, newest first.
+    """
+    filter_dto = _run_filter_dto(connection_id)
+    total = run_service.count_records(dto=filter_dto, owner=owner)
+    rows = run_service.list_runs(
+        owner=owner,
+        connection_id=connection_id,
+        skip=pagination.skip,
+        limit=pagination.limit,
+    )
+    return PaginatedResponse(
+        items=[IngestionRunResponse.from_dto(row) for row in rows],
+        total=total,
+        skip=pagination.skip,
+        limit=pagination.limit,
+    )

--- a/modules/api/src/papita_txnsapi/schemas/converters.py
+++ b/modules/api/src/papita_txnsapi/schemas/converters.py
@@ -11,7 +11,14 @@ from __future__ import annotations
 from enum import Enum
 from typing import TypeVar
 
-from papita_txnsmodel.model.enums import AccountKind, CategoryKind, LedgerSide, TransactionKind, TransactionStatus
+from papita_txnsmodel.model.enums import (
+    AccountKind,
+    CategoryKind,
+    IngestionRunStatus,
+    LedgerSide,
+    TransactionKind,
+    TransactionStatus,
+)
 
 E = TypeVar("E", bound=Enum)
 
@@ -122,3 +129,19 @@ def parse_transaction_status(slug: str) -> TransactionStatus:
         ValueError: When the slug is not a valid transaction status.
     """
     return api_slug_to_enum(TransactionStatus, slug)
+
+
+def parse_ingestion_run_status(slug: str) -> IngestionRunStatus:
+    """Parse an API ingestion run ``status`` slug to ``IngestionRunStatus``.
+
+    Args:
+        slug: Lowercase status from request JSON or query params
+            (e.g. ``succeeded``, ``partial``).
+
+    Returns:
+        Corresponding ``IngestionRunStatus`` member.
+
+    Raises:
+        ValueError: When the slug is not a valid ingestion run status.
+    """
+    return api_slug_to_enum(IngestionRunStatus, slug)

--- a/modules/api/src/papita_txnsapi/schemas/ingestion.py
+++ b/modules/api/src/papita_txnsapi/schemas/ingestion.py
@@ -1,0 +1,180 @@
+"""Ingestion connection and run-status response schemas (PPT-083 / #177).
+
+Allowlisted read models for ``GET /ingestion/connections`` and
+``GET /ingestion/runs*``. Intentionally excludes OAuth secrets, Gmail tokens,
+raw mailbox payloads, and DLQ ``raw_payload`` — those never appear on these
+resources.
+
+Routers own HTTP shape only; persistence stays in ``papita_txnsmodel`` services
+(worker writes; API is read-only).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from papita_txnsapi.schemas.converters import enum_to_api_slug
+from papita_txnsmodel.access.base.dto import TableDTO
+from papita_txnsmodel.access.ingestion.dto import IngestionConnectionDTO, IngestionRunDTO
+from papita_txnsmodel.model.enums import IngestionRunStatus
+
+# Fields that must never appear on public ingestion status responses.
+_FORBIDDEN_RESPONSE_FIELDS = frozenset(
+    {
+        "raw_payload",
+        "client_secret",
+        "client_id",
+        "refresh_token",
+        "access_token",
+        "password",
+        "gmail_token",
+        "oauth_token",
+        "credentials",
+    }
+)
+
+
+def _require_uuid(value: uuid.UUID | None, *, field_name: str) -> uuid.UUID:
+    """Return a persisted UUID or raise when the DTO primary key is missing."""
+    if value is None:
+        raise ValueError(f"{field_name} is required.")
+    return value
+
+
+def _relation_uuid(value: uuid.UUID | Any | None) -> uuid.UUID | None:
+    """Extract a UUID from a relation field that may be a nested DTO."""
+    if value is None:
+        return None
+    if isinstance(value, uuid.UUID):
+        return value
+    if isinstance(value, TableDTO):
+        return value.id
+    return uuid.UUID(str(value))
+
+
+def _status_slug(value: IngestionRunStatus | str | Enum) -> str:
+    """Normalize run status to the API lowercase slug."""
+    if isinstance(value, Enum):
+        return enum_to_api_slug(value)
+    return str(value).strip().lower()
+
+
+class IngestionConnectionResponse(BaseModel):
+    """Non-secret connection metadata for status APIs.
+
+    Allowlist: identity + provider/flow labels + enabled/lookback only.
+    """
+
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
+
+    id: uuid.UUID
+    provider: str
+    flow_name: str
+    deployment_name: str | None = None
+    enabled: bool
+    lookback_hours: int = Field(ge=1)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    @classmethod
+    def from_dto(cls, connection: IngestionConnectionDTO) -> IngestionConnectionResponse:
+        """Build an API response from ``IngestionConnectionDTO``.
+
+        Args:
+            connection: Owner-scoped connection row from the model service.
+
+        Returns:
+            Allowlisted connection resource (no credentials).
+        """
+        return cls(
+            id=_require_uuid(connection.id, field_name="Connection id"),
+            provider=connection.provider,
+            flow_name=connection.flow_name,
+            deployment_name=connection.deployment_name,
+            enabled=bool(connection.enabled),
+            lookback_hours=int(connection.lookback_hours),
+            created_at=connection.created_at,
+            updated_at=connection.updated_at,
+        )
+
+
+class IngestionRunResponse(BaseModel):
+    """Owner-scoped ingestion run history for status APIs.
+
+    Counters and status only — never per-record failure payloads or DLQ bodies.
+    """
+
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
+
+    id: uuid.UUID
+    connection_id: uuid.UUID | None = None
+    status: str
+    started_at: datetime
+    finished_at: datetime | None = None
+    fetched: int = Field(ge=0)
+    created: int = Field(ge=0)
+    updated: int = Field(ge=0)
+    reactivated: int = Field(ge=0)
+    failed: int = Field(ge=0)
+    dead_lettered: int = Field(ge=0)
+    acknowledged: int = Field(ge=0)
+    dry_run_skipped: int = Field(ge=0)
+    error_summary: str | None = None
+    flow_name: str | None = None
+    deployment_name: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    @classmethod
+    def from_dto(cls, run: IngestionRunDTO) -> IngestionRunResponse:
+        """Build an API response from ``IngestionRunDTO``.
+
+        Args:
+            run: Owner-scoped run row from the model service.
+
+        Returns:
+            Allowlisted run resource (no raw payloads).
+        """
+        return cls(
+            id=_require_uuid(run.id, field_name="Run id"),
+            connection_id=_relation_uuid(run.connection_id),
+            status=_status_slug(run.status),
+            started_at=run.started_at,
+            finished_at=run.finished_at,
+            fetched=int(run.fetched),
+            created=int(run.created),
+            updated=int(run.updated),
+            reactivated=int(run.reactivated),
+            failed=int(run.failed),
+            dead_lettered=int(run.dead_lettered),
+            acknowledged=int(run.acknowledged),
+            dry_run_skipped=int(run.dry_run_skipped),
+            error_summary=run.error_summary,
+            flow_name=run.flow_name,
+            deployment_name=run.deployment_name,
+            created_at=run.created_at,
+            updated_at=run.updated_at,
+        )
+
+
+def assert_ingestion_response_allowlist() -> None:
+    """Raise if forbidden secret/raw field names appear on public schemas.
+
+    Intended for unit tests / import-time hygiene — not a runtime router check.
+    """
+    for schema in (IngestionConnectionResponse, IngestionRunResponse):
+        overlap = _FORBIDDEN_RESPONSE_FIELDS.intersection(schema.model_fields)
+        if overlap:
+            raise AssertionError(f"{schema.__name__} exposes forbidden fields: {sorted(overlap)}")
+
+
+__all__ = [
+    "IngestionConnectionResponse",
+    "IngestionRunResponse",
+    "assert_ingestion_response_allowlist",
+]

--- a/modules/api/tests/conftest.py
+++ b/modules/api/tests/conftest.py
@@ -194,6 +194,28 @@ def reports_client() -> tuple[TestClient, UsersDTO, MagicMock]:
 
 
 @pytest.fixture
+def ingestion_client() -> tuple[TestClient, UsersDTO, MagicMock, MagicMock]:
+    """Authenticated client with mocked ingestion connection/run services (PPT-083)."""
+    from papita_txnsapi.dependencies.auth import get_current_owner
+    from papita_txnsapi.dependencies.services import (
+        get_ingestion_connection_service,
+        get_ingestion_run_service,
+    )
+
+    _clear_auth_singletons()
+    app = create_app()
+    owner = make_user()
+    mock_connections = MagicMock()
+    mock_runs = MagicMock()
+    app.dependency_overrides[get_current_owner] = lambda: owner
+    app.dependency_overrides[get_ingestion_connection_service] = lambda: mock_connections
+    app.dependency_overrides[get_ingestion_run_service] = lambda: mock_runs
+    test_client = TestClient(app)
+    yield test_client, owner, mock_connections, mock_runs
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
 def fake_redis():
     """In-memory Redis client for unit tests (decode_responses=True)."""
     import fakeredis

--- a/modules/api/tests/test_ingestion.py
+++ b/modules/api/tests/test_ingestion.py
@@ -1,0 +1,119 @@
+"""Ingestion connection/run-status router tests (PPT-083 / #177 T7–T8, T10)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from papita_txnsmodel.access.ingestion.dto import IngestionConnectionDTO, IngestionRunDTO
+from papita_txnsmodel.access.users.dto import UsersDTO
+from papita_txnsmodel.model.enums import IngestionRunStatus
+
+
+def _connection_dto(owner: UsersDTO, *, connection_id: uuid.UUID | None = None) -> IngestionConnectionDTO:
+    now = datetime.now(timezone.utc)
+    return IngestionConnectionDTO(
+        id=connection_id or uuid.uuid4(),
+        owner_id=owner.id,
+        provider="email",
+        flow_name="papita-email-ingestion",
+        deployment_name="papita-email-ingestion-hourly",
+        enabled=True,
+        lookback_hours=24,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _run_dto(owner: UsersDTO, *, connection_id: uuid.UUID | None = None) -> IngestionRunDTO:
+    started = datetime.now(timezone.utc)
+    return IngestionRunDTO(
+        id=uuid.uuid4(),
+        owner_id=owner.id,
+        connection_id=connection_id,
+        status=IngestionRunStatus.SUCCEEDED,
+        started_at=started,
+        finished_at=started,
+        fetched=2,
+        created=2,
+        flow_name="papita-email-ingestion",
+        deployment_name="papita-email-ingestion-hourly",
+    )
+
+
+def test_ingestion_routes_require_auth(client: TestClient) -> None:
+    assert client.get("/api/v1/ingestion/connections").status_code == 401
+    assert client.get("/api/v1/ingestion/runs").status_code == 401
+    assert client.get("/api/v1/ingestion/runs/latest").status_code == 401
+
+
+def test_list_connections_and_get_by_id(ingestion_client) -> None:
+    test_client, owner, mock_connections, _mock_runs = ingestion_client
+    conn = _connection_dto(owner)
+    mock_connections.count_records.return_value = 1
+    mock_connections.list_connections.return_value = [conn]
+    mock_connections.get_connection.return_value = conn
+
+    listed = test_client.get("/api/v1/ingestion/connections")
+    assert listed.status_code == 200
+    body = listed.json()
+    assert body["total"] == 1
+    assert body["items"][0]["id"] == str(conn.id)
+    assert body["items"][0]["provider"] == "email"
+    assert "raw_payload" not in body["items"][0]
+    assert "refresh_token" not in body["items"][0]
+    mock_connections.list_connections.assert_called_once()
+
+    got = test_client.get(f"/api/v1/ingestion/connections/{conn.id}")
+    assert got.status_code == 200
+    assert got.json()["flow_name"] == "papita-email-ingestion"
+
+
+def test_get_connection_cross_tenant_is_404(ingestion_client) -> None:
+    test_client, _owner, mock_connections, _mock_runs = ingestion_client
+    mock_connections.get_connection.return_value = None
+    response = test_client.get(f"/api/v1/ingestion/connections/{uuid.uuid4()}")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Ingestion connection not found"
+
+
+def test_list_runs_and_latest(ingestion_client) -> None:
+    test_client, owner, _mock_connections, mock_runs = ingestion_client
+    run = _run_dto(owner)
+    mock_runs.count_records.return_value = 1
+    mock_runs.list_runs.return_value = [run]
+    mock_runs.get_latest_run.return_value = run
+
+    listed = test_client.get("/api/v1/ingestion/runs?skip=0&limit=10")
+    assert listed.status_code == 200
+    body = listed.json()
+    assert body["items"][0]["status"] == "succeeded"
+    assert body["items"][0]["fetched"] == 2
+    assert "failures" not in body["items"][0]
+    assert "raw_payload" not in body["items"][0]
+
+    latest = test_client.get("/api/v1/ingestion/runs/latest")
+    assert latest.status_code == 200
+    assert latest.json()["id"] == str(run.id)
+
+
+def test_latest_run_missing_is_404(ingestion_client) -> None:
+    test_client, _owner, _mock_connections, mock_runs = ingestion_client
+    mock_runs.get_latest_run.return_value = None
+    response = test_client.get("/api/v1/ingestion/runs/latest")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Ingestion run not found"
+
+
+def test_openapi_includes_ingestion_paths(client: TestClient) -> None:
+    spec = client.get("/api/openapi.json").json()
+    paths = spec["paths"]
+    assert "/api/v1/ingestion/connections" in paths
+    assert "/api/v1/ingestion/connections/{connection_id}" in paths
+    assert "/api/v1/ingestion/runs" in paths
+    assert "/api/v1/ingestion/runs/latest" in paths
+    # Read-only: no POST trigger route.
+    assert "post" not in paths["/api/v1/ingestion/connections"]
+    assert "post" not in paths.get("/api/v1/ingestion/runs", {})

--- a/modules/api/tests/test_ingestion_schemas.py
+++ b/modules/api/tests/test_ingestion_schemas.py
@@ -1,0 +1,84 @@
+"""Allowlist tests for ingestion status API schemas (PPT-083 / #177 T6)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from papita_txnsapi.schemas.converters import parse_ingestion_run_status
+from papita_txnsapi.schemas.ingestion import (
+    IngestionConnectionResponse,
+    IngestionRunResponse,
+    assert_ingestion_response_allowlist,
+)
+from papita_txnsmodel.access.ingestion.dto import IngestionConnectionDTO, IngestionRunDTO
+from papita_txnsmodel.model.enums import IngestionRunStatus
+
+
+def test_assert_ingestion_response_allowlist() -> None:
+    assert_ingestion_response_allowlist()
+
+
+def test_connection_response_from_dto_allowlisted_only() -> None:
+    owner_id = uuid.uuid4()
+    conn_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    dto = IngestionConnectionDTO(
+        id=conn_id,
+        owner_id=owner_id,
+        provider="email",
+        flow_name="papita-email-ingestion",
+        deployment_name="papita-email-ingestion-hourly",
+        enabled=True,
+        lookback_hours=24,
+        created_at=now,
+        updated_at=now,
+    )
+    response = IngestionConnectionResponse.from_dto(dto)
+    payload = response.model_dump()
+    assert payload["id"] == conn_id
+    assert payload["provider"] == "email"
+    assert payload["flow_name"] == "papita-email-ingestion"
+    assert "owner_id" not in payload
+    assert "raw_payload" not in payload
+    assert "refresh_token" not in payload
+    assert set(IngestionConnectionResponse.model_fields) == {
+        "id",
+        "provider",
+        "flow_name",
+        "deployment_name",
+        "enabled",
+        "lookback_hours",
+        "created_at",
+        "updated_at",
+    }
+
+
+def test_run_response_from_dto_uses_status_slug() -> None:
+    owner_id = uuid.uuid4()
+    run_id = uuid.uuid4()
+    started = datetime(2026, 8, 12, tzinfo=timezone.utc)
+    dto = IngestionRunDTO(
+        id=run_id,
+        owner_id=owner_id,
+        status=IngestionRunStatus.PARTIAL,
+        started_at=started,
+        finished_at=started,
+        fetched=3,
+        created=1,
+        failed=1,
+        dead_lettered=1,
+        error_summary="IngestorValidationError@msg-1: missing FK",
+        flow_name="papita-email-ingestion",
+    )
+    response = IngestionRunResponse.from_dto(dto)
+    assert response.status == "partial"
+    assert response.fetched == 3
+    assert response.error_summary is not None
+    assert "raw_payload" not in response.model_fields
+    assert "failures" not in response.model_fields
+
+
+def test_parse_ingestion_run_status_slug() -> None:
+    assert parse_ingestion_run_status("succeeded") == IngestionRunStatus.SUCCEEDED
+    assert parse_ingestion_run_status("FAILED") == IngestionRunStatus.FAILED

--- a/modules/ingestor-core/src/papita_ingestor_core/flows/base.py
+++ b/modules/ingestor-core/src/papita_ingestor_core/flows/base.py
@@ -16,6 +16,7 @@ def build_base_ingestion_flow(
     retries: int = 0,
     retry_delay_seconds: float = 60,
     default_fetch_filter_factory: Callable[[], FetchFilter | None] | None = None,
+    execute: Callable[[IngestionRunner, FetchFilter | None], RunResult] | None = None,
 ) -> Any:
     """Return a Prefect ``@flow`` that runs ``IngestionRunner``.
 
@@ -32,6 +33,8 @@ def build_base_ingestion_flow(
         retry_delay_seconds: Delay between Prefect flow retries.
         default_fetch_filter_factory: Used when the flow is invoked without an
             explicit ``fetch_filter`` (e.g. lookback window).
+        execute: Optional wrapper around ``runner.run`` (e.g. status persistence).
+            Defaults to ``runner.run(fetch_filter)``.
 
     Returns:
         A Prefect flow callable.
@@ -56,6 +59,8 @@ def build_base_ingestion_flow(
         if effective is None and default_fetch_filter_factory is not None:
             effective = default_fetch_filter_factory()
         runner = runner_factory()
+        if execute is not None:
+            return execute(runner, effective)
         return runner.run(effective)
 
     return _ingestion_flow

--- a/modules/ingestors/email/README.md
+++ b/modules/ingestors/email/README.md
@@ -161,8 +161,13 @@ and module `.gitignore`.
 Runner knobs stay on `PAPITA_INGESTOR_*` — do not remap them to `GMAIL_*`.
 Compose `EmailFlowSettings` + `GmailSettings` at the flow boundary.
 
-**Handoff for PPT-083 / #177:** flow name `papita-email-ingestion`; serve
-deployment name `papita-email-ingestion-hourly`.
+**Status persistence (PPT-083 / #177):** non-dry runs upsert allowlisted connection
+metadata and append/finish run rows via model services (never `GmailSettings`
+secrets). Flow name `papita-email-ingestion`; serve deployment
+`papita-email-ingestion-hourly`. **Trigger SSOT is this Prefect worker**
+(`make ingestor-flow` / serve / Compose `ingestor`) — the API exposes
+**read-only** `GET /api/v1/ingestion/*` status routes only (no HTTP run-once).
+Catalog: [`modules/api/README.md` § Ingestion status](../../api/README.md#ingestion-status-endpoints-ppt-083).
 
 ## Local Gmail OAuth bootstrap
 

--- a/modules/ingestors/email/src/papita_ingestor_email/flows/email_flow.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/flows/email_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -13,6 +14,7 @@ from papita_ingestor_core.types.records import FetchFilter, RunResult
 from papita_ingestor_email.flow_settings import EmailFlowSettings
 from papita_ingestor_email.owner import users_dto_for_owner_id
 from papita_ingestor_email.parsers import ensure_parsers_registered
+from papita_ingestor_email.run_status import execute_with_run_status
 from papita_ingestor_email.runtime import (
     establish_database_from_env,
     load_environment_file,
@@ -105,9 +107,14 @@ def build_email_ingestion_flow(
     without an injected enricher will DLQ-then-ack successfully parsed mail —
     they will not upsert ledger rows. Prefer ``PAPITA_INGESTOR_DRY_RUN=true``
     until a FK enricher lands.
+
+    Non-dry runs persist connection + run status (PPT-083) via model services —
+    never Gmail OAuth secrets.
     """
     wiring = deps or EmailFlowDeps()
     settings = wiring.flow_settings or EmailFlowSettings()
+    deployment_name = wiring.deployment_name or _DEPLOYMENT_NAME
+    should_persist_status = wiring.persist_status if wiring.persist_status is not None else not settings.dry_run
 
     def _runner_factory() -> IngestionRunner:
         return build_email_runner(wiring)
@@ -121,12 +128,25 @@ def build_email_ingestion_flow(
         )
         return default_fetch_filter(settings)
 
+    def _execute(runner: IngestionRunner, fetch_filter: FetchFilter | None) -> RunResult:
+        return execute_with_run_status(
+            runner,
+            fetch_filter,
+            settings=settings,
+            flow_name=name,
+            deployment_name=deployment_name,
+            connection_service=wiring.connection_service,
+            run_service=wiring.run_service,
+            persist_status=should_persist_status,
+        )
+
     return build_base_ingestion_flow(
         name=name,
         runner_factory=_runner_factory,
         retries=settings.flow_retries,
         retry_delay_seconds=settings.flow_retry_delay_seconds,
         default_fetch_filter_factory=_default_filter,
+        execute=_execute,
     )
 
 
@@ -140,9 +160,10 @@ def serve_email_ingestion(
     """Serve the email flow on an interval schedule (Prefect ``flow.serve``).
 
     ``webserver=True`` exposes Prefect runner ``/health`` (default port 8080) for
-    Compose HEALTHCHECK.
+    Compose HEALTHCHECK. ``deployment_name`` is persisted on connection/run rows
+    (overrides ``EmailFlowDeps.deployment_name``).
     """
-    wiring = deps or EmailFlowDeps()
+    wiring = replace(deps or EmailFlowDeps(), deployment_name=deployment_name)
     settings = wiring.flow_settings or EmailFlowSettings()
     minutes = interval_minutes if interval_minutes is not None else settings.schedule_interval_minutes
     flow_fn = build_email_ingestion_flow(deps=wiring)

--- a/modules/ingestors/email/src/papita_ingestor_email/run_status.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/run_status.py
@@ -1,0 +1,172 @@
+"""Persist non-secret connection + run status around one runner invocation (PPT-083)."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from papita_ingestor_core.runner.ingestion_runner import IngestionRunner
+from papita_ingestor_core.types.records import FetchFilter, RunResult
+from papita_ingestor_email.flow_settings import EmailFlowSettings
+from papita_ingestor_email.status_mapping import derive_run_status, run_result_to_record_request
+from papita_txnsmodel.access.users.dto import UsersDTO
+from papita_txnsmodel.model.enums import IngestionRunStatus
+from papita_txnsmodel.services.ingestion_status import (
+    IngestionConnectionService,
+    IngestionRunService,
+    RecordIngestionRunRequest,
+    UpsertIngestionConnectionRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+_PROVIDER = "email"
+
+
+def _resolve_owner(runner: IngestionRunner) -> UsersDTO:
+    """Resolve the runner owner (callable or DTO)."""
+    return runner._resolve_owner()  # pylint: disable=protected-access  # intentional plugin seam
+
+
+def execute_with_run_status(  # pylint: disable=too-many-locals
+    runner: IngestionRunner,
+    fetch_filter: FetchFilter | None,
+    *,
+    settings: EmailFlowSettings,
+    flow_name: str,
+    deployment_name: str | None,
+    connection_service: IngestionConnectionService | Any | None = None,
+    run_service: IngestionRunService | Any | None = None,
+    persist_status: bool = True,
+) -> RunResult:
+    """Upsert connection → start run → ``runner.run`` → finish run (or FAILED on abort).
+
+    Skips all status writes when ``persist_status`` is false (e.g. dry-run). Status
+    persistence errors are logged and do not replace runner exceptions.
+    """
+    if not persist_status:
+        return runner.run(fetch_filter)
+
+    conn_svc = connection_service or IngestionConnectionService()
+    run_svc = run_service or IngestionRunService()
+    owner = _resolve_owner(runner)
+    started_at = datetime.now(timezone.utc)
+    connection_id: uuid.UUID | None = None
+    run_id: uuid.UUID | None = None
+
+    try:
+        connection = conn_svc.upsert_connection(
+            owner=owner,
+            request=UpsertIngestionConnectionRequest(
+                provider=_PROVIDER,
+                flow_name=flow_name,
+                deployment_name=deployment_name,
+                enabled=True,
+                lookback_hours=settings.lookback_hours,
+            ),
+        )
+        connection_id = connection.id
+        started = run_svc.start_run(
+            owner=owner,
+            connection_id=connection_id,
+            started_at=started_at,
+            flow_name=flow_name,
+            deployment_name=deployment_name,
+        )
+        run_id = started.id
+    except Exception:  # pylint: disable=broad-except
+        logger.exception(
+            "Failed to start ingestion status persistence owner_id=%s flow_name=%s",
+            owner.id,
+            flow_name,
+        )
+
+    try:
+        result = runner.run(fetch_filter)
+    except Exception as exc:
+        _safe_finish_failed(
+            run_svc=run_svc,
+            owner=owner,
+            run_id=run_id,
+            connection_id=connection_id,
+            started_at=started_at,
+            flow_name=flow_name,
+            deployment_name=deployment_name,
+            error_summary=str(exc),
+        )
+        raise
+
+    _safe_finish_result(
+        run_svc=run_svc,
+        owner=owner,
+        run_id=run_id,
+        connection_id=connection_id,
+        started_at=started_at,
+        flow_name=flow_name,
+        deployment_name=deployment_name,
+        result=result,
+    )
+    return result
+
+
+def _safe_finish_result(
+    *,
+    run_svc: IngestionRunService | Any,
+    owner: UsersDTO,
+    run_id: uuid.UUID | None,
+    connection_id: uuid.UUID | None,
+    started_at: datetime,
+    flow_name: str,
+    deployment_name: str | None,
+    result: RunResult,
+) -> None:
+    if run_id is None:
+        return
+    finished_at = datetime.now(timezone.utc)
+    status = derive_run_status(result)
+    request = run_result_to_record_request(
+        result,
+        status=status,
+        started_at=started_at,
+        finished_at=finished_at,
+        connection_id=connection_id,
+        flow_name=flow_name,
+        deployment_name=deployment_name,
+    )
+    try:
+        run_svc.finish_run(owner=owner, run_id=run_id, request=request)
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Failed to finish ingestion run status run_id=%s", run_id)
+
+
+def _safe_finish_failed(
+    *,
+    run_svc: IngestionRunService | Any,
+    owner: UsersDTO,
+    run_id: uuid.UUID | None,
+    connection_id: uuid.UUID | None,
+    started_at: datetime,
+    flow_name: str,
+    deployment_name: str | None,
+    error_summary: str,
+) -> None:
+    if run_id is None:
+        return
+    request = RecordIngestionRunRequest(
+        connection_id=connection_id,
+        status=IngestionRunStatus.FAILED,
+        started_at=started_at,
+        finished_at=datetime.now(timezone.utc),
+        error_summary=error_summary[:1024] if error_summary else None,
+        flow_name=flow_name,
+        deployment_name=deployment_name,
+    )
+    try:
+        run_svc.finish_run(owner=owner, run_id=run_id, request=request)
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Failed to mark ingestion run FAILED run_id=%s", run_id)
+
+
+__all__ = ["execute_with_run_status"]

--- a/modules/ingestors/email/src/papita_ingestor_email/status_mapping.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/status_mapping.py
@@ -1,0 +1,86 @@
+"""Map ingestor-core ``RunResult`` → model run-status DTOs (PPT-083 / #177).
+
+Lives in the email plugin so ``papita_txnsmodel`` never imports ``RunResult``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from papita_ingestor_core.types.records import RunResult
+from papita_txnsmodel.model.enums import IngestionRunStatus
+from papita_txnsmodel.services.ingestion_status import RecordIngestionRunRequest
+
+_ERROR_SUMMARY_MAX = 1024
+_MAX_FAILURE_LINES = 5
+
+
+def derive_run_status(result: RunResult) -> IngestionRunStatus:
+    """Derive terminal status from aggregate counters.
+
+    - ``SUCCEEDED`` when ``failed == 0``
+    - ``PARTIAL`` when some ledger success or handled DLQ exists alongside failures
+    - ``FAILED`` when failures dominate with no successful outcomes
+    """
+    if result.failed <= 0:
+        return IngestionRunStatus.SUCCEEDED
+    successes = result.created + result.updated + result.reactivated
+    if successes > 0 or result.dead_lettered > 0:
+        return IngestionRunStatus.PARTIAL
+    return IngestionRunStatus.FAILED
+
+
+def summarize_failures(result: RunResult, *, max_lines: int = _MAX_FAILURE_LINES) -> str | None:
+    """Build a short error summary from failure messages (never raw payloads)."""
+    if not result.failures:
+        return None
+    lines: list[str] = []
+    for failure in result.failures[:max_lines]:
+        ref = failure.source_ref or "?"
+        lines.append(f"{failure.error_type}@{ref}: {failure.message}")
+    summary = "; ".join(lines)
+    if len(result.failures) > max_lines:
+        summary = f"{summary}; …(+{len(result.failures) - max_lines} more)"
+    if len(summary) > _ERROR_SUMMARY_MAX:
+        return summary[: _ERROR_SUMMARY_MAX - 1] + "…"
+    return summary
+
+
+def run_result_to_record_request(
+    result: RunResult,
+    *,
+    status: IngestionRunStatus,
+    started_at: datetime,
+    finished_at: datetime | None,
+    connection_id: uuid.UUID | None,
+    flow_name: str | None,
+    deployment_name: str | None,
+    error_summary: str | None = None,
+) -> RecordIngestionRunRequest:
+    """Copy counter fields from ``RunResult`` into a model-local write request."""
+    summary = error_summary if error_summary is not None else summarize_failures(result)
+    return RecordIngestionRunRequest(
+        connection_id=connection_id,
+        status=status,
+        started_at=started_at,
+        finished_at=finished_at,
+        fetched=result.fetched,
+        created=result.created,
+        updated=result.updated,
+        reactivated=result.reactivated,
+        failed=result.failed,
+        dead_lettered=result.dead_lettered,
+        acknowledged=result.acknowledged,
+        dry_run_skipped=result.dry_run_skipped,
+        error_summary=summary,
+        flow_name=flow_name,
+        deployment_name=deployment_name,
+    )
+
+
+__all__ = [
+    "derive_run_status",
+    "run_result_to_record_request",
+    "summarize_failures",
+]

--- a/modules/ingestors/email/src/papita_ingestor_email/wiring.py
+++ b/modules/ingestors/email/src/papita_ingestor_email/wiring.py
@@ -12,7 +12,7 @@ from papita_ingestor_email.settings import GmailSettings
 
 
 @dataclass(frozen=True, slots=True)
-class EmailFlowDeps:
+class EmailFlowDeps:  # pylint: disable=too-many-instance-attributes
     """Single wiring object for ``build_email_runner`` / ``build_email_ingestion_flow``.
 
     Avoids duplicating the same keyword surface on both factories.
@@ -25,6 +25,10 @@ class EmailFlowDeps:
     owner: OwnerProvider | None = None
     establish_db: bool | None = None
     verify_owner: bool | None = None
+    connection_service: Any | None = None
+    run_service: Any | None = None
+    persist_status: bool | None = None
+    deployment_name: str | None = None
 
 
 __all__ = ["EmailFlowDeps"]

--- a/modules/ingestors/email/tests/test_email_flow.py
+++ b/modules/ingestors/email/tests/test_email_flow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -217,6 +217,7 @@ def test_email_flow_applies_lookback_and_persists_injected_fks() -> None:
                 owner=users_dto_for_owner_id(owner_id),
                 establish_db=False,
                 verify_owner=False,
+                persist_status=False,
             )
         )
         result = flow_fn()
@@ -228,6 +229,147 @@ def test_email_flow_applies_lookback_and_persists_injected_fks() -> None:
     assert source.last_filter is not None
     assert source.last_filter.limit == 7  # merged from settings by runner
     assert source.last_filter.since is not None
+
+
+class _FakeConnectionService:
+    def __init__(self) -> None:
+        self.upserts: list[dict] = []
+
+    def upsert_connection(self, *, owner: UsersDTO, request: object, **kwargs: object) -> object:
+        self.upserts.append({"owner": owner, "request": request, "kwargs": kwargs})
+        return SimpleNamespace(id=uuid.uuid4())
+
+
+class _FakeRunService:
+    def __init__(self) -> None:
+        self.starts: list[dict] = []
+        self.finishes: list[dict] = []
+        self._run_id = uuid.uuid4()
+
+    def start_run(self, *, owner: UsersDTO, **kwargs: object) -> object:
+        self.starts.append({"owner": owner, **kwargs})
+        return SimpleNamespace(id=self._run_id)
+
+    def finish_run(self, *, owner: UsersDTO, run_id: uuid.UUID, request: object, **kwargs: object) -> object:
+        self.finishes.append({"owner": owner, "run_id": run_id, "request": request, "kwargs": kwargs})
+        return SimpleNamespace(id=run_id, status=getattr(request, "status", None))
+
+
+def test_email_flow_persists_connection_and_run_status() -> None:
+    """PPT-083: upsert connection + start/finish run around runner (allowlisted fields only)."""
+    bridge = _FakeBridge()
+    source = _FakeSource([_raw("ok-status-1")])
+    owner_id = uuid.uuid4()
+    settings = EmailFlowSettings(owner_id=owner_id, flow_retries=0, lookback_hours=6)
+    conn_svc = _FakeConnectionService()
+    run_svc = _FakeRunService()
+
+    import papita_ingestor_email.flows.email_flow as email_flow_mod
+
+    real_build = email_flow_mod.build_email_runner
+
+    def _wrap_build_runner(deps=None):
+        runner = real_build(deps)
+        runner._parsers = [_CompleteFkParser()]  # noqa: SLF001
+        return runner
+
+    with patch.object(email_flow_mod, "build_email_runner", side_effect=_wrap_build_runner):
+        flow_fn = email_flow_mod.build_email_ingestion_flow(
+            deps=EmailFlowDeps(
+                flow_settings=settings,
+                source=source,
+                bridge=bridge,
+                owner=users_dto_for_owner_id(owner_id),
+                establish_db=False,
+                verify_owner=False,
+                connection_service=conn_svc,
+                run_service=run_svc,
+                persist_status=True,
+            )
+        )
+        result = flow_fn()
+
+    assert result.created == 1
+    assert len(conn_svc.upserts) == 1
+    upsert_req = conn_svc.upserts[0]["request"]
+    assert upsert_req.provider == "email"
+    assert upsert_req.flow_name == "papita-email-ingestion"
+    assert upsert_req.deployment_name == "papita-email-ingestion-hourly"
+    assert upsert_req.lookback_hours == 6
+    assert not hasattr(upsert_req, "client_secret")
+    assert not hasattr(upsert_req, "refresh_token")
+    assert len(run_svc.starts) == 1
+    assert len(run_svc.finishes) == 1
+    finish_req = run_svc.finishes[0]["request"]
+    assert finish_req.fetched == 1
+    assert finish_req.created == 1
+    assert finish_req.status.value == "SUCCEEDED"
+
+
+def test_serve_email_ingestion_propagates_deployment_name_to_deps() -> None:
+    """Serve arg must win for status persistence (PPT-083 audit fix)."""
+    import papita_ingestor_email.flows.email_flow as email_flow_mod
+
+    captured: dict[str, object] = {}
+
+    def _fake_build_flow(*, deps=None, name=None):
+        captured["deps"] = deps
+        flow = MagicMock()
+        flow.serve = MagicMock()
+        captured["flow"] = flow
+        return flow
+
+    settings = EmailFlowSettings(owner_id=uuid.uuid4(), schedule_interval_minutes=15)
+    with patch.object(email_flow_mod, "build_email_ingestion_flow", side_effect=_fake_build_flow):
+        email_flow_mod.serve_email_ingestion(
+            deps=EmailFlowDeps(flow_settings=settings, deployment_name="stale-name"),
+            deployment_name="custom-hourly",
+            webserver=False,
+        )
+
+    deps = captured["deps"]
+    assert deps is not None
+    assert deps.deployment_name == "custom-hourly"
+    captured["flow"].serve.assert_called_once()
+    assert captured["flow"].serve.call_args.kwargs["name"] == "custom-hourly"
+
+
+def test_email_flow_skips_status_persist_when_dry_run() -> None:
+    bridge = _FakeBridge()
+    source = _FakeSource([_raw("dry-1")])
+    owner_id = uuid.uuid4()
+    settings = EmailFlowSettings(owner_id=owner_id, flow_retries=0, dry_run=True)
+    conn_svc = _FakeConnectionService()
+    run_svc = _FakeRunService()
+
+    import papita_ingestor_email.flows.email_flow as email_flow_mod
+
+    real_build = email_flow_mod.build_email_runner
+
+    def _wrap_build_runner(deps=None):
+        runner = real_build(deps)
+        runner._parsers = [_CompleteFkParser()]  # noqa: SLF001
+        return runner
+
+    with patch.object(email_flow_mod, "build_email_runner", side_effect=_wrap_build_runner):
+        flow_fn = email_flow_mod.build_email_ingestion_flow(
+            deps=EmailFlowDeps(
+                flow_settings=settings,
+                source=source,
+                bridge=bridge,
+                owner=users_dto_for_owner_id(owner_id),
+                establish_db=False,
+                verify_owner=False,
+                connection_service=conn_svc,
+                run_service=run_svc,
+            )
+        )
+        result = flow_fn()
+
+    assert result.dry_run_skipped == 1
+    assert conn_svc.upserts == []
+    assert run_svc.starts == []
+    assert run_svc.finishes == []
 
 
 def test_real_bridge_path_establishes_database_and_verifies_owner() -> None:

--- a/modules/ingestors/email/tests/test_status_mapping.py
+++ b/modules/ingestors/email/tests/test_status_mapping.py
@@ -29,9 +29,7 @@ def test_derive_run_status_failed() -> None:
 
 
 def test_summarize_failures_omits_raw_and_truncates_count() -> None:
-    failures = [
-        RecordFailure(source_ref=f"r-{i}", error_type="X", message=f"m{i}") for i in range(7)
-    ]
+    failures = [RecordFailure(source_ref=f"r-{i}", error_type="X", message=f"m{i}") for i in range(7)]
     summary = summarize_failures(RunResult(failures=failures), max_lines=3)
     assert summary is not None
     assert "r-0" in summary

--- a/modules/ingestors/email/tests/test_status_mapping.py
+++ b/modules/ingestors/email/tests/test_status_mapping.py
@@ -1,0 +1,62 @@
+"""Unit tests for RunResult → model status mapping (PPT-083 / #177)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from papita_ingestor_core.types.records import RecordFailure, RunResult
+from papita_ingestor_email.status_mapping import (
+    derive_run_status,
+    run_result_to_record_request,
+    summarize_failures,
+)
+from papita_txnsmodel.model.enums import IngestionRunStatus
+
+
+def test_derive_run_status_succeeded() -> None:
+    assert derive_run_status(RunResult(fetched=2, created=2)) == IngestionRunStatus.SUCCEEDED
+
+
+def test_derive_run_status_partial_with_dead_letters() -> None:
+    result = RunResult(fetched=2, failed=2, dead_lettered=2)
+    assert derive_run_status(result) == IngestionRunStatus.PARTIAL
+
+
+def test_derive_run_status_failed() -> None:
+    result = RunResult(fetched=1, failed=1)
+    assert derive_run_status(result) == IngestionRunStatus.FAILED
+
+
+def test_summarize_failures_omits_raw_and_truncates_count() -> None:
+    failures = [
+        RecordFailure(source_ref=f"r-{i}", error_type="X", message=f"m{i}") for i in range(7)
+    ]
+    summary = summarize_failures(RunResult(failures=failures), max_lines=3)
+    assert summary is not None
+    assert "r-0" in summary
+    assert "+4 more" in summary
+    assert "opaque" not in summary
+
+
+def test_run_result_to_record_request_copies_counters() -> None:
+    started = datetime(2026, 8, 12, tzinfo=timezone.utc)
+    finished = datetime(2026, 8, 12, 1, tzinfo=timezone.utc)
+    conn_id = uuid.uuid4()
+    result = RunResult(fetched=3, created=1, updated=1, reactivated=0, failed=1, acknowledged=2)
+    request = run_result_to_record_request(
+        result,
+        status=IngestionRunStatus.PARTIAL,
+        started_at=started,
+        finished_at=finished,
+        connection_id=conn_id,
+        flow_name="papita-email-ingestion",
+        deployment_name="papita-email-ingestion-hourly",
+    )
+    assert request.fetched == 3
+    assert request.created == 1
+    assert request.updated == 1
+    assert request.failed == 1
+    assert request.connection_id == conn_id
+    assert request.flow_name == "papita-email-ingestion"
+    assert request.status == IngestionRunStatus.PARTIAL

--- a/modules/ingestors/email/tests/test_status_mapping.py
+++ b/modules/ingestors/email/tests/test_status_mapping.py
@@ -6,11 +6,7 @@ import uuid
 from datetime import datetime, timezone
 
 from papita_ingestor_core.types.records import RecordFailure, RunResult
-from papita_ingestor_email.status_mapping import (
-    derive_run_status,
-    run_result_to_record_request,
-    summarize_failures,
-)
+from papita_ingestor_email.status_mapping import derive_run_status, run_result_to_record_request, summarize_failures
 from papita_txnsmodel.model.enums import IngestionRunStatus
 
 

--- a/modules/model/alembic/versions/2026_08_12_1200-l9a0b1c2d3e4_ppt_083_ingestion_connection_runs.py
+++ b/modules/model/alembic/versions/2026_08_12_1200-l9a0b1c2d3e4_ppt_083_ingestion_connection_runs.py
@@ -1,0 +1,191 @@
+# pylint: disable=C0103
+"""Add ingestion connection and run-status tables (PPT-083 / #177).
+
+Revision ID: l9a0b1c2d3e4
+Revises: k8f9a0b1c2d3
+Create Date: 2026-08-12 12:00:00.000000+00:00
+
+Non-secret connection metadata + append-only run history for status APIs.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from papita_txnsmodel.model.contstants import (
+    INGESTION_CONNECTIONS__TABLENAME,
+    INGESTION_RUNS__TABLENAME,
+    SCHEMA_NAME,
+    USERS__TABLENAME,
+)
+
+revision: str = "l9a0b1c2d3e4"
+down_revision: Union[str, Sequence[str], None] = "k8f9a0b1c2d3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INGESTION_RUN_STATUS_ENUM = "ingestion_run_status"
+_FK_CONN_OWNER = "fk_ingestion_connections_owner_id"
+_FK_RUN_OWNER = "fk_ingestion_runs_owner_id"
+_FK_RUN_CONN = "fk_ingestion_runs_connection_id"
+_UQ_CONN = "uq_ingestion_connections_owner_provider_flow"
+_IX_CONN_OWNER = "ix_ingestion_connections_owner_id"
+_IX_RUN_OWNER = "ix_ingestion_runs_owner_id"
+_IX_RUN_CONN = "ix_ingestion_runs_connection_id"
+_IX_RUN_OWNER_STARTED = "ix_ingestion_runs_owner_started_at"
+
+
+def _ingestion_run_status_type(*, create_type: bool = False) -> postgresql.ENUM:
+    """Return the shared Postgres enum type for ingestion_run_status columns."""
+    return postgresql.ENUM(
+        "STARTED",
+        "SUCCEEDED",
+        "FAILED",
+        "PARTIAL",
+        name=_INGESTION_RUN_STATUS_ENUM,
+        schema=SCHEMA_NAME,
+        create_type=create_type,
+    )
+
+
+def upgrade() -> None:
+    """Create ingestion_run_status enum, connections table, and runs table."""
+    op.execute(sa.text(f"""
+            DO $$ BEGIN
+                CREATE TYPE {SCHEMA_NAME}.{_INGESTION_RUN_STATUS_ENUM}
+                    AS ENUM ('STARTED', 'SUCCEEDED', 'FAILED', 'PARTIAL');
+            EXCEPTION
+                WHEN duplicate_object THEN NULL;
+            END $$;
+            """))
+    run_status = _ingestion_run_status_type(create_type=False)
+
+    op.create_table(
+        INGESTION_CONNECTIONS__TABLENAME,
+        sa.Column("active", sa.Boolean(), nullable=False),
+        sa.Column("deleted_at", sa.TIMESTAMP(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(), nullable=False),
+        sa.Column("updated_at", sa.TIMESTAMP(), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("owner_id", sa.Uuid(), nullable=False),
+        sa.Column("provider", sa.String(length=64), nullable=False),
+        sa.Column("flow_name", sa.String(length=128), nullable=False),
+        sa.Column("deployment_name", sa.String(length=128), nullable=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False),
+        sa.Column("lookback_hours", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            [f"{SCHEMA_NAME}.{USERS__TABLENAME}.id"],
+            name=_FK_CONN_OWNER,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        _IX_CONN_OWNER,
+        INGESTION_CONNECTIONS__TABLENAME,
+        ["owner_id"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        _UQ_CONN,
+        INGESTION_CONNECTIONS__TABLENAME,
+        ["owner_id", "provider", "flow_name"],
+        unique=True,
+        schema=SCHEMA_NAME,
+    )
+
+    op.create_table(
+        INGESTION_RUNS__TABLENAME,
+        sa.Column("active", sa.Boolean(), nullable=False),
+        sa.Column("deleted_at", sa.TIMESTAMP(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(), nullable=False),
+        sa.Column("updated_at", sa.TIMESTAMP(), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("owner_id", sa.Uuid(), nullable=False),
+        sa.Column("connection_id", sa.Uuid(), nullable=True),
+        sa.Column("status", run_status, nullable=False),
+        sa.Column("started_at", sa.TIMESTAMP(), nullable=False),
+        sa.Column("finished_at", sa.TIMESTAMP(), nullable=True),
+        sa.Column("fetched", sa.Integer(), nullable=False),
+        sa.Column("created", sa.Integer(), nullable=False),
+        sa.Column("updated", sa.Integer(), nullable=False),
+        sa.Column("reactivated", sa.Integer(), nullable=False),
+        sa.Column("failed", sa.Integer(), nullable=False),
+        sa.Column("dead_lettered", sa.Integer(), nullable=False),
+        sa.Column("acknowledged", sa.Integer(), nullable=False),
+        sa.Column("dry_run_skipped", sa.Integer(), nullable=False),
+        sa.Column("error_summary", sa.Text(), nullable=True),
+        sa.Column("flow_name", sa.String(length=128), nullable=True),
+        sa.Column("deployment_name", sa.String(length=128), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            [f"{SCHEMA_NAME}.{USERS__TABLENAME}.id"],
+            name=_FK_RUN_OWNER,
+        ),
+        sa.ForeignKeyConstraint(
+            ["connection_id"],
+            [f"{SCHEMA_NAME}.{INGESTION_CONNECTIONS__TABLENAME}.id"],
+            name=_FK_RUN_CONN,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        _IX_RUN_OWNER,
+        INGESTION_RUNS__TABLENAME,
+        ["owner_id"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        _IX_RUN_CONN,
+        INGESTION_RUNS__TABLENAME,
+        ["connection_id"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        _IX_RUN_OWNER_STARTED,
+        INGESTION_RUNS__TABLENAME,
+        ["owner_id", "started_at"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+
+
+def downgrade() -> None:
+    """Drop run and connection tables, then the ingestion_run_status enum."""
+    op.drop_index(
+        _IX_RUN_OWNER_STARTED,
+        table_name=INGESTION_RUNS__TABLENAME,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        _IX_RUN_CONN,
+        table_name=INGESTION_RUNS__TABLENAME,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        _IX_RUN_OWNER,
+        table_name=INGESTION_RUNS__TABLENAME,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_table(INGESTION_RUNS__TABLENAME, schema=SCHEMA_NAME)
+
+    op.drop_index(
+        _UQ_CONN,
+        table_name=INGESTION_CONNECTIONS__TABLENAME,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        _IX_CONN_OWNER,
+        table_name=INGESTION_CONNECTIONS__TABLENAME,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_table(INGESTION_CONNECTIONS__TABLENAME, schema=SCHEMA_NAME)
+
+    op.execute(sa.text(f"DROP TYPE IF EXISTS {SCHEMA_NAME}.{_INGESTION_RUN_STATUS_ENUM}"))

--- a/modules/model/src/papita_txnsmodel/access/ingestion/__init__.py
+++ b/modules/model/src/papita_txnsmodel/access/ingestion/__init__.py
@@ -1,14 +1,25 @@
-"""Access layer for ingestion provenance and dead-letter rows (PPT-078)."""
+"""Access layer for ingestion provenance, DLQ, connections, and runs."""
 
-from papita_txnsmodel.access.ingestion.dto import IngestionDeadLetterDTO, TransactionIngestionProvenanceDTO
+from papita_txnsmodel.access.ingestion.dto import (
+    IngestionConnectionDTO,
+    IngestionDeadLetterDTO,
+    IngestionRunDTO,
+    TransactionIngestionProvenanceDTO,
+)
 from papita_txnsmodel.access.ingestion.repository import (
+    IngestionConnectionRepository,
     IngestionDeadLetterRepository,
+    IngestionRunRepository,
     TransactionIngestionProvenanceRepository,
 )
 
 __all__ = [
+    "IngestionConnectionDTO",
+    "IngestionConnectionRepository",
     "IngestionDeadLetterDTO",
     "IngestionDeadLetterRepository",
+    "IngestionRunDTO",
+    "IngestionRunRepository",
     "TransactionIngestionProvenanceDTO",
     "TransactionIngestionProvenanceRepository",
 ]

--- a/modules/model/src/papita_txnsmodel/access/ingestion/dto.py
+++ b/modules/model/src/papita_txnsmodel/access/ingestion/dto.py
@@ -1,4 +1,4 @@
-"""DTOs for ingestion provenance sidecar and dead letters (PPT-078 / #172)."""
+"""DTOs for ingestion provenance, DLQ, connections, and runs."""
 
 from __future__ import annotations
 
@@ -8,8 +8,13 @@ import uuid
 from pydantic import Field
 
 from papita_txnsmodel.access.users.dto import OwnedTableDTO
-from papita_txnsmodel.model.enums import IngestionSource
-from papita_txnsmodel.model.ingestion import IngestionDeadLetter, TransactionIngestionProvenance
+from papita_txnsmodel.model.enums import IngestionRunStatus, IngestionSource
+from papita_txnsmodel.model.ingestion import (
+    IngestionConnection,
+    IngestionDeadLetter,
+    IngestionRun,
+    TransactionIngestionProvenance,
+)
 
 
 class TransactionIngestionProvenanceDTO(OwnedTableDTO):
@@ -32,3 +37,37 @@ class IngestionDeadLetterDTO(OwnedTableDTO):
     raw_payload: str = ""
     error_message: str = ""
     source_ref: str | None = Field(default=None, max_length=255)
+
+
+class IngestionConnectionDTO(OwnedTableDTO):
+    """Non-secret connection metadata for status APIs (PPT-083 / #177)."""
+
+    __dao_type__ = IngestionConnection
+
+    provider: str = Field(default="email", min_length=1, max_length=64)
+    flow_name: str = Field(min_length=1, max_length=128)
+    deployment_name: str | None = Field(default=None, max_length=128)
+    enabled: bool = True
+    lookback_hours: int = Field(default=24, ge=1)
+
+
+class IngestionRunDTO(OwnedTableDTO):
+    """Owner-scoped ingestion run row for status APIs (PPT-083 / #177)."""
+
+    __dao_type__ = IngestionRun
+
+    connection_id: uuid.UUID | None = None
+    status: IngestionRunStatus
+    started_at: datetime.datetime
+    finished_at: datetime.datetime | None = None
+    fetched: int = Field(default=0, ge=0)
+    created: int = Field(default=0, ge=0)
+    updated: int = Field(default=0, ge=0)
+    reactivated: int = Field(default=0, ge=0)
+    failed: int = Field(default=0, ge=0)
+    dead_lettered: int = Field(default=0, ge=0)
+    acknowledged: int = Field(default=0, ge=0)
+    dry_run_skipped: int = Field(default=0, ge=0)
+    error_summary: str | None = None
+    flow_name: str | None = Field(default=None, max_length=128)
+    deployment_name: str | None = Field(default=None, max_length=128)

--- a/modules/model/src/papita_txnsmodel/access/ingestion/repository.py
+++ b/modules/model/src/papita_txnsmodel/access/ingestion/repository.py
@@ -1,13 +1,19 @@
-"""Repositories for ingestion provenance and dead letters (PPT-078 / #172)."""
+"""Repositories for ingestion provenance, DLQ, connections, and runs."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from papita_txnsmodel.access.base.repository import OwnedTableRepository
-from papita_txnsmodel.access.ingestion.dto import IngestionDeadLetterDTO, TransactionIngestionProvenanceDTO
+from papita_txnsmodel.access.ingestion.dto import (
+    IngestionConnectionDTO,
+    IngestionDeadLetterDTO,
+    IngestionRunDTO,
+    TransactionIngestionProvenanceDTO,
+)
 from papita_txnsmodel.model.enums import IngestionSource
-from papita_txnsmodel.model.ingestion import TransactionIngestionProvenance
+from papita_txnsmodel.model.ingestion import IngestionConnection, IngestionRun, TransactionIngestionProvenance
 from papita_txnsmodel.utils.classutils import MetaSingleton
 
 if TYPE_CHECKING:
@@ -49,3 +55,62 @@ class IngestionDeadLetterRepository(OwnedTableRepository, metaclass=MetaSingleto
     """Owner-scoped access to ``ingestion_dead_letters``."""
 
     __expected_dto__ = IngestionDeadLetterDTO
+
+
+class IngestionConnectionRepository(OwnedTableRepository, metaclass=MetaSingleton):
+    """Owner-scoped access to ``ingestion_connections`` (PPT-083 / #177)."""
+
+    __expected_dto__ = IngestionConnectionDTO
+
+    def get_by_natural_key(
+        self,
+        *,
+        owner: UsersDTO,
+        provider: str,
+        flow_name: str,
+        include_deleted: bool = False,
+        **kwargs,
+    ) -> IngestionConnectionDTO | None:
+        """Return the connection for ``(owner, provider, flow_name)`` if present."""
+        if not provider or not flow_name:
+            return None
+        dao = IngestionConnection
+        frame = self.get_records(
+            dao.owner_id == owner.id,
+            dao.provider == provider,
+            dao.flow_name == flow_name,
+            owner=owner,
+            dto_type=IngestionConnectionDTO,
+            include_deleted=include_deleted,
+            limit=1,
+            **kwargs,
+        )
+        return self._dataframe_row_to_dto(frame, IngestionConnectionDTO, **kwargs)
+
+
+class IngestionRunRepository(OwnedTableRepository, metaclass=MetaSingleton):
+    """Owner-scoped access to ``ingestion_runs`` (PPT-083 / #177)."""
+
+    __expected_dto__ = IngestionRunDTO
+
+    def get_latest(
+        self,
+        *,
+        owner: UsersDTO,
+        connection_id: UUID | None = None,
+        **kwargs,
+    ) -> IngestionRunDTO | None:
+        """Return the most recently started run for the owner (optionally per connection)."""
+        dao = IngestionRun
+        filters = [dao.owner_id == owner.id]
+        if connection_id is not None:
+            filters.append(dao.connection_id == connection_id)
+        frame = self.get_records(
+            *filters,
+            owner=owner,
+            dto_type=IngestionRunDTO,
+            order_by=[dao.started_at.desc()],
+            limit=1,
+            **kwargs,
+        )
+        return self._dataframe_row_to_dto(frame, IngestionRunDTO, **kwargs)

--- a/modules/model/src/papita_txnsmodel/model/contstants.py
+++ b/modules/model/src/papita_txnsmodel/model/contstants.py
@@ -15,6 +15,8 @@ TRANSACTION_TEMPLATES__TABLENAME = "transaction_templates"
 TRANSACTIONS__TABLENAME = "transactions"
 TRANSACTION_INGESTION_PROVENANCE__TABLENAME = "transaction_ingestion_provenance"
 INGESTION_DEAD_LETTERS__TABLENAME = "ingestion_dead_letters"
+INGESTION_CONNECTIONS__TABLENAME = "ingestion_connections"
+INGESTION_RUNS__TABLENAME = "ingestion_runs"
 ACCOUNT_FINANCING__TABLENAME = "account_financing"
 
 BANKING_ACCOUNT_DETAILS__TABLENAME = "banking_account_details"

--- a/modules/model/src/papita_txnsmodel/model/enums.py
+++ b/modules/model/src/papita_txnsmodel/model/enums.py
@@ -86,6 +86,15 @@ class IngestionSource(str, Enum):
     API = "API"
 
 
+class IngestionRunStatus(str, Enum):
+    """Lifecycle status for an owner-scoped ingestion run (PPT-083 / #177)."""
+
+    STARTED = "STARTED"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    PARTIAL = "PARTIAL"
+
+
 class RealEstateOwnership(str, Enum):
     """Real estate ownership mode."""
 

--- a/modules/model/src/papita_txnsmodel/model/ingestion.py
+++ b/modules/model/src/papita_txnsmodel/model/ingestion.py
@@ -1,4 +1,8 @@
-"""Ingestion provenance sidecar and dead-letter tables (PPT-078 / #172)."""
+"""Ingestion provenance, dead-letter, connection, and run tables.
+
+PPT-078 / #172: provenance sidecar + thin DLQ.
+PPT-083 / #177: non-secret connection metadata + run-status history (API read model).
+"""
 
 from __future__ import annotations
 
@@ -7,17 +11,19 @@ from datetime import datetime
 
 from sqlalchemy import TIMESTAMP, Column
 from sqlalchemy import Enum as SAEnum
-from sqlalchemy import ForeignKeyConstraint, Index, String, Text, text
+from sqlalchemy import ForeignKeyConstraint, Index, Integer, String, Text, text
 from sqlmodel import Field
 
 from .base import SCHEMA_NAME, BaseSQLModel
 from .contstants import (
+    INGESTION_CONNECTIONS__TABLENAME,
     INGESTION_DEAD_LETTERS__TABLENAME,
+    INGESTION_RUNS__TABLENAME,
     TRANSACTION_INGESTION_PROVENANCE__TABLENAME,
     TRANSACTIONS__TABLENAME,
     USERS__TABLENAME,
 )
-from .enums import IngestionSource
+from .enums import IngestionRunStatus, IngestionSource
 
 
 class TransactionIngestionProvenance(BaseSQLModel, table=True):  # type: ignore
@@ -82,3 +88,76 @@ class IngestionDeadLetter(BaseSQLModel, table=True):  # type: ignore
     raw_payload: str = Field(sa_type=Text, nullable=False, default="")
     error_message: str = Field(sa_type=Text, nullable=False, default="")
     source_ref: str | None = Field(default=None, max_length=255, sa_type=String(255), nullable=True)
+
+
+class IngestionConnection(BaseSQLModel, table=True):  # type: ignore
+    """Non-secret owner-scoped ingestion connection metadata (PPT-083 / #177).
+
+    Upserted by the worker from settings + flow identity. Never stores OAuth tokens,
+    client secrets, or raw mailbox credentials — those stay in env (``GMAIL_*``).
+    """
+
+    __tablename__ = INGESTION_CONNECTIONS__TABLENAME
+    __table_args__ = (
+        Index(
+            "uq_ingestion_connections_owner_provider_flow",
+            "owner_id",
+            "provider",
+            "flow_name",
+            unique=True,
+        ),
+        Index("ix_ingestion_connections_owner_id", "owner_id"),
+        {"schema": SCHEMA_NAME},
+    )
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    owner_id: uuid.UUID = Field(foreign_key=f"{USERS__TABLENAME}.id", nullable=False)
+    provider: str = Field(max_length=64, sa_type=String(64), nullable=False, default="email")
+    flow_name: str = Field(max_length=128, sa_type=String(128), nullable=False)
+    deployment_name: str | None = Field(default=None, max_length=128, sa_type=String(128), nullable=True)
+    enabled: bool = Field(nullable=False, default=True)
+    lookback_hours: int = Field(nullable=False, default=24, sa_type=Integer)
+
+
+class IngestionRun(BaseSQLModel, table=True):  # type: ignore
+    """Owner-scoped ingestion run history for status APIs (PPT-083 / #177).
+
+    Written by the worker after mapping ``RunResult`` counters into model fields.
+    Does not store per-record failure payloads (avoid raw-leak adjacency).
+    """
+
+    __tablename__ = INGESTION_RUNS__TABLENAME
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["connection_id"],
+            [f"{SCHEMA_NAME}.{INGESTION_CONNECTIONS__TABLENAME}.id"],
+            name="fk_ingestion_runs_connection_id",
+        ),
+        Index("ix_ingestion_runs_owner_id", "owner_id"),
+        Index("ix_ingestion_runs_connection_id", "connection_id"),
+        Index("ix_ingestion_runs_owner_started_at", "owner_id", "started_at"),
+        {"schema": SCHEMA_NAME},
+    )
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    owner_id: uuid.UUID = Field(foreign_key=f"{USERS__TABLENAME}.id", nullable=False)
+    connection_id: uuid.UUID | None = Field(default=None, nullable=True)
+    status: IngestionRunStatus = Field(
+        sa_column=Column(
+            SAEnum(IngestionRunStatus, name="ingestion_run_status", schema=SCHEMA_NAME, create_type=False),
+            nullable=False,
+        )
+    )
+    started_at: datetime = Field(sa_column=Column(TIMESTAMP, nullable=False))
+    finished_at: datetime | None = Field(default=None, sa_type=TIMESTAMP, nullable=True)
+    fetched: int = Field(nullable=False, default=0, sa_type=Integer)
+    created: int = Field(nullable=False, default=0, sa_type=Integer)
+    updated: int = Field(nullable=False, default=0, sa_type=Integer)
+    reactivated: int = Field(nullable=False, default=0, sa_type=Integer)
+    failed: int = Field(nullable=False, default=0, sa_type=Integer)
+    dead_lettered: int = Field(nullable=False, default=0, sa_type=Integer)
+    acknowledged: int = Field(nullable=False, default=0, sa_type=Integer)
+    dry_run_skipped: int = Field(nullable=False, default=0, sa_type=Integer)
+    error_summary: str | None = Field(default=None, sa_type=Text, nullable=True)
+    flow_name: str | None = Field(default=None, max_length=128, sa_type=String(128), nullable=True)
+    deployment_name: str | None = Field(default=None, max_length=128, sa_type=String(128), nullable=True)

--- a/modules/model/src/papita_txnsmodel/services/__init__.py
+++ b/modules/model/src/papita_txnsmodel/services/__init__.py
@@ -24,6 +24,12 @@ from papita_txnsmodel.services.ingestion import (
     IngestTransactionRequest,
     IngestTransactionResult,
 )
+from papita_txnsmodel.services.ingestion_status import (
+    IngestionConnectionService,
+    IngestionRunService,
+    RecordIngestionRunRequest,
+    UpsertIngestionConnectionRequest,
+)
 from papita_txnsmodel.services.owner_period_balances import OwnerPeriodBalancesService
 from papita_txnsmodel.services.owner_yearly_balances import OwnerYearlyBalancesService
 from papita_txnsmodel.services.reports import ReportService
@@ -41,7 +47,11 @@ __all__ = [
     "IngestTransactionRequest",
     "IngestTransactionResult",
     "IngestionBridgeService",
+    "IngestionConnectionService",
+    "IngestionRunService",
     "LoanAccountDetailsService",
+    "RecordIngestionRunRequest",
+    "UpsertIngestionConnectionRequest",
     "OwnerPeriodBalancesService",
     "OwnerYearlyBalancesService",
     "RealEstateAccountDetailsService",

--- a/modules/model/src/papita_txnsmodel/services/ingestion_status.py
+++ b/modules/model/src/papita_txnsmodel/services/ingestion_status.py
@@ -1,0 +1,300 @@
+"""Connection metadata and run-status services for ingestion (PPT-083 / #177).
+
+Worker-facing writes upsert non-secret connection rows and append run history.
+API-facing reads are owner-scoped list/get helpers. Does not import
+``papita_ingestor_core.RunResult`` — callers map counters into
+``RecordIngestionRunRequest`` before calling.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from papita_txnsmodel.access.ingestion.dto import IngestionConnectionDTO, IngestionRunDTO
+from papita_txnsmodel.access.ingestion.repository import IngestionConnectionRepository, IngestionRunRepository
+from papita_txnsmodel.access.users.dto import UsersDTO
+from papita_txnsmodel.database.upsert import OnUpsertConflictDo
+from papita_txnsmodel.model.enums import IngestionRunStatus
+from papita_txnsmodel.services.base import BaseService
+
+logger = logging.getLogger(__name__)
+
+
+class UpsertIngestionConnectionRequest(BaseModel):
+    """Non-secret connection fields the worker may persist from settings + flow id."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str = Field(default="email", min_length=1, max_length=64)
+    flow_name: str = Field(min_length=1, max_length=128)
+    deployment_name: str | None = Field(default=None, max_length=128)
+    enabled: bool = True
+    lookback_hours: int = Field(default=24, ge=1)
+
+
+class RecordIngestionRunRequest(BaseModel):
+    """Model-local run payload (not an API schema). Trusted caller supplies ``owner``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    connection_id: uuid.UUID | None = None
+    status: IngestionRunStatus
+    started_at: datetime
+    finished_at: datetime | None = None
+    fetched: int = Field(default=0, ge=0)
+    created: int = Field(default=0, ge=0)
+    updated: int = Field(default=0, ge=0)
+    reactivated: int = Field(default=0, ge=0)
+    failed: int = Field(default=0, ge=0)
+    dead_lettered: int = Field(default=0, ge=0)
+    acknowledged: int = Field(default=0, ge=0)
+    dry_run_skipped: int = Field(default=0, ge=0)
+    error_summary: str | None = None
+    flow_name: str | None = Field(default=None, max_length=128)
+    deployment_name: str | None = Field(default=None, max_length=128)
+
+
+class IngestionConnectionService(BaseService):
+    """Owner-scoped connection metadata for status APIs and worker upserts."""
+
+    dto_type: type[IngestionConnectionDTO] = IngestionConnectionDTO
+    repository_type: type[IngestionConnectionRepository] = IngestionConnectionRepository
+    on_conflict_do: OnUpsertConflictDo | str = OnUpsertConflictDo.UPDATE
+
+    _connection_repository: IngestionConnectionRepository | None = None
+
+    @model_validator(mode="after")
+    def _init_connection_repo(self) -> Self:
+        """Expose typed repository after BaseService wires ``_repository``."""
+        self._connection_repository = self.repository_type()
+        return self
+
+    def _owned(self, owner: UsersDTO | None) -> UsersDTO:
+        """Return a non-optional owner after BaseService tenant checks."""
+        ensured = self._ensure_owner(owner)
+        if ensured is None:
+            raise ValueError(f"{self.dto_type.__name__} requires owner=UsersDTO for tenant-scoped operations.")
+        return ensured
+
+    def upsert_connection(
+        self,
+        *,
+        owner: UsersDTO,
+        request: UpsertIngestionConnectionRequest,
+        **kwargs,
+    ) -> IngestionConnectionDTO:
+        """Insert or update the connection for ``(owner, provider, flow_name)``.
+
+        Preserves the existing row id on natural-key match so run FKs stay stable.
+        Soft-deleted natural-key matches are reactivated in place (unique index is
+        not partial, matching provenance sidecar semantics).
+        """
+        owner = self._owned(owner)
+        existing = self._connection_repository.get_by_natural_key(
+            owner=owner,
+            provider=request.provider,
+            flow_name=request.flow_name,
+            include_deleted=True,
+            **kwargs,
+        )
+        payload = request.model_dump()
+        reactivate = False
+        if existing is not None and existing.id is not None:
+            payload["id"] = existing.id
+            payload["created_at"] = existing.created_at
+            if not getattr(existing, "active", True):
+                reactivate = True
+                payload["active"] = True
+                payload["deleted_at"] = None
+        dto = IngestionConnectionDTO.model_validate({**payload, "owner_id": owner.id})
+        upserted = self._connection_repository.upsert_record(
+            dto,
+            owner=owner,
+            reactivate=reactivate,
+            **kwargs,
+        )
+        if not isinstance(upserted, IngestionConnectionDTO):
+            raise RuntimeError(
+                "Failed to upsert ingestion connection "
+                f"(owner_id={owner.id}, provider={request.provider!r}, flow_name={request.flow_name!r})."
+            )
+        logger.debug(
+            "Upserted ingestion connection owner_id=%s provider=%s flow_name=%s id=%s reactivate=%s",
+            owner.id,
+            request.provider,
+            request.flow_name,
+            upserted.id,
+            reactivate,
+        )
+        return upserted
+
+    def list_connections(self, *, owner: UsersDTO, **kwargs) -> list[IngestionConnectionDTO]:
+        """Return active connections for the owner, newest first."""
+        owner = self._owned(owner)
+        dao = IngestionConnectionDTO.__dao_type__
+        frame = self._connection_repository.get_records(
+            owner=owner,
+            dto_type=IngestionConnectionDTO,
+            order_by=[dao.updated_at.desc()],
+            **kwargs,
+        )
+        if getattr(frame, "empty", True):
+            return []
+        if len(frame.columns) == 1 and isinstance(frame.iloc[0, 0], dao):
+            return [IngestionConnectionDTO.from_dao(cell) for cell in frame.iloc[:, 0]]
+        return [IngestionConnectionDTO.model_validate(row) for row in frame.to_dict(orient="records")]
+
+    def get_connection(
+        self,
+        *,
+        owner: UsersDTO,
+        connection_id: uuid.UUID,
+        **kwargs,
+    ) -> IngestionConnectionDTO | None:
+        """Return one connection by id when owned by ``owner``; else ``None`` (API → 404)."""
+        dto = self.get(obj=connection_id, owner=owner, **kwargs)
+        return dto if isinstance(dto, IngestionConnectionDTO) else None
+
+
+class IngestionRunService(BaseService):
+    """Owner-scoped run history writes (worker) and reads (API)."""
+
+    dto_type: type[IngestionRunDTO] = IngestionRunDTO
+    repository_type: type[IngestionRunRepository] = IngestionRunRepository
+    on_conflict_do: OnUpsertConflictDo | str = OnUpsertConflictDo.UPDATE
+
+    _run_repository: IngestionRunRepository | None = None
+
+    @model_validator(mode="after")
+    def _init_run_repo(self) -> Self:
+        """Expose typed repository after BaseService wires ``_repository``."""
+        self._run_repository = self.repository_type()
+        return self
+
+    def _owned(self, owner: UsersDTO | None) -> UsersDTO:
+        """Return a non-optional owner after BaseService tenant checks."""
+        ensured = self._ensure_owner(owner)
+        if ensured is None:
+            raise ValueError(f"{self.dto_type.__name__} requires owner=UsersDTO for tenant-scoped operations.")
+        return ensured
+
+    def start_run(
+        self,
+        *,
+        owner: UsersDTO,
+        connection_id: uuid.UUID | None = None,
+        started_at: datetime | None = None,
+        flow_name: str | None = None,
+        deployment_name: str | None = None,
+        **kwargs,
+    ) -> IngestionRunDTO:
+        """Append a ``STARTED`` run row at flow begin."""
+        started = started_at or datetime.now(timezone.utc)
+        return self.record_run(
+            owner=owner,
+            request=RecordIngestionRunRequest(
+                connection_id=connection_id,
+                status=IngestionRunStatus.STARTED,
+                started_at=started,
+                flow_name=flow_name,
+                deployment_name=deployment_name,
+            ),
+            **kwargs,
+        )
+
+    def finish_run(
+        self,
+        *,
+        owner: UsersDTO,
+        run_id: uuid.UUID,
+        request: RecordIngestionRunRequest,
+        **kwargs,
+    ) -> IngestionRunDTO:
+        """Update an existing run with terminal status and counters."""
+        owner = self._owned(owner)
+        existing = self.get(obj=run_id, owner=owner, **kwargs)
+        if existing is None:
+            raise ValueError(f"Ingestion run {run_id} not found for owner.")
+        payload = request.model_dump()
+        payload["id"] = run_id
+        payload["created_at"] = existing.created_at
+        if payload.get("started_at") is None:
+            payload["started_at"] = existing.started_at
+        dto = IngestionRunDTO.model_validate({**payload, "owner_id": owner.id})
+        upserted = self._run_repository.upsert_record(dto, owner=owner, **kwargs)
+        if not isinstance(upserted, IngestionRunDTO):
+            raise RuntimeError(f"Failed to finish ingestion run {run_id} for owner_id={owner.id}.")
+        logger.debug(
+            "Finished ingestion run owner_id=%s run_id=%s status=%s",
+            owner.id,
+            run_id,
+            upserted.status,
+        )
+        return upserted
+
+    def record_run(
+        self,
+        *,
+        owner: UsersDTO,
+        request: RecordIngestionRunRequest,
+        **kwargs,
+    ) -> IngestionRunDTO:
+        """Insert a new run row (start or one-shot terminal write)."""
+        owner = self._owned(owner)
+        dto = IngestionRunDTO.model_validate({**request.model_dump(), "owner_id": owner.id})
+        upserted = self._run_repository.upsert_record(dto, owner=owner, **kwargs)
+        if not isinstance(upserted, IngestionRunDTO):
+            raise RuntimeError(f"Failed to record ingestion run status={request.status!r} for owner_id={owner.id}.")
+        logger.debug(
+            "Recorded ingestion run owner_id=%s status=%s id=%s",
+            owner.id,
+            upserted.status,
+            upserted.id,
+        )
+        return upserted
+
+    def get_latest_run(
+        self,
+        *,
+        owner: UsersDTO,
+        connection_id: uuid.UUID | None = None,
+        **kwargs,
+    ) -> IngestionRunDTO | None:
+        """Return the most recently started run for the owner."""
+        owner = self._owned(owner)
+        return self._run_repository.get_latest(owner=owner, connection_id=connection_id, **kwargs)
+
+    def list_runs(
+        self,
+        *,
+        owner: UsersDTO,
+        connection_id: uuid.UUID | None = None,
+        skip: int = 0,
+        limit: int = 50,
+        **kwargs,
+    ) -> list[IngestionRunDTO]:
+        """Return recent runs for the owner, newest first."""
+        owner = self._owned(owner)
+        dao = IngestionRunDTO.__dao_type__
+        filters = []
+        if connection_id is not None:
+            filters.append(dao.connection_id == connection_id)
+        frame = self._run_repository.get_records(
+            *filters,
+            owner=owner,
+            dto_type=IngestionRunDTO,
+            order_by=[dao.started_at.desc()],
+            skip=skip,
+            limit=limit,
+            **kwargs,
+        )
+        if getattr(frame, "empty", True):
+            return []
+        if len(frame.columns) == 1 and isinstance(frame.iloc[0, 0], dao):
+            return [IngestionRunDTO.from_dao(cell) for cell in frame.iloc[:, 0]]
+        return [IngestionRunDTO.model_validate(row) for row in frame.to_dict(orient="records")]

--- a/modules/model/tests/tests_papita_txnsmodel/services/test_ingestion_status.py
+++ b/modules/model/tests/tests_papita_txnsmodel/services/test_ingestion_status.py
@@ -1,0 +1,137 @@
+"""Unit tests for ingestion connection/run status services (PPT-083 / #177)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from papita_txnsmodel.access.ingestion.dto import IngestionConnectionDTO, IngestionRunDTO
+from papita_txnsmodel.model.enums import IngestionRunStatus
+from papita_txnsmodel.services.ingestion_status import (
+    IngestionConnectionService,
+    IngestionRunService,
+    RecordIngestionRunRequest,
+    UpsertIngestionConnectionRequest,
+)
+from papita_txnsmodel.access.users.dto import UsersDTO
+
+
+def _owner() -> UsersDTO:
+    return UsersDTO(
+        id=uuid.uuid4(),
+        username="ingest_owner",
+        email="ingest_owner@example.local",
+        password="Password1!",
+        auth_provider="local",
+    )
+
+
+def test_upsert_connection_reactivates_soft_deleted_natural_key() -> None:
+    """Soft-deleted natural key must reuse id + reactivate (unique index not partial)."""
+    owner = _owner()
+    existing_id = uuid.uuid4()
+    created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    soft_deleted = IngestionConnectionDTO(
+        id=existing_id,
+        owner_id=owner.id,
+        provider="email",
+        flow_name="papita-email-ingestion",
+        deployment_name="old-deploy",
+        enabled=False,
+        lookback_hours=12,
+        active=False,
+        deleted_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        created_at=created_at,
+        updated_at=created_at,
+    )
+    revived = soft_deleted.model_copy(
+        update={
+            "active": True,
+            "deleted_at": None,
+            "enabled": True,
+            "lookback_hours": 24,
+            "deployment_name": "papita-email-ingestion-hourly",
+        }
+    )
+
+    service = IngestionConnectionService()
+    repo = MagicMock()
+    repo.get_by_natural_key.return_value = soft_deleted
+    repo.upsert_record.return_value = revived
+    service._connection_repository = repo  # noqa: SLF001
+    service._repository = repo  # noqa: SLF001
+
+    result = service.upsert_connection(
+        owner=owner,
+        request=UpsertIngestionConnectionRequest(
+            provider="email",
+            flow_name="papita-email-ingestion",
+            deployment_name="papita-email-ingestion-hourly",
+            enabled=True,
+            lookback_hours=24,
+        ),
+    )
+
+    assert result.id == existing_id
+    assert result.active is True
+    repo.get_by_natural_key.assert_called_once()
+    assert repo.get_by_natural_key.call_args.kwargs["include_deleted"] is True
+    upsert_kwargs = repo.upsert_record.call_args.kwargs
+    assert upsert_kwargs["reactivate"] is True
+    upserted_dto = repo.upsert_record.call_args.args[0]
+    assert upserted_dto.id == existing_id
+    assert upserted_dto.active is True
+    assert upserted_dto.deleted_at is None
+
+
+def test_upsert_connection_raises_when_repository_returns_none() -> None:
+    owner = _owner()
+    service = IngestionConnectionService()
+    repo = MagicMock()
+    repo.get_by_natural_key.return_value = None
+    repo.upsert_record.return_value = None
+    service._connection_repository = repo  # noqa: SLF001
+
+    with pytest.raises(RuntimeError, match="Failed to upsert ingestion connection"):
+        service.upsert_connection(
+            owner=owner,
+            request=UpsertIngestionConnectionRequest(
+                provider="email",
+                flow_name="papita-email-ingestion",
+            ),
+        )
+
+
+def test_finish_run_raises_when_repository_returns_none() -> None:
+    owner = _owner()
+    run_id = uuid.uuid4()
+    started = datetime.now(timezone.utc)
+    existing = IngestionRunDTO(
+        id=run_id,
+        owner_id=owner.id,
+        status=IngestionRunStatus.STARTED,
+        started_at=started,
+        created_at=started,
+    )
+    service = IngestionRunService()
+    repo = MagicMock()
+    service._run_repository = repo  # noqa: SLF001
+    service._repository = repo  # noqa: SLF001
+
+    with patch.object(service, "get", return_value=existing):
+        repo.upsert_record.return_value = None
+        with pytest.raises(RuntimeError, match="Failed to finish ingestion run"):
+            service.finish_run(
+                owner=owner,
+                run_id=run_id,
+                request=RecordIngestionRunRequest(
+                    status=IngestionRunStatus.SUCCEEDED,
+                    started_at=started,
+                    finished_at=started,
+                    fetched=1,
+                    created=1,
+                ),
+            )


### PR DESCRIPTION
**Branch:** `177-featppt-083-api-ingestion-connection-and-run-status-endpoints` · **Base:** `main` · **1 commit** · **29 files**

**Suggested title:** `feat/PPT-083: [api] Ingestion connection and run-status endpoints`

## Summary

Adds owner-scoped ingestion **connection** and **run-status** persistence plus read-only API routes for PPT-083 / #177. The email Prefect worker upserts allowlisted connection metadata and appends/finishes run rows (mapping `RunResult` at the plugin boundary so `papita_txnsmodel` never imports it). The API exposes `GET /api/v1/ingestion/*` only — no HTTP run trigger, no OAuth/DLQ secrets in responses.

## Out of scope / Highlights

**Out of scope**

- Full web OpenAPI artifact regen / CI contract gate (PPT-084 / #178) — PR labeled `skip-openapi`
- Live account/category FK enricher (still H1=B from PPT-082)
- HTTP “run once” trigger; DLQ `raw_payload` exposure

**Highlights**

- Soft-deleted connections reactivate in place on `(owner, provider, flow_name)` (unique index is not partial)
- Upsert/finish return `None` now raises `RuntimeError` instead of returning unsaved DTOs
- `serve_email_ingestion(deployment_name=…)` is persisted on connection/run rows via `EmailFlowDeps`

## Changes

**Model**

- `IngestionRunStatus` enum; `IngestionConnection` / `IngestionRun` tables
- Alembic `l9a0b1c2d3e4` (revises PPT-078)
- DTOs/repos + `IngestionConnectionService` / `IngestionRunService`

**Ingestor**

- Core `build_base_ingestion_flow(..., execute=)` hook
- Email `status_mapping` + `run_status` persist around `runner.run`; dry-run skips writes

**API**

- Allowlisted schemas; thin router + DI factories
- Routes: connections list/get; runs latest/list (+ pagination, optional `connection_id`)
- Cross-tenant → 404; unauth → 401

**Docs / strata**

- API + email README Prefect trigger SSOT; `.strata/memory/project_state.md` updated

## File changes

<details>
<summary>File changes (~29 files)</summary>

```
 .strata/memory/project_state.md
 modules/api/README.md
 modules/api/src/papita_txnsapi/dependencies/services.py
 modules/api/src/papita_txnsapi/routers/v1/__init__.py
 modules/api/src/papita_txnsapi/routers/v1/ingestion.py
 modules/api/src/papita_txnsapi/schemas/converters.py
 modules/api/src/papita_txnsapi/schemas/ingestion.py
 modules/api/tests/conftest.py
 modules/api/tests/test_ingestion.py
 modules/api/tests/test_ingestion_schemas.py
 modules/ingestor-core/src/papita_ingestor_core/flows/base.py
 modules/ingestors/email/README.md
 modules/ingestors/email/src/papita_ingestor_email/flows/email_flow.py
 modules/ingestors/email/src/papita_ingestor_email/run_status.py
 modules/ingestors/email/src/papita_ingestor_email/status_mapping.py
 modules/ingestors/email/src/papita_ingestor_email/wiring.py
 modules/ingestors/email/tests/test_email_flow.py
 modules/ingestors/email/tests/test_status_mapping.py
 modules/model/alembic/versions/2026_08_12_1200-l9a0b1c2d3e4_ppt_083_ingestion_connection_runs.py
 modules/model/src/papita_txnsmodel/access/ingestion/*
 modules/model/src/papita_txnsmodel/model/{contstants,enums,ingestion}.py
 modules/model/src/papita_txnsmodel/services/ingestion_status.py
 modules/model/tests/.../test_ingestion_status.py
```

</details>

## Commits

- `838ffb4` feat/PPT-083: [api] Add ingestion connection and run-status endpoints

## Checks, tests, and validation already done

- `poetry run pytest` (PPT-083 related: model status, email flow/mapping, API ingestion) — **26 passed**
- Pre-commit (black/isort/flake8/pylint/mypy/interrogate/strata) — **passed** on commit
- `./bin/bash/alembic.sh upgrade --env local` — migration applied earlier in session (B0)
- Bugbot re-audit after soft-delete/serve/upsert-None fixes — **no bugs**
- GitHub CI — **not yet observed** (will run on this PR)

## QA / test plan

- [ ] CI green on this PR (model/api/ingestor; web/OpenAPI skipped by labels)
- [ ] B0: `./bin/bash/alembic.sh upgrade --env local` → head `l9a0b1c2d3e4`
- [ ] Authenticated `GET /api/v1/ingestion/connections` / `runs` / `runs/latest` after a worker run
- [ ] Unauth → 401; foreign connection id → 404; response bodies have no token/raw_payload fields
- [ ] Confirm dry-run worker does not write status rows

## Risks

> [!CAUTION]
>
> ### Risks
>
> - Alembic adds enum + tables — must run migrations before API/worker use in each env
> - Model package consumers need a release that includes PPT-083 before deployed API images work against old wheels
> - Prefect flow retries can leave extra `STARTED` rows if a prior attempt did not finish (accepted v1 limitation)
> - Status `finish_run` failures are logged and do not abort ingest — latest run can briefly stay `started`

## Caveats

> [!WARNING]
>
> ### Caveats
>
> - Web OpenAPI committed artifact not regenerated here (PPT-084 / #178; `skip-openapi` applied)
> - Worker is SSOT for writes; API is read-only (no POST trigger)
> - Connection allowlist only: `provider`, `flow_name`, `deployment_name`, `enabled`, `lookback_hours`

## References

- Closes [#177](https://github.com/Elmorralito/save-ma-money/issues/177) (PPT-083)
- Parent epic [#170](https://github.com/Elmorralito/save-ma-money/issues/170) (PPT-076)
- Depends on closed [#172](https://github.com/Elmorralito/save-ma-money/issues/172) / [#173](https://github.com/Elmorralito/save-ma-money/issues/173) / [#176](https://github.com/Elmorralito/save-ma-money/issues/176)
- Follow-up [#178](https://github.com/Elmorralito/save-ma-money/issues/178) (PPT-084)

Made with [Cursor](https://cursor.com)